### PR TITLE
fix(security): close route and dynamic boundary gates (TAN-792–794, TAN-821)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,14 @@ jobs:
           node --test scripts/generate-artifact-manifest.test.mjs scripts/verify-workflow-security.test.mjs
           node scripts/verify-workflow-security.mjs --self-test
 
+      - name: Verify route policy and focused security retest inventories
+        run: |
+          node --test scripts/verify-route-policy-inventory.test.mjs scripts/verify-security-retest-matrix.test.mjs
+          node scripts/verify-route-policy-inventory.mjs --self-test
+          node scripts/verify-route-policy-inventory.mjs
+          node scripts/verify-security-retest-matrix.mjs --self-test
+          node scripts/verify-security-retest-matrix.mjs
+
       - name: Check touched Rust/TSX file sizes
         run: bash scripts/ci-file-size-check.sh
 

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -324,20 +324,20 @@ jobs:
           set -euo pipefail
           cargo nextest list --workspace --exclude tandem \
             --features tandem-ai/browser,tandem-server/premium-governance \
-            --profile ci > "$RUNNER_TEMP/nextest-tests.txt"
+            --profile ci --message-format json > "$RUNNER_TEMP/nextest-tests.json"
           grep -Fq 'migration_write_failures_roll_back_every_imported_record_type' \
-            "$RUNNER_TEMP/nextest-tests.txt"
+            "$RUNNER_TEMP/nextest-tests.json"
           grep -Fq 'completed_migration_keeps_sqlite_authoritative_when_legacy_files_change' \
-            "$RUNNER_TEMP/nextest-tests.txt"
+            "$RUNNER_TEMP/nextest-tests.json"
           grep -Fq 'tan_707_goal_plan_execute_verify_complete_survives_180_day_store_journey' \
-            "$RUNNER_TEMP/nextest-tests.txt"
+            "$RUNNER_TEMP/nextest-tests.json"
           grep -Fq 'tan_707_named_replan_edge_and_day_180_limit_are_explicit' \
-            "$RUNNER_TEMP/nextest-tests.txt"
+            "$RUNNER_TEMP/nextest-tests.json"
 
       - name: Verify focused security tests were discovered and executed
         run: |
           node scripts/verify-security-retest-matrix.mjs \
-            --nextest-list "$RUNNER_TEMP/nextest-tests.txt" \
+            --nextest-list "$RUNNER_TEMP/nextest-tests.json" \
             --junit target/nextest/ci/junit.xml
 
       - name: Verify governance audit tests were discovered and executed
@@ -353,7 +353,7 @@ jobs:
               for line in pathlib.Path('.github/governance-audit-critical-tests.txt').read_text().splitlines()
               if line.strip() and not line.lstrip().startswith('#')
           ]
-          discovered = pathlib.Path("${{ runner.temp }}/nextest-tests.txt").read_text()
+          discovered = pathlib.Path("${{ runner.temp }}/nextest-tests.json").read_text()
           junit_path = pathlib.Path('target/nextest/ci/junit.xml')
           if not junit_path.exists():
               raise SystemExit('nextest junit report is missing')
@@ -407,7 +407,7 @@ jobs:
           name: nextest-junit
           path: |
             target/nextest/ci/junit.xml
-            ${{ runner.temp }}/nextest-tests.txt
+            ${{ runner.temp }}/nextest-tests.json
             ${{ runner.temp }}/governance-coverage.md
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -334,6 +334,12 @@ jobs:
           grep -Fq 'tan_707_named_replan_edge_and_day_180_limit_are_explicit' \
             "$RUNNER_TEMP/nextest-tests.txt"
 
+      - name: Verify focused security tests were discovered and executed
+        run: |
+          node scripts/verify-security-retest-matrix.mjs \
+            --nextest-list "$RUNNER_TEMP/nextest-tests.txt" \
+            --junit target/nextest/ci/junit.xml
+
       - name: Verify governance audit tests were discovered and executed
         shell: bash
         run: |

--- a/crates/tandem-server/src/action_authorization.rs
+++ b/crates/tandem-server/src/action_authorization.rs
@@ -44,6 +44,10 @@ pub enum HostAction {
     GlobalConfigUpdate,
     ApiTokenManage,
     ChannelRead,
+    ChannelSenderRead,
+    ChannelEnrollmentIssue,
+    ChannelEnrollmentConfirm,
+    ChannelStepUpGrant,
     ChannelVerify,
     ChannelConfigUpdate,
     ChannelConfigDelete,
@@ -76,6 +80,10 @@ impl HostAction {
             Self::GlobalConfigUpdate => "deployment.config.manage",
             Self::ApiTokenManage => "deployment.api_token.manage",
             Self::ChannelRead => "deployment.channels.read",
+            Self::ChannelSenderRead => "deployment.channels.senders.read",
+            Self::ChannelEnrollmentIssue => "deployment.channels.enrollment.issue",
+            Self::ChannelEnrollmentConfirm => "deployment.channels.enrollment.confirm",
+            Self::ChannelStepUpGrant => "deployment.channels.step_up.grant",
             Self::ChannelVerify => "deployment.channels.verify",
             Self::ChannelConfigUpdate => "deployment.channels.manage",
             Self::ChannelConfigDelete => "deployment.channels.manage",
@@ -101,6 +109,10 @@ impl HostAction {
                 | Self::GlobalConfigUpdate
                 | Self::ApiTokenManage
                 | Self::ChannelRead
+                | Self::ChannelSenderRead
+                | Self::ChannelEnrollmentIssue
+                | Self::ChannelEnrollmentConfirm
+                | Self::ChannelStepUpGrant
                 | Self::ChannelVerify
                 | Self::ChannelConfigUpdate
                 | Self::ChannelConfigDelete

--- a/crates/tandem-server/src/app/state/channel_user_capabilities.rs
+++ b/crates/tandem-server/src/app/state/channel_user_capabilities.rs
@@ -203,6 +203,17 @@ impl AppState {
         Ok(record)
     }
 
+    pub async fn pending_channel_enrollment_code(
+        &self,
+        code: &str,
+    ) -> Option<ChannelEnrollmentCodeRecord> {
+        self.channel_enrollment_codes
+            .read()
+            .await
+            .get(&normalize_enrollment_code(code))
+            .cloned()
+    }
+
     /// Resolve org-unit references (bare unit id or `taxonomy/unit_id`
     /// principal id) against the enterprise org-unit store. Errors on any
     /// unknown reference. Ambiguity is always REJECTED, never resolved to an

--- a/crates/tandem-server/src/http/channel_enrollment.rs
+++ b/crates/tandem-server/src/http/channel_enrollment.rs
@@ -209,16 +209,6 @@ pub(crate) async fn channel_enroll(
             pairing_code,
             enrolled_by,
         } => {
-            let Some(pending) = state.pending_channel_enrollment_code(pairing_code).await else {
-                return enrollment_error(StatusCode::NOT_FOUND, "pairing code not found");
-            };
-            let target = match normalized_target_tenant(
-                pending.tenant_org_id.as_deref(),
-                pending.tenant_workspace_id.as_deref(),
-            ) {
-                Ok(target) => target,
-                Err(response) => return response,
-            };
             if let Some(actor_id) = authority_actor(&request_tenant, verified.as_deref()) {
                 *enrolled_by = Some(actor_id);
             }
@@ -228,22 +218,24 @@ pub(crate) async fn channel_enroll(
                     "code-sha256:{:x}",
                     Sha256::digest(pairing_code.trim().to_ascii_uppercase().as_bytes())
                 ),
-                target,
+                None,
             )
         }
     };
-    if let Err(response) = require_target_tenant_scope(
-        &state,
-        &request_tenant,
-        verified.as_deref(),
-        target_tenant
-            .as_ref()
-            .map(|(org, workspace)| (org.as_str(), workspace.as_str())),
-        "channel_enrollment",
-    )
-    .await
-    {
-        return response;
+    if matches!(&input, ChannelEnrollRequest::Issue { .. }) {
+        if let Err(response) = require_target_tenant_scope(
+            &state,
+            &request_tenant,
+            verified.as_deref(),
+            target_tenant
+                .as_ref()
+                .map(|(org, workspace)| (org.as_str(), workspace.as_str())),
+            "channel_enrollment_issue",
+        )
+        .await
+        {
+            return response;
+        }
     }
     let arguments = match serde_json::to_value(&input) {
         Ok(arguments) => arguments,
@@ -269,6 +261,31 @@ pub(crate) async fn channel_enroll(
         Ok(authorized) => authorized,
         Err(status) => return status.into_response(),
     };
+    if let ChannelEnrollRequest::Confirm { pairing_code, .. } = &input {
+        let Some(pending) = state.pending_channel_enrollment_code(pairing_code).await else {
+            return enrollment_error(StatusCode::NOT_FOUND, "pairing code not found");
+        };
+        let target = match normalized_target_tenant(
+            pending.tenant_org_id.as_deref(),
+            pending.tenant_workspace_id.as_deref(),
+        ) {
+            Ok(target) => target,
+            Err(response) => return response,
+        };
+        if let Err(response) = require_target_tenant_scope(
+            &state,
+            &request_tenant,
+            verified.as_deref(),
+            target
+                .as_ref()
+                .map(|(org, workspace)| (org.as_str(), workspace.as_str())),
+            "channel_enrollment_confirm",
+        )
+        .await
+        {
+            return response;
+        }
+    }
     if let Err(error) = grant.revalidate(&state, &effect) {
         return crate::http::host_authority::host_authorization_status(error).into_response();
     }

--- a/crates/tandem-server/src/http/channel_enrollment.rs
+++ b/crates/tandem-server/src/http/channel_enrollment.rs
@@ -1,19 +1,21 @@
 // Copyright (c) 2026 Frumu LTD
 // Licensed under the Business Source License 1.1
 
-use axum::extract::State;
+use axum::extract::{Extension, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use sha2::{Digest, Sha256};
+use tandem_types::{TenantContext, VerifiedTenantContext};
 
 use crate::app::state::channel_user_capabilities::{
     ChannelEnrollmentCodeRecord, ChannelUserCapabilityRecord, StoredCommandTier,
 };
 use crate::AppState;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub(crate) enum ChannelEnrollRequest {
     Issue {
@@ -61,7 +63,7 @@ enum ChannelEnrollResponse {
 /// GOV-B5b: control-panel issuance of a per-identity, expiring channel step-up.
 /// A channel configured with `require_approval_step_up` only honors an approval
 /// from an identity that holds an active grant issued here.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct ChannelStepUpRequest {
     channel: String,
     user_id: String,
@@ -79,6 +81,9 @@ const DEFAULT_STEP_UP_TTL_MS: u64 = 5 * 60 * 1000;
 
 pub(crate) async fn channel_step_up(
     State(state): State<AppState>,
+    Extension(request_tenant): Extension<TenantContext>,
+    Extension(locality): Extension<crate::http::host_authority::RequestLocality>,
+    verified: Option<Extension<VerifiedTenantContext>>,
     Json(input): Json<ChannelStepUpRequest>,
 ) -> Response {
     if input.channel.trim().is_empty() || input.user_id.trim().is_empty() {
@@ -111,18 +116,50 @@ pub(crate) async fn channel_step_up(
             );
         }
     };
+    if let Err(response) = require_target_tenant_scope(
+        &state,
+        &request_tenant,
+        verified.as_deref(),
+        tenant,
+        "channel_step_up",
+    )
+    .await
+    {
+        return response;
+    }
+    let channel = input.channel.trim().to_ascii_lowercase();
+    let user_id = input.user_id.trim();
+    let (grant, effect) = match crate::http::host_authority::authorize_administrative_effect(
+        &state,
+        &request_tenant,
+        verified.as_deref(),
+        locality,
+        crate::action_authorization::HostAction::ChannelStepUpGrant,
+        "channel_identity",
+        format!("{channel}:{user_id}"),
+        json!({
+            "channel": &channel,
+            "user_id": user_id,
+            "ttl_ms": ttl_ms,
+            "tenant_org_id": tenant.map(|(org_id, _)| org_id),
+            "tenant_workspace_id": tenant.map(|(_, workspace_id)| workspace_id),
+        }),
+    )
+    .await
+    {
+        Ok(authorized) => authorized,
+        Err(status) => return status.into_response(),
+    };
+    if let Err(error) = grant.revalidate(&state, &effect) {
+        return crate::http::host_authority::host_authorization_status(error).into_response();
+    }
     let expires_at_ms = state
-        .grant_channel_step_up(
-            &input.channel.trim().to_ascii_lowercase(),
-            input.user_id.trim(),
-            ttl_ms,
-            tenant,
-        )
+        .grant_channel_step_up(&channel, user_id, ttl_ms, tenant)
         .await;
     Json(json!({
         "status": "step_up_granted",
-        "channel": input.channel.trim().to_ascii_lowercase(),
-        "user_id": input.user_id.trim(),
+        "channel": channel,
+        "user_id": user_id,
         "expires_at_ms": expires_at_ms,
         "tenant_org_id": tenant.map(|(org_id, _)| org_id),
         "tenant_workspace_id": tenant.map(|(_, workspace_id)| workspace_id),
@@ -131,6 +168,114 @@ pub(crate) async fn channel_step_up(
 }
 
 pub(crate) async fn channel_enroll(
+    State(state): State<AppState>,
+    Extension(request_tenant): Extension<TenantContext>,
+    Extension(locality): Extension<crate::http::host_authority::RequestLocality>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Json(mut input): Json<ChannelEnrollRequest>,
+) -> Response {
+    let (action, resource_id, target_tenant) = match &mut input {
+        ChannelEnrollRequest::Issue {
+            channel,
+            user_id,
+            issued_by,
+            tenant_org_id,
+            tenant_workspace_id,
+            ..
+        } => {
+            if channel.trim().is_empty() || user_id.trim().is_empty() {
+                return enrollment_error(
+                    StatusCode::BAD_REQUEST,
+                    "channel and user_id are required",
+                );
+            }
+            let target = match normalized_target_tenant(
+                tenant_org_id.as_deref(),
+                tenant_workspace_id.as_deref(),
+            ) {
+                Ok(target) => target,
+                Err(response) => return response,
+            };
+            if let Some(actor_id) = authority_actor(&request_tenant, verified.as_deref()) {
+                *issued_by = Some(actor_id);
+            }
+            (
+                crate::action_authorization::HostAction::ChannelEnrollmentIssue,
+                format!("{}:{}", channel.trim().to_ascii_lowercase(), user_id.trim()),
+                target,
+            )
+        }
+        ChannelEnrollRequest::Confirm {
+            pairing_code,
+            enrolled_by,
+        } => {
+            let Some(pending) = state.pending_channel_enrollment_code(pairing_code).await else {
+                return enrollment_error(StatusCode::NOT_FOUND, "pairing code not found");
+            };
+            let target = match normalized_target_tenant(
+                pending.tenant_org_id.as_deref(),
+                pending.tenant_workspace_id.as_deref(),
+            ) {
+                Ok(target) => target,
+                Err(response) => return response,
+            };
+            if let Some(actor_id) = authority_actor(&request_tenant, verified.as_deref()) {
+                *enrolled_by = Some(actor_id);
+            }
+            (
+                crate::action_authorization::HostAction::ChannelEnrollmentConfirm,
+                format!(
+                    "code-sha256:{:x}",
+                    Sha256::digest(pairing_code.trim().to_ascii_uppercase().as_bytes())
+                ),
+                target,
+            )
+        }
+    };
+    if let Err(response) = require_target_tenant_scope(
+        &state,
+        &request_tenant,
+        verified.as_deref(),
+        target_tenant
+            .as_ref()
+            .map(|(org, workspace)| (org.as_str(), workspace.as_str())),
+        "channel_enrollment",
+    )
+    .await
+    {
+        return response;
+    }
+    let arguments = match serde_json::to_value(&input) {
+        Ok(arguments) => arguments,
+        Err(_) => {
+            return enrollment_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "channel enrollment request could not be authorized",
+            );
+        }
+    };
+    let (grant, effect) = match crate::http::host_authority::authorize_administrative_effect(
+        &state,
+        &request_tenant,
+        verified.as_deref(),
+        locality,
+        action,
+        "channel_identity",
+        resource_id,
+        arguments,
+    )
+    .await
+    {
+        Ok(authorized) => authorized,
+        Err(status) => return status.into_response(),
+    };
+    if let Err(error) = grant.revalidate(&state, &effect) {
+        return crate::http::host_authority::host_authorization_status(error).into_response();
+    }
+    channel_enroll_inner(State(state), Json(input)).await
+}
+
+async fn channel_enroll_inner(
     State(state): State<AppState>,
     Json(input): Json<ChannelEnrollRequest>,
 ) -> Response {
@@ -209,6 +354,61 @@ pub(crate) async fn channel_enroll(
     }
 }
 
+fn normalized_target_tenant(
+    org_id: Option<&str>,
+    workspace_id: Option<&str>,
+) -> Result<Option<(String, String)>, Response> {
+    match (org_id.map(str::trim), workspace_id.map(str::trim)) {
+        (Some(org_id), Some(workspace_id)) if !org_id.is_empty() && !workspace_id.is_empty() => {
+            Ok(Some((org_id.to_string(), workspace_id.to_string())))
+        }
+        (None, None) => Ok(None),
+        _ => Err(enrollment_error(
+            StatusCode::BAD_REQUEST,
+            "tenant_org_id and tenant_workspace_id must be provided together",
+        )),
+    }
+}
+
+fn authority_actor(
+    tenant: &TenantContext,
+    verified: Option<&VerifiedTenantContext>,
+) -> Option<String> {
+    verified
+        .map(|context| context.human_actor.actor_id.clone())
+        .or_else(|| tenant.actor_id.clone())
+}
+
+async fn require_target_tenant_scope(
+    state: &AppState,
+    request_tenant: &TenantContext,
+    verified: Option<&VerifiedTenantContext>,
+    target: Option<(&str, &str)>,
+    operation: &'static str,
+) -> Result<(), Response> {
+    if verified.is_none()
+        || target.is_some_and(|(org_id, workspace_id)| {
+            org_id == request_tenant.org_id && workspace_id == request_tenant.workspace_id
+        })
+    {
+        return Ok(());
+    }
+    crate::audit::append_protected_audit_event_best_effort(
+        state,
+        "authority.channel_scope.denied",
+        request_tenant,
+        verified.map(|context| context.human_actor.actor_id.clone()),
+        json!({
+            "operation": operation,
+            "reason": if target.is_some() { "cross_tenant_target" } else { "unscoped_hosted_target" },
+            "target_org_id": target.map(|(org_id, _)| org_id),
+            "target_workspace_id": target.map(|(_, workspace_id)| workspace_id),
+        }),
+    )
+    .await;
+    Err(StatusCode::FORBIDDEN.into_response())
+}
+
 fn enrollment_error(status: StatusCode, message: &str) -> Response {
     (status, Json(json!({ "error": message }))).into_response()
 }
@@ -224,7 +424,7 @@ mod tests {
         let mut state = AppState::new_starting("test".to_string(), true);
         state.channel_user_capabilities_path = dir.path().join("channel_user_capabilities.json");
 
-        let response = channel_enroll(
+        let response = channel_enroll_inner(
             State(state.clone()),
             Json(ChannelEnrollRequest::Issue {
                 channel: "telegram".to_string(),
@@ -249,7 +449,7 @@ mod tests {
             .next()
             .cloned()
             .expect("code stored");
-        let response = channel_enroll(
+        let response = channel_enroll_inner(
             State(state.clone()),
             Json(ChannelEnrollRequest::Confirm {
                 pairing_code: issued.code,

--- a/crates/tandem-server/src/http/channels_api.rs
+++ b/crates/tandem-server/src/http/channels_api.rs
@@ -301,7 +301,33 @@ const SLACK_SENDERS_CAP: usize = 500;
 /// tenant, with mapped/unmapped department status (TAN-765). Data source is
 /// the protected audit ledger (`channel.slack.ingress.accepted` / `.denied`),
 /// so the fail-closed unmapped state is visible and actionable.
-pub(crate) async fn slack_senders(State(state): State<AppState>) -> Response {
+pub(crate) async fn slack_senders(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantContext>,
+    Extension(locality): Extension<crate::http::host_authority::RequestLocality>,
+    verified: Option<Extension<tandem_types::VerifiedTenantContext>>,
+) -> Response {
+    let (grant, effect) = match crate::http::host_authority::authorize_administrative_effect(
+        &state,
+        &tenant,
+        verified.as_deref(),
+        locality,
+        crate::action_authorization::HostAction::ChannelSenderRead,
+        "deployment_channels",
+        tenant
+            .deployment_id
+            .as_deref()
+            .unwrap_or("local-deployment"),
+        json!({"operation": "read_slack_senders"}),
+    )
+    .await
+    {
+        Ok(authorized) => authorized,
+        Err(status) => return status.into_response(),
+    };
+    if let Err(error) = grant.revalidate(&state, &effect) {
+        return crate::http::host_authority::host_authorization_status(error).into_response();
+    }
     let effective = state.config.get_effective_value().await;
     let connections = crate::config::channels::slack_connections_from_effective_config(&effective);
     let mut tenants = connections

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -59,7 +59,7 @@ pub(super) async fn auth_gate(
     {
         return next.run(request).await;
     }
-    if path == "/global/health" {
+    if is_public_health_request(request.method(), path) {
         return next.run(request).await;
     }
     if is_public_oauth_callback_path(path) {
@@ -401,6 +401,10 @@ fn is_public_web_ui_request(method: &Method, path: &str, prefix: &str) -> bool {
         || path
             .strip_prefix(prefix)
             .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn is_public_health_request(method: &Method, path: &str) -> bool {
+    matches!(*method, Method::GET | Method::HEAD) && path == "/global/health"
 }
 
 /// The signed Slack Events webhook (`/channels/slack/events`) authenticates via the
@@ -1860,6 +1864,21 @@ mod web_ui_bypass_tests {
     }
 }
 
+#[cfg(test)]
+mod health_bypass_tests {
+    use super::is_public_health_request;
+    use axum::http::Method;
+
+    #[test]
+    fn health_bypass_is_method_and_path_exact() {
+        assert!(is_public_health_request(&Method::GET, "/global/health"));
+        assert!(is_public_health_request(&Method::HEAD, "/global/health"));
+        assert!(!is_public_health_request(&Method::POST, "/global/health"));
+        assert!(!is_public_health_request(&Method::PATCH, "/global/health"));
+        assert!(!is_public_health_request(&Method::GET, "/global/health/"));
+    }
+}
+
 pub(super) async fn startup_gate(
     State(state): State<AppState>,
     request: Request,
@@ -1868,7 +1887,7 @@ pub(super) async fn startup_gate(
     if request.method() == Method::OPTIONS {
         return next.run(request).await;
     }
-    if request.uri().path() == "/global/health" {
+    if is_public_health_request(request.method(), request.uri().path()) {
         return next.run(request).await;
     }
     if state.is_ready() {

--- a/crates/tandem-server/src/http/tests/automation_webhooks/security.rs
+++ b/crates/tandem-server/src/http/tests/automation_webhooks/security.rs
@@ -107,7 +107,6 @@ async fn public_webhook_body_limits_apply_before_collection_and_vary_by_provider
 /// conservative CPU/lock-time proxy: every request performs all work inline in
 /// this process, and the per-request ceiling includes the rejection-ledger lock.
 #[tokio::test]
-#[ignore = "run explicitly as the bounded TA-13 bad-signature load harness"]
 async fn bad_signature_load_is_throttled_and_retained_within_explicit_ceilings() {
     const REQUESTS: usize = 512;
     const MAX_UNTHROTTLED_REQUESTS: usize = 30;

--- a/crates/tandem-server/src/http/tests/channels.rs
+++ b/crates/tandem-server/src/http/tests/channels.rs
@@ -40,7 +40,7 @@ fn verified_channel_actor(
     }
 }
 
-fn channel_tenant_request(
+pub(super) fn channel_tenant_request(
     method: &str,
     uri: &str,
     org_id: &str,

--- a/crates/tandem-server/src/http/tests/channels.rs
+++ b/crates/tandem-server/src/http/tests/channels.rs
@@ -2,6 +2,7 @@
 // Licensed under the Business Source License 1.1
 
 use super::*;
+use sha2::Digest;
 
 fn direct_loopback_request() -> axum::http::request::Builder {
     Request::builder().extension(axum::extract::ConnectInfo(
@@ -9,6 +10,62 @@ fn direct_loopback_request() -> axum::http::request::Builder {
             .parse::<std::net::SocketAddr>()
             .expect("loopback socket address"),
     ))
+}
+
+fn verified_channel_actor(
+    tenant_context: tandem_types::TenantContext,
+    actor_id: &str,
+    deployment_admin: bool,
+) -> tandem_types::VerifiedTenantContext {
+    let now = crate::now_ms();
+    tandem_types::VerifiedTenantContext {
+        tenant_context,
+        human_actor: tandem_types::HumanActor::tandem_user(actor_id),
+        authority_chain: tandem_types::AuthorityChain::from_request(
+            tandem_types::RequestPrincipal::authenticated_user(actor_id, "channel-test"),
+        ),
+        roles: Vec::new(),
+        org_units: Vec::new(),
+        capabilities: deployment_admin
+            .then(|| vec!["deployment.admin".to_string()])
+            .unwrap_or_default(),
+        policy_version: None,
+        strict_projection: None,
+        issuer: "channel-test".to_string(),
+        audience: "tandem".to_string(),
+        issued_at_ms: now,
+        expires_at_ms: now.saturating_add(60_000),
+        assertion_id: format!("channel-test-{actor_id}-{now}"),
+        assertion_key_id: None,
+    }
+}
+
+fn channel_tenant_request(
+    method: &str,
+    uri: &str,
+    org_id: &str,
+    workspace_id: &str,
+    actor_id: &str,
+    deployment_admin: bool,
+    body: Value,
+) -> Request<Body> {
+    let tenant =
+        tandem_types::TenantContext::explicit_user_workspace(org_id, workspace_id, None, actor_id);
+    Request::builder()
+        .extension(axum::extract::ConnectInfo(
+            "198.51.100.44:443"
+                .parse::<std::net::SocketAddr>()
+                .expect("remote socket address"),
+        ))
+        .extension(verified_channel_actor(tenant, actor_id, deployment_admin))
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("x-tandem-org-id", org_id)
+        .header("x-tandem-workspace-id", workspace_id)
+        .header("x-tandem-actor-id", actor_id)
+        .body(Body::from(body.to_string()))
+        .expect("channel tenant request")
 }
 
 #[tokio::test]
@@ -864,6 +921,211 @@ async fn channels_delete_unknown_channel_returns_not_found() {
         .expect("request");
     let resp = app.clone().oneshot(req).await.expect("response");
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn channel_identity_authority_is_admin_only_tenant_exact_and_locally_compatible() {
+    let state = test_state().await;
+    let app = app_router(state.clone());
+
+    let low_privilege = channel_tenant_request(
+        "POST",
+        "/channels/step-up",
+        "org-a",
+        "workspace-a",
+        "member-a",
+        false,
+        json!({
+            "channel": "slack",
+            "user_id": "U-EXACT",
+            "tenant_org_id": "org-a",
+            "tenant_workspace_id": "workspace-a"
+        }),
+    );
+    let response = app.clone().oneshot(low_privilege).await.expect("response");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    let cross_tenant = channel_tenant_request(
+        "POST",
+        "/channels/step-up",
+        "org-a",
+        "workspace-a",
+        "admin-a",
+        true,
+        json!({
+            "channel": "slack",
+            "user_id": "U-EXACT",
+            "tenant_org_id": "org-b",
+            "tenant_workspace_id": "workspace-b"
+        }),
+    );
+    let response = app.clone().oneshot(cross_tenant).await.expect("response");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(
+        !state
+            .channel_step_up_active("slack", "U-EXACT", Some(("org-b", "workspace-b")))
+            .await
+    );
+
+    let exact_tenant = channel_tenant_request(
+        "POST",
+        "/channels/step-up",
+        "org-a",
+        "workspace-a",
+        "admin-a",
+        true,
+        json!({
+            "channel": "slack",
+            "user_id": "U-EXACT",
+            "tenant_org_id": "org-a",
+            "tenant_workspace_id": "workspace-a"
+        }),
+    );
+    let response = app.clone().oneshot(exact_tenant).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        state
+            .channel_step_up_active("slack", "U-EXACT", Some(("org-a", "workspace-a")))
+            .await
+    );
+
+    let issue = channel_tenant_request(
+        "POST",
+        "/channels/enroll",
+        "org-a",
+        "workspace-a",
+        "admin-a",
+        true,
+        json!({
+            "action": "issue",
+            "channel": "telegram",
+            "user_id": "4242",
+            "tier": "approve",
+            "issued_by": "spoofed-actor",
+            "tenant_org_id": "org-a",
+            "tenant_workspace_id": "workspace-a"
+        }),
+    );
+    let response = app.clone().oneshot(issue).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    let issued: Value = serde_json::from_slice(&body).expect("issue response");
+    let pairing_code = issued
+        .get("pairing_code")
+        .and_then(Value::as_str)
+        .expect("pairing code")
+        .to_string();
+    let pending = state
+        .pending_channel_enrollment_code(&pairing_code)
+        .await
+        .expect("pending enrollment");
+    assert_eq!(pending.issued_by.as_deref(), Some("admin-a"));
+    assert_eq!(pending.tenant_org_id.as_deref(), Some("org-a"));
+
+    let wrong_tenant_confirm = channel_tenant_request(
+        "POST",
+        "/channels/enroll",
+        "org-b",
+        "workspace-b",
+        "admin-b",
+        true,
+        json!({
+            "action": "confirm",
+            "pairing_code": pairing_code,
+            "enrolled_by": "admin-b"
+        }),
+    );
+    let response = app
+        .clone()
+        .oneshot(wrong_tenant_confirm)
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(state
+        .pending_channel_enrollment_code(&pairing_code)
+        .await
+        .is_some());
+
+    let exact_confirm = channel_tenant_request(
+        "POST",
+        "/channels/enroll",
+        "org-a",
+        "workspace-a",
+        "admin-a",
+        true,
+        json!({
+            "action": "confirm",
+            "pairing_code": pairing_code,
+            "enrolled_by": "spoofed-actor"
+        }),
+    );
+    let response = app.clone().oneshot(exact_confirm).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(state
+        .pending_channel_enrollment_code(&pairing_code)
+        .await
+        .is_none());
+    let audit = tokio::fs::read_to_string(&state.protected_audit_path)
+        .await
+        .expect("protected audit file");
+    let code_resource = format!(
+        "code-sha256:{:x}",
+        sha2::Sha256::digest(pairing_code.trim().to_ascii_uppercase().as_bytes())
+    );
+    assert!(audit.contains(&code_resource));
+    assert!(
+        !audit.contains(&pairing_code),
+        "channel enrollment audit must identify the code by digest, never reveal it"
+    );
+
+    let local_state = test_state().await;
+    let local_app = app_router(local_state.clone());
+    let local_step_up = direct_loopback_request()
+        .method("POST")
+        .uri("/channels/step-up")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({"channel": "slack", "user_id": "U-LOCAL"}).to_string(),
+        ))
+        .expect("local request");
+    let response = local_app.oneshot(local_step_up).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        local_state
+            .channel_step_up_active("slack", "U-LOCAL", None)
+            .await
+    );
+}
+
+#[tokio::test]
+async fn slack_sender_inventory_requires_deployment_admin() {
+    let state = test_state().await;
+    let app = app_router(state);
+    let member = channel_tenant_request(
+        "GET",
+        "/channels/slack/senders",
+        "org-a",
+        "workspace-a",
+        "member-a",
+        false,
+        json!({}),
+    );
+    let response = app.clone().oneshot(member).await.expect("response");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    let admin = channel_tenant_request(
+        "GET",
+        "/channels/slack/senders",
+        "org-a",
+        "workspace-a",
+        "admin-a",
+        true,
+        json!({}),
+    );
+    let response = app.oneshot(admin).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[tokio::test]

--- a/crates/tandem-server/src/http/tests/channels.rs
+++ b/crates/tandem-server/src/http/tests/channels.rs
@@ -1024,6 +1024,32 @@ async fn channel_identity_authority_is_admin_only_tenant_exact_and_locally_compa
     assert_eq!(pending.issued_by.as_deref(), Some("admin-a"));
     assert_eq!(pending.tenant_org_id.as_deref(), Some("org-a"));
 
+    for candidate in ["NOT-A-REAL-CODE", pairing_code.as_str()] {
+        let ordinary_confirm = channel_tenant_request(
+            "POST",
+            "/channels/enroll",
+            "org-a",
+            "workspace-a",
+            "member-a",
+            false,
+            json!({
+                "action": "confirm",
+                "pairing_code": candidate,
+                "enrolled_by": "member-a"
+            }),
+        );
+        let response = app
+            .clone()
+            .oneshot(ordinary_confirm)
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+    assert!(state
+        .pending_channel_enrollment_code(&pairing_code)
+        .await
+        .is_some());
+
     let wrong_tenant_confirm = channel_tenant_request(
         "POST",
         "/channels/enroll",

--- a/crates/tandem-server/src/http/tests/slack_events_governance.rs
+++ b/crates/tandem-server/src/http/tests/slack_events_governance.rs
@@ -499,11 +499,15 @@ async fn slack_senders_endpoint_surfaces_mapped_and_unmapped_identities() {
     let response = app.clone().oneshot(denied).await.expect("denied response");
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
-    let request = Request::builder()
-        .method("GET")
-        .uri("/channels/slack/senders")
-        .body(Body::empty())
-        .expect("senders request");
+    let request = super::channels::channel_tenant_request(
+        "GET",
+        "/channels/slack/senders",
+        ORG_ID,
+        WORKSPACE_ID,
+        "sender-inventory-admin",
+        true,
+        json!({}),
+    );
     let response = app.oneshot(request).await.expect("senders response");
     assert_eq!(response.status(), StatusCode::OK);
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
@@ -623,11 +627,15 @@ async fn denials_are_audited_under_a_connection_bound_tenant() {
         "the denial must be audited under the connection's bound tenant"
     );
 
-    let request = Request::builder()
-        .method("GET")
-        .uri("/channels/slack/senders")
-        .body(Body::empty())
-        .expect("senders request");
+    let request = super::channels::channel_tenant_request(
+        "GET",
+        "/channels/slack/senders",
+        ORG_ID,
+        WORKSPACE_ID,
+        "sender-inventory-admin",
+        true,
+        json!({}),
+    );
     let response = app.oneshot(request).await.expect("senders response");
     assert_eq!(response.status(), StatusCode::OK);
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
@@ -733,11 +741,15 @@ async fn sender_mapping_is_computed_against_each_channels_department_binding() {
 
     // Sender discovery must not let the engineering membership mask the
     // sales-channel gap: mapped is per observed channel, not tenant-wide.
-    let request = Request::builder()
-        .method("GET")
-        .uri("/channels/slack/senders")
-        .body(Body::empty())
-        .expect("senders request");
+    let request = super::channels::channel_tenant_request(
+        "GET",
+        "/channels/slack/senders",
+        ORG_ID,
+        WORKSPACE_ID,
+        "sender-inventory-admin",
+        true,
+        json!({}),
+    );
     let response = app.oneshot(request).await.expect("senders response");
     assert_eq!(response.status(), StatusCode::OK);
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)

--- a/crates/tandem-server/src/outbound_http.rs
+++ b/crates/tandem-server/src/outbound_http.rs
@@ -27,6 +27,7 @@ impl ResolvedPublicHttpsTarget {
 
     pub fn client(&self, timeout: Duration) -> anyhow::Result<Client> {
         let mut builder = Client::builder()
+            .no_proxy()
             .redirect(RedirectPolicy::none())
             .timeout(timeout);
         if let Some(host) = self.dns_override_host.as_deref() {

--- a/crates/tandem-server/src/outbound_http.rs
+++ b/crates/tandem-server/src/outbound_http.rs
@@ -53,6 +53,27 @@ async fn resolve_outbound_url(
     raw: &str,
     allow_private_provider_endpoint: bool,
 ) -> anyhow::Result<ResolvedPublicHttpsTarget> {
+    resolve_outbound_url_with_resolver(
+        raw,
+        allow_private_provider_endpoint,
+        |host, port| async move {
+            Ok(tokio::net::lookup_host((host.as_str(), port))
+                .await?
+                .collect::<Vec<_>>())
+        },
+    )
+    .await
+}
+
+async fn resolve_outbound_url_with_resolver<F, Fut>(
+    raw: &str,
+    allow_private_provider_endpoint: bool,
+    resolver: F,
+) -> anyhow::Result<ResolvedPublicHttpsTarget>
+where
+    F: FnOnce(String, u16) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<Vec<SocketAddr>>>,
+{
     let url = Url::parse(raw).context("parse outbound URL")?;
     let insecure_http = url.scheme() == "http";
     if url.scheme() != "https" && !(insecure_http && allow_private_provider_endpoint) {
@@ -102,10 +123,9 @@ async fn resolve_outbound_url(
             {
                 anyhow::bail!("outbound URL points to localhost/private network");
             }
-            let addrs = tokio::net::lookup_host((host.as_str(), port))
+            let addrs = resolver(host.clone(), port)
                 .await
-                .context("resolve outbound destination host")?
-                .collect::<Vec<_>>();
+                .context("resolve outbound destination host")?;
             if addrs.is_empty() {
                 anyhow::bail!("outbound destination host did not resolve");
             }
@@ -219,16 +239,56 @@ mod tests {
         }
     }
 
-    #[test]
-    fn fake_dns_and_cloud_metadata_answers_fail_closed() {
+    #[tokio::test]
+    async fn fake_dns_and_cloud_metadata_answers_fail_closed() {
         let public: SocketAddr = "8.8.8.8:443".parse().expect("public address");
         let private: SocketAddr = "10.0.0.7:443".parse().expect("private address");
-        let metadata: SocketAddr = "169.254.169.254:80".parse().expect("metadata address");
-        assert!(validate_resolved_addresses(&[public], false, false).is_ok());
-        assert!(validate_resolved_addresses(&[metadata], false, false).is_err());
-        assert!(validate_resolved_addresses(&[public, private], false, false).is_err());
-        assert!(validate_resolved_addresses(&[private], true, true).is_ok());
-        assert!(validate_resolved_addresses(&[public], true, true).is_err());
+        let metadata: SocketAddr = "169.254.169.254:443".parse().expect("metadata address");
+
+        let public_target = resolve_outbound_url_with_resolver(
+            "https://public.fixture.invalid/archive",
+            false,
+            move |host, port| async move {
+                assert_eq!(host, "public.fixture.invalid");
+                assert_eq!(port, 443);
+                Ok(vec![public])
+            },
+        )
+        .await
+        .expect("public fake DNS answer");
+        assert_eq!(public_target.dns_override_addrs, vec![public]);
+        public_target
+            .client(Duration::from_secs(2))
+            .expect("public fake DNS answer builds pinned client");
+
+        for answers in [vec![metadata], vec![public, private]] {
+            assert!(resolve_outbound_url_with_resolver(
+                "https://blocked.fixture.invalid/archive",
+                false,
+                move |_, _| async move { Ok(answers) },
+            )
+            .await
+            .is_err());
+        }
+
+        assert!(resolve_outbound_url_with_resolver(
+            "http://public.fixture.invalid/archive",
+            true,
+            move |_, _| async move { Ok(vec![public]) },
+        )
+        .await
+        .is_err());
+
+        let private_target = resolve_outbound_url_with_resolver(
+            "http://private.fixture.invalid/archive",
+            true,
+            move |_, _| async move { Ok(vec![private]) },
+        )
+        .await
+        .expect("explicit standalone private endpoint allowance");
+        private_target
+            .client(Duration::from_secs(2))
+            .expect("private fake DNS answer builds pinned client");
     }
 
     #[tokio::test]
@@ -259,11 +319,17 @@ mod tests {
                 .await
                 .expect("fake egress server");
         });
-        let target = ResolvedPublicHttpsTarget {
-            url: Url::parse(&format!("http://{address}/redirect")).expect("redirect URL"),
-            dns_override_host: None,
-            dns_override_addrs: Vec::new(),
-        };
+        let target = resolve_outbound_url_with_resolver(
+            &format!("http://fixture.invalid:{}/redirect", address.port()),
+            true,
+            move |host, port| async move {
+                assert_eq!(host, "fixture.invalid");
+                assert_eq!(port, address.port());
+                Ok(vec![address])
+            },
+        )
+        .await
+        .expect("fake DNS-pinned target");
         let client = target
             .client(Duration::from_secs(2))
             .expect("hardened client");
@@ -282,7 +348,7 @@ mod tests {
         );
 
         let stream = client
-            .get(format!("http://{address}/stream"))
+            .get(target.url().join("/stream").expect("stream URL"))
             .send()
             .await
             .expect("stream response");

--- a/crates/tandem-server/src/outbound_http.rs
+++ b/crates/tandem-server/src/outbound_http.rs
@@ -109,14 +109,7 @@ async fn resolve_outbound_url(
             if addrs.is_empty() {
                 anyhow::bail!("outbound destination host did not resolve");
             }
-            let any_private = addrs.iter().any(|addr| !ip_is_publicly_routable(addr.ip()));
-            let any_public = addrs.iter().any(|addr| ip_is_publicly_routable(addr.ip()));
-            if any_private && !allow_private_provider_endpoint {
-                anyhow::bail!("outbound URL resolves to a private or internal address");
-            }
-            if insecure_http && any_public {
-                anyhow::bail!("insecure provider HTTP is limited to private standalone endpoints");
-            }
+            validate_resolved_addresses(&addrs, allow_private_provider_endpoint, insecure_http)?;
             Ok(ResolvedPublicHttpsTarget {
                 url,
                 dns_override_host: Some(host),
@@ -124,6 +117,22 @@ async fn resolve_outbound_url(
             })
         }
     }
+}
+
+fn validate_resolved_addresses(
+    addrs: &[SocketAddr],
+    allow_private_provider_endpoint: bool,
+    insecure_http: bool,
+) -> anyhow::Result<()> {
+    let any_private = addrs.iter().any(|addr| !ip_is_publicly_routable(addr.ip()));
+    let any_public = addrs.iter().any(|addr| ip_is_publicly_routable(addr.ip()));
+    if any_private && !allow_private_provider_endpoint {
+        anyhow::bail!("outbound URL resolves to a private or internal address");
+    }
+    if insecure_http && any_public {
+        anyhow::bail!("insecure provider HTTP is limited to private standalone endpoints");
+    }
+    Ok(())
 }
 
 pub async fn read_response_body_limited(
@@ -190,6 +199,11 @@ fn ipv6_is_publicly_routable(ip: Ipv6Addr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::{Body, Bytes};
+    use axum::http::{header, StatusCode};
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::Router;
 
     #[tokio::test]
     async fn rejects_private_literal_and_url_credentials() {
@@ -203,5 +217,76 @@ mod tests {
         ] {
             assert!(resolve_public_https_url(url).await.is_err(), "{url}");
         }
+    }
+
+    #[test]
+    fn fake_dns_and_cloud_metadata_answers_fail_closed() {
+        let public: SocketAddr = "8.8.8.8:443".parse().expect("public address");
+        let private: SocketAddr = "10.0.0.7:443".parse().expect("private address");
+        let metadata: SocketAddr = "169.254.169.254:80".parse().expect("metadata address");
+        assert!(validate_resolved_addresses(&[public], false, false).is_ok());
+        assert!(validate_resolved_addresses(&[metadata], false, false).is_err());
+        assert!(validate_resolved_addresses(&[public, private], false, false).is_err());
+        assert!(validate_resolved_addresses(&[private], true, true).is_ok());
+        assert!(validate_resolved_addresses(&[public], true, true).is_err());
+    }
+
+    #[tokio::test]
+    async fn fake_redirect_and_streaming_budget_service_is_contained() {
+        async fn redirect_to_metadata() -> Response<Body> {
+            Response::builder()
+                .status(StatusCode::TEMPORARY_REDIRECT)
+                .header(header::LOCATION, "http://169.254.169.254/latest/meta-data/")
+                .body(Body::empty())
+                .expect("redirect response")
+        }
+        async fn unbounded_stream() -> Response<Body> {
+            Response::new(Body::from_stream(futures::stream::iter([
+                Ok::<Bytes, std::io::Error>(Bytes::from_static(b"12345678")),
+                Ok::<Bytes, std::io::Error>(Bytes::from_static(b"overflow")),
+            ])))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake egress service");
+        let address = listener.local_addr().expect("fake service address");
+        let app = Router::new()
+            .route("/redirect", get(redirect_to_metadata))
+            .route("/stream", get(unbounded_stream));
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("fake egress server");
+        });
+        let target = ResolvedPublicHttpsTarget {
+            url: Url::parse(&format!("http://{address}/redirect")).expect("redirect URL"),
+            dns_override_host: None,
+            dns_override_addrs: Vec::new(),
+        };
+        let client = target
+            .client(Duration::from_secs(2))
+            .expect("hardened client");
+        let redirect = client
+            .get(target.url().clone())
+            .send()
+            .await
+            .expect("redirect response");
+        assert_eq!(redirect.status(), StatusCode::TEMPORARY_REDIRECT);
+        assert_eq!(
+            redirect
+                .headers()
+                .get(header::LOCATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("http://169.254.169.254/latest/meta-data/")
+        );
+
+        let stream = client
+            .get(format!("http://{address}/stream"))
+            .send()
+            .await
+            .expect("stream response");
+        assert!(read_response_body_limited(stream, 8).await.is_err());
+        server.abort();
     }
 }

--- a/docs/HOST_EFFECT_AUTHORIZATION.md
+++ b/docs/HOST_EFFECT_AUTHORIZATION.md
@@ -2,8 +2,8 @@
 
 Host effects are operations that cross from request or workflow state into the
 engine host: file reads/searches, process creation, browser installation or
-navigation, storage repair, global disposal, managed Git worktrees, and pack
-lifecycle operations.
+navigation, storage repair, global disposal, managed Git worktrees, pack
+lifecycle operations, and process-global channel identity administration.
 
 Every migrated effect uses action_authorization and follows the same order:
 
@@ -58,6 +58,9 @@ handler.
 | Browser install/smoke test | action-specific capability | Yes |
 | Storage repair/global dispose | action-specific capability | Yes |
 | Pack reads/detect/install/uninstall/export | action-specific capability | Hosted host-path operations are disabled; full managed-resource migration remains pending |
+| Channel sender inventory | deployment.channels.senders.read | Yes |
+| Channel enrollment issue/confirm | deployment.channels.enrollment.issue / .confirm | Yes |
+| Channel step-up grant | deployment.channels.step_up.grant | Yes |
 
 ## Resource rules
 
@@ -103,6 +106,13 @@ returns counts without host paths or raw Git errors.
 
 Pack host-path operations fail closed outside the standalone loopback-local
 posture until their inputs are migrated to managed resource IDs and grants.
+
+Channel enrollment and step-up requests in a verified deployment must name the
+same org/workspace as the verified caller; unscoped or cross-tenant targets fail
+closed before state mutation. Confirmation resolves tenant scope from the
+server-side pending enrollment record, not from the caller. Caller-supplied
+issuer/enroller labels cannot replace the verified human actor. The standalone
+loopback owner retains the legacy unscoped workflow for local compatibility.
 
 ## Migration rule
 

--- a/docs/SECURITY_BOUNDARY_RETEST.md
+++ b/docs/SECURITY_BOUNDARY_RETEST.md
@@ -3,7 +3,8 @@
 The focused retest is an executable evidence index for TA-01 through TA-17. The
 authoritative matrix is `SECURITY_BOUNDARY_RETEST_MATRIX.json`; it maps every
 finding to at least one denied exploit control and one intended-behavior control
-using exact checked-in Rust test symbols.
+using checked-in Rust sources plus package, nextest binary, and full test-name
+identities.
 
 The fixtures cover two tenants and three authority roles, temporary workspaces,
 Git repositories and pack roots, marker credentials/audit values, protected
@@ -26,10 +27,11 @@ not use production credentials, repositories, pack roots, or endpoints.
 ## CI evidence
 
 The normal Workspace Tests job remains authoritative because it executes the
-entire non-desktop Rust workspace. After nextest completes, CI validates that
-every matrix symbol was present in both nextest discovery output and the JUnit
-execution report. A renamed, deleted, skipped, filtered-out, or unexecuted
-security test therefore fails the gate even if the JSON still references it.
+entire non-desktop Rust workspace. After nextest completes, CI validates each
+matrix package, binary ID, and full test name against structured nextest
+discovery output and the non-skipped JUnit execution report. A same-named test
+in another package or binary cannot satisfy the gate; a renamed, deleted,
+skipped, filtered-out, or unexecuted security test fails it as well.
 
 The desktop crate remains covered by its dedicated CI job. TA-14/TA-15 use the
 shared artifact-integrity verifier in the focused matrix and the desktop job

--- a/docs/SECURITY_BOUNDARY_RETEST.md
+++ b/docs/SECURITY_BOUNDARY_RETEST.md
@@ -1,0 +1,40 @@
+# Focused security-boundary retest
+
+The focused retest is an executable evidence index for TA-01 through TA-17. The
+authoritative matrix is `SECURITY_BOUNDARY_RETEST_MATRIX.json`; it maps every
+finding to at least one denied exploit control and one intended-behavior control
+using exact checked-in Rust test symbols.
+
+The fixtures cover two tenants and three authority roles, temporary workspaces,
+Git repositories and pack roots, marker credentials/audit values, protected
+audit and persistence failure injection, fake private/cloud-metadata DNS
+answers, a redirect-to-metadata service, a chunked over-budget response, and two
+replay-store instances.
+
+## Local focused run
+
+Install cargo-nextest, then run:
+
+```bash
+bash scripts/run-security-boundary-retest.sh
+```
+
+The script validates the matrix and runs only its named tests with the same
+browser and premium-governance features as the full workspace CI job. It does
+not use production credentials, repositories, pack roots, or endpoints.
+
+## CI evidence
+
+The normal Workspace Tests job remains authoritative because it executes the
+entire non-desktop Rust workspace. After nextest completes, CI validates that
+every matrix symbol was present in both nextest discovery output and the JUnit
+execution report. A renamed, deleted, skipped, filtered-out, or unexecuted
+security test therefore fails the gate even if the JSON still references it.
+
+The desktop crate remains covered by its dedicated CI job. TA-14/TA-15 use the
+shared artifact-integrity verifier in the focused matrix and the desktop job
+executes the desktop installer tests that consume that verifier.
+
+Passing this matrix closes focused implementation validation; it does not by
+itself authorize a shared/hosted release. The assurance/dependency/deployment
+batch and final release-decision issue remain separate gates.

--- a/docs/SECURITY_BOUNDARY_RETEST_MATRIX.json
+++ b/docs/SECURITY_BOUNDARY_RETEST_MATRIX.json
@@ -2,217 +2,617 @@
   "schema_version": 1,
   "scope": "Focused dynamic retest for confirmed findings TA-01 through TA-17",
   "fixture_catalog": {
-    "synthetic_tenants": ["org-a/workspace-a", "org-b/workspace-b"],
-    "roles": ["ordinary_member", "deployment_admin", "independent_reviewer"],
-    "disposable_resources": ["temporary_workspace", "temporary_git_repository", "temporary_pack_root"],
-    "canaries": ["marker_provider_credential", "marker_channel_credential", "marker_audit_value"],
-    "network": ["fake_private_dns_answer", "fake_cloud_metadata_address", "fake_redirect_service", "chunked_over_budget_service"],
-    "failure_injection": ["protected_audit_unwritable", "state_persistence_failure", "two_replay_store_instances"]
+    "synthetic_tenants": [
+      "org-a/workspace-a",
+      "org-b/workspace-b"
+    ],
+    "roles": [
+      "ordinary_member",
+      "deployment_admin",
+      "independent_reviewer"
+    ],
+    "disposable_resources": [
+      "temporary_workspace",
+      "temporary_git_repository",
+      "temporary_pack_root"
+    ],
+    "canaries": [
+      "marker_provider_credential",
+      "marker_channel_credential",
+      "marker_audit_value"
+    ],
+    "network": [
+      "fake_private_dns_answer",
+      "fake_cloud_metadata_address",
+      "fake_redirect_service",
+      "chunked_over_budget_service"
+    ],
+    "failure_injection": [
+      "protected_audit_unwritable",
+      "state_persistence_failure",
+      "two_replay_store_instances"
+    ]
   },
   "findings": [
     {
       "id": "TA-01",
       "title": "Authenticated OS command execution and process-global Windows PTY",
-      "fixture_tags": ["ordinary_member", "temporary_workspace"],
+      "fixture_tags": [
+        "ordinary_member",
+        "temporary_workspace"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/action_authorization.rs", "symbol": "broad_role_does_not_authorize_host_effect"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "legacy_command_payloads_cannot_supply_an_executable_or_arguments"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/action_authorization.rs",
+          "symbol": "broad_role_does_not_authorize_host_effect",
+          "binary_id": "tandem-server",
+          "test_name": "action_authorization::tests::broad_role_does_not_authorize_host_effect"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/system_api_hardened.rs",
+          "symbol": "legacy_command_payloads_cannot_supply_an_executable_or_arguments",
+          "binary_id": "tandem-server",
+          "test_name": "http::system_api_hardened::tests::legacy_command_payloads_cannot_supply_an_executable_or_arguments"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "command_presets_do_not_accept_executables_or_interpreters"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/system_api_hardened.rs",
+          "symbol": "command_presets_do_not_accept_executables_or_interpreters",
+          "binary_id": "tandem-server",
+          "test_name": "http::system_api_hardened::tests::command_presets_do_not_accept_executables_or_interpreters"
+        }
       ]
     },
     {
       "id": "TA-02",
       "title": "Arbitrary-root file content search and resource exhaustion",
-      "fixture_tags": ["temporary_workspace", "marker_audit_value"],
+      "fixture_tags": [
+        "temporary_workspace",
+        "marker_audit_value"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "workspace_path_resolution_blocks_absolute_and_symlink_escapes"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "descriptor_relative_open_rejects_symlink_swaps"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/system_api_hardened.rs",
+          "symbol": "workspace_path_resolution_blocks_absolute_and_symlink_escapes",
+          "binary_id": "tandem-server",
+          "test_name": "http::system_api_hardened::tests::workspace_path_resolution_blocks_absolute_and_symlink_escapes"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/system_api_hardened.rs",
+          "symbol": "descriptor_relative_open_rejects_symlink_swaps",
+          "binary_id": "tandem-server",
+          "test_name": "http::system_api_hardened::tests::descriptor_relative_open_rejects_symlink_swaps"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "bounded_file_listing_honors_the_server_owned_result_limit"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/system_api_hardened.rs",
+          "symbol": "bounded_file_listing_honors_the_server_owned_result_limit",
+          "binary_id": "tandem-server",
+          "test_name": "http::system_api_hardened::tests::bounded_file_listing_honors_the_server_owned_result_limit"
+        }
       ]
     },
     {
       "id": "TA-03",
       "title": "Process-global permission/question queues permit cross-tenant decisions",
-      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "independent_reviewer"],
+      "fixture_tags": [
+        "org-a/workspace-a",
+        "org-b/workspace-b",
+        "independent_reviewer"
+      ],
       "negative_controls": [
-        {"package": "tandem-core", "source": "crates/tandem-core/src/permissions.rs", "symbol": "tenant_scoped_permission_state_cannot_be_discovered_or_decided_cross_tenant"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/permissions.rs", "symbol": "question_reply_rejects_requester_self_review"}
+        {
+          "package": "tandem-core",
+          "source": "crates/tandem-core/src/permissions.rs",
+          "symbol": "tenant_scoped_permission_state_cannot_be_discovered_or_decided_cross_tenant",
+          "binary_id": "tandem-core",
+          "test_name": "permissions::tests::tenant_scoped_permission_state_cannot_be_discovered_or_decided_cross_tenant"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/permissions.rs",
+          "symbol": "question_reply_rejects_requester_self_review",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::permissions::question_reply_rejects_requester_self_review"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/permissions.rs", "symbol": "permission_reply_route_applies_and_persists_allow_rule"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/permissions.rs",
+          "symbol": "permission_reply_route_applies_and_persists_allow_rule",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::permissions::permission_reply_route_applies_and_persists_allow_rule"
+        }
       ]
     },
     {
       "id": "TA-04",
       "title": "Legacy workflow gates can be approved by an unrelated tenant actor",
-      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "independent_reviewer"],
+      "fixture_tags": [
+        "org-a/workspace-a",
+        "org-b/workspace-b",
+        "independent_reviewer"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/workflows.rs", "symbol": "workflow_gate_hosted_visibility_and_review_are_actor_scoped"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/workflows.rs", "symbol": "workflow_gate_rejects_stale_and_expired_requests_without_resuming"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/workflows.rs",
+          "symbol": "workflow_gate_hosted_visibility_and_review_are_actor_scoped",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::workflows::workflow_gate_hosted_visibility_and_review_are_actor_scoped"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/workflows.rs",
+          "symbol": "workflow_gate_rejects_stale_and_expired_requests_without_resuming",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::workflows::workflow_gate_rejects_stale_and_expired_requests_without_resuming"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/workflows.rs", "symbol": "workflow_gate_pauses_run_and_resumes_after_human_approval"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/workflows.rs",
+          "symbol": "workflow_gate_pauses_run_and_resumes_after_human_approval",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::workflows::workflow_gate_pauses_run_and_resumes_after_human_approval"
+        }
       ]
     },
     {
       "id": "TA-05",
       "title": "Governance grants and lifecycle mutations lack tenant/resource authorization",
-      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "protected_audit_unwritable"],
+      "fixture_tags": [
+        "org-a/workspace-a",
+        "org-b/workspace-b",
+        "protected_audit_unwritable"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/governance_parts/part01.rs", "symbol": "governance_approval_rejects_cross_tenant_approve_replay"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/governance_parts/part01.rs", "symbol": "governance_grant_audit_failure_leaves_state_unchanged"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/governance_parts/part01.rs",
+          "symbol": "governance_approval_rejects_cross_tenant_approve_replay",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::governance::governance_approval_rejects_cross_tenant_approve_replay"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/governance_parts/part01.rs",
+          "symbol": "governance_grant_audit_failure_leaves_state_unchanged",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::governance::governance_grant_audit_failure_leaves_state_unchanged"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/governance.rs", "symbol": "automations_v2_grant_revoke_pauses_automation_and_requests_dependency_review"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/governance.rs",
+          "symbol": "automations_v2_grant_revoke_pauses_automation_and_requests_dependency_review",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::governance::automations_v2_grant_revoke_pauses_automation_and_requests_dependency_review"
+        }
       ]
     },
     {
       "id": "TA-06",
       "title": "Global provider endpoint poisoning and shared transport-token rotation",
-      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "marker_provider_credential"],
+      "fixture_tags": [
+        "org-a/workspace-a",
+        "org-b/workspace-b",
+        "marker_provider_credential"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/providers.rs", "symbol": "hosted_admin_cannot_configure_private_local_provider_origin"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/providers.rs", "symbol": "tenant_a_cannot_list_update_or_delete_tenant_b_provider_api_key"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/providers.rs",
+          "symbol": "hosted_admin_cannot_configure_private_local_provider_origin",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::providers::hosted_admin_cannot_configure_private_local_provider_origin"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/providers.rs",
+          "symbol": "tenant_a_cannot_list_update_or_delete_tenant_b_provider_api_key",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::providers::tenant_a_cannot_list_update_or_delete_tenant_b_provider_api_key"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/providers.rs", "symbol": "standalone_loopback_owner_can_configure_private_local_provider_origin"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/providers.rs",
+          "symbol": "standalone_loopback_owner_can_configure_private_local_provider_origin",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::providers::standalone_loopback_owner_can_configure_private_local_provider_origin"
+        }
       ]
     },
     {
       "id": "TA-07",
       "title": "Channel endpoint changes exfiltrate preserved shared bot credentials",
-      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "marker_channel_credential"],
+      "fixture_tags": [
+        "org-a/workspace-a",
+        "org-b/workspace-b",
+        "marker_channel_credential"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/channels.rs", "symbol": "channel_identity_authority_is_admin_only_tenant_exact_and_locally_compatible"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/channels.rs", "symbol": "slack_sender_inventory_requires_deployment_admin"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/channels.rs",
+          "symbol": "channel_identity_authority_is_admin_only_tenant_exact_and_locally_compatible",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::channels::channel_identity_authority_is_admin_only_tenant_exact_and_locally_compatible"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/channels.rs",
+          "symbol": "slack_sender_inventory_requires_deployment_admin",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::channels::slack_sender_inventory_requires_deployment_admin"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/channels.rs", "symbol": "channels_put_protected_audit_records_shape_without_raw_credentials"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/channels.rs", "symbol": "channel_identity_authority_is_admin_only_tenant_exact_and_locally_compatible"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/channels.rs",
+          "symbol": "channels_put_protected_audit_records_shape_without_raw_credentials",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::channels::channels_put_protected_audit_records_shape_without_raw_credentials"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/channels.rs",
+          "symbol": "channel_identity_authority_is_admin_only_tenant_exact_and_locally_compatible",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::channels::channel_identity_authority_is_admin_only_tenant_exact_and_locally_compatible"
+        }
       ]
     },
     {
       "id": "TA-08",
       "title": "Global MCP mutation/deletion and unrestricted server-side requests",
-      "fixture_tags": ["ordinary_member", "temporary_workspace", "marker_audit_value"],
+      "fixture_tags": [
+        "ordinary_member",
+        "temporary_workspace",
+        "marker_audit_value"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/mcp_admin_hardening.rs", "symbol": "private_mcp_oauth_requires_standalone_listener_posture"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/mcp_admin_hardening.rs", "symbol": "stopped_listener_posture_blocks_actual_private_mcp_request"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/mcp_admin_hardening.rs",
+          "symbol": "private_mcp_oauth_requires_standalone_listener_posture",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::mcp_admin_hardening::private_mcp_oauth_requires_standalone_listener_posture"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/mcp_admin_hardening.rs",
+          "symbol": "stopped_listener_posture_blocks_actual_private_mcp_request",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::mcp_admin_hardening::stopped_listener_posture_blocks_actual_private_mcp_request"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/mcp_admin_hardening.rs", "symbol": "mcp_registration_audit_records_header_names_without_values"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/mcp_admin_hardening.rs",
+          "symbol": "mcp_registration_audit_records_header_names_without_values",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::mcp_admin_hardening::mcp_registration_audit_records_header_names_without_values"
+        }
       ]
     },
     {
       "id": "TA-09",
       "title": "Destructive process-global and arbitrary-repository operations",
-      "fixture_tags": ["temporary_git_repository", "org-a/workspace-a", "org-b/workspace-b"],
+      "fixture_tags": [
+        "temporary_git_repository",
+        "org-a/workspace-a",
+        "org-b/workspace-b"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/global_parts/part07.rs", "symbol": "managed_worktree_create_rejects_external_path_override"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/global_parts/part07.rs", "symbol": "managed_worktree_mutations_require_matching_active_lease"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/global_parts/part07.rs",
+          "symbol": "managed_worktree_create_rejects_external_path_override",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::global::managed_worktree_create_rejects_external_path_override"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/global_parts/part07.rs",
+          "symbol": "managed_worktree_mutations_require_matching_active_lease",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::global::managed_worktree_mutations_require_matching_active_lease"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/global_parts/part07.rs", "symbol": "managed_worktree_endpoints_are_idempotent_and_cleanup_branch"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/global_parts/part07.rs",
+          "symbol": "managed_worktree_endpoints_are_idempotent_and_cleanup_branch",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::global::managed_worktree_endpoints_are_idempotent_and_cleanup_branch"
+        }
       ]
     },
     {
       "id": "TA-10",
       "title": "Pack install/export path escape, SSRF, and unbounded download",
-      "fixture_tags": ["temporary_pack_root", "fake_private_dns_answer", "fake_cloud_metadata_address", "fake_redirect_service", "chunked_over_budget_service"],
+      "fixture_tags": [
+        "temporary_pack_root",
+        "fake_private_dns_answer",
+        "fake_cloud_metadata_address",
+        "fake_redirect_service",
+        "chunked_over_budget_service"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/outbound_http.rs", "symbol": "fake_dns_and_cloud_metadata_answers_fail_closed"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/outbound_http.rs", "symbol": "fake_redirect_and_streaming_budget_service_is_contained"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/pack_manager_tests.rs", "symbol": "safe_extract_blocks_traversal"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/outbound_http.rs",
+          "symbol": "fake_dns_and_cloud_metadata_answers_fail_closed",
+          "binary_id": "tandem-server",
+          "test_name": "outbound_http::tests::fake_dns_and_cloud_metadata_answers_fail_closed"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/outbound_http.rs",
+          "symbol": "fake_redirect_and_streaming_budget_service_is_contained",
+          "binary_id": "tandem-server",
+          "test_name": "outbound_http::tests::fake_redirect_and_streaming_budget_service_is_contained"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/pack_manager_tests.rs",
+          "symbol": "safe_extract_blocks_traversal",
+          "binary_id": "tandem-server",
+          "test_name": "pack_manager::tests::safe_extract_blocks_traversal"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/packs.rs", "symbol": "packs_install_list_and_uninstall_roundtrip"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/packs.rs",
+          "symbol": "packs_install_list_and_uninstall_roundtrip",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::packs::packs_install_list_and_uninstall_roundtrip"
+        }
       ]
     },
     {
       "id": "TA-11",
       "title": "Configurable Web UI prefix can exempt API routes from authentication",
-      "fixture_tags": ["ordinary_member", "marker_audit_value"],
+      "fixture_tags": [
+        "ordinary_member",
+        "marker_audit_value"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/middleware.rs", "symbol": "web_ui_bypass_is_method_and_segment_exact"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/middleware.rs",
+          "symbol": "web_ui_bypass_is_method_and_segment_exact",
+          "binary_id": "tandem-server",
+          "test_name": "http::middleware::web_ui_bypass_tests::web_ui_bypass_is_method_and_segment_exact"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/global_parts/part01.rs", "symbol": "global_health_route_returns_only_minimal_public_shape"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/global_parts/part01.rs",
+          "symbol": "global_health_route_returns_only_minimal_public_shape",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::global::global_health_route_returns_only_minimal_public_shape"
+        }
       ]
     },
     {
       "id": "TA-12",
       "title": "Security-relevant effects can precede protected audit durability",
-      "fixture_tags": ["protected_audit_unwritable", "state_persistence_failure", "marker_audit_value"],
+      "fixture_tags": [
+        "protected_audit_unwritable",
+        "state_persistence_failure",
+        "marker_audit_value"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/action_authorization.rs", "symbol": "audit_persistence_failure_prevents_grant_issuance"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/workflows.rs", "symbol": "workflow_gate_persistence_failure_keeps_nonce_pending"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/action_authorization.rs",
+          "symbol": "audit_persistence_failure_prevents_grant_issuance",
+          "binary_id": "tandem-server",
+          "test_name": "action_authorization::tests::audit_persistence_failure_prevents_grant_issuance"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/workflows.rs",
+          "symbol": "workflow_gate_persistence_failure_keeps_nonce_pending",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::workflows::workflow_gate_persistence_failure_keeps_nonce_pending"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/providers.rs", "symbol": "provider_auth_set_writes_protected_audit_record"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/providers.rs",
+          "symbol": "provider_auth_set_writes_protected_audit_record",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::providers::provider_auth_set_writes_protected_audit_record"
+        }
       ]
     },
     {
       "id": "TA-13",
       "title": "Public webhook rejection path enables disk/write amplification",
-      "fixture_tags": ["chunked_over_budget_service", "marker_audit_value"],
+      "fixture_tags": [
+        "chunked_over_budget_service",
+        "marker_audit_value"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/automation_webhooks/security.rs", "symbol": "bad_signature_load_is_throttled_and_retained_within_explicit_ceilings"},
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/automation_webhooks/security.rs", "symbol": "public_webhook_body_limits_apply_before_collection_and_vary_by_provider"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/automation_webhooks/security.rs",
+          "symbol": "bad_signature_load_is_throttled_and_retained_within_explicit_ceilings",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::automation_webhooks::security::bad_signature_load_is_throttled_and_retained_within_explicit_ceilings"
+        },
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/automation_webhooks/security.rs",
+          "symbol": "public_webhook_body_limits_apply_before_collection_and_vary_by_provider",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::automation_webhooks::security::public_webhook_body_limits_apply_before_collection_and_vary_by_provider"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/automation_webhooks.rs", "symbol": "public_automation_webhook_accepts_signed_request_without_transport_auth"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/http/tests/automation_webhooks.rs",
+          "symbol": "public_automation_webhook_accepts_signed_request_without_transport_auth",
+          "binary_id": "tandem-server",
+          "test_name": "http::tests::automation_webhooks::public_automation_webhook_accepts_signed_request_without_transport_auth"
+        }
       ]
     },
     {
       "id": "TA-14",
       "title": "Browser sidecar installer executes unsigned, unbounded release artifacts",
-      "fixture_tags": ["temporary_workspace", "marker_audit_value"],
+      "fixture_tags": [
+        "temporary_workspace",
+        "marker_audit_value"
+      ],
       "negative_controls": [
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "rejects_tampered_manifest_bytes"},
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "digest_verifier_rejects_oversize_before_hashing"}
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs",
+          "symbol": "rejects_tampered_manifest_bytes",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "artifact_integrity::tests::rejects_tampered_manifest_bytes"
+        },
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs",
+          "symbol": "digest_verifier_rejects_oversize_before_hashing",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "artifact_integrity::tests::digest_verifier_rejects_oversize_before_hashing"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "verifies_signed_manifest_and_exact_target"}
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs",
+          "symbol": "verifies_signed_manifest_and_exact_target",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "artifact_integrity::tests::verifies_signed_manifest_and_exact_target"
+        }
       ]
     },
     {
       "id": "TA-15",
       "title": "Desktop engine sidecar and release chain lack artifact integrity",
-      "fixture_tags": ["temporary_workspace", "marker_audit_value"],
+      "fixture_tags": [
+        "temporary_workspace",
+        "marker_audit_value"
+      ],
       "negative_controls": [
-        {"package": "tandem-server", "source": "crates/tandem-server/src/browser_parts/artifact_install.rs", "symbol": "failed_version_probe_restores_previous_binary"},
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "rejects_wrong_release_after_valid_signature"}
+        {
+          "package": "tandem-server",
+          "source": "crates/tandem-server/src/browser_parts/artifact_install.rs",
+          "symbol": "failed_version_probe_restores_previous_binary",
+          "binary_id": "tandem-server",
+          "test_name": "browser::browser_artifact_install_tests::failed_version_probe_restores_previous_binary"
+        },
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs",
+          "symbol": "rejects_wrong_release_after_valid_signature",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "artifact_integrity::tests::rejects_wrong_release_after_valid_signature"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "digest_verifier_accepts_exact_bytes"}
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs",
+          "symbol": "digest_verifier_accepts_exact_bytes",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "artifact_integrity::tests::digest_verifier_accepts_exact_bytes"
+        }
       ]
     },
     {
       "id": "TA-16",
       "title": "Context-assertion replay cache is process-local",
-      "fixture_tags": ["two_replay_store_instances", "org-a/workspace-a", "org-b/workspace-b"],
+      "fixture_tags": [
+        "two_replay_store_instances",
+        "org-a/workspace-a",
+        "org-b/workspace-b"
+      ],
       "negative_controls": [
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/context_assertion_security_tests.rs", "symbol": "persistent_replay_store_coordinates_one_shot_and_bound_across_instances"},
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/context_assertion_security_tests.rs", "symbol": "concurrent_one_shot_race_has_exactly_one_winner"}
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/context_assertion_security_tests.rs",
+          "symbol": "persistent_replay_store_coordinates_one_shot_and_bound_across_instances",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "context_assertion_security::tests::persistent_replay_store_coordinates_one_shot_and_bound_across_instances"
+        },
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/context_assertion_security_tests.rs",
+          "symbol": "concurrent_one_shot_race_has_exactly_one_winner",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "context_assertion_security::tests::concurrent_one_shot_race_has_exactly_one_winner"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/context_assertion_security_tests.rs", "symbol": "replay_expiry_namespace_and_capacity_limits_are_enforced"}
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/context_assertion_security_tests.rs",
+          "symbol": "replay_expiry_namespace_and_capacity_limits_are_enforced",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "context_assertion_security::tests::replay_expiry_namespace_and_capacity_limits_are_enforced"
+        }
       ]
     },
     {
       "id": "TA-17",
       "title": "ACA verifier accepts materially under-validated identity claims",
-      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "marker_audit_value"],
+      "fixture_tags": [
+        "org-a/workspace-a",
+        "org-b/workspace-b",
+        "marker_audit_value"
+      ],
       "negative_controls": [
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/aca_request_auth.rs", "symbol": "hosted_mode_rejects_identity_issuer_version_and_lifetime_drift"},
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/aca_request_auth.rs", "symbol": "hosted_mode_rejects_wrong_audience_in_claims"}
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/aca_request_auth.rs",
+          "symbol": "hosted_mode_rejects_identity_issuer_version_and_lifetime_drift",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "aca_request_auth::tests::hosted_mode_rejects_identity_issuer_version_and_lifetime_drift"
+        },
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/aca_request_auth.rs",
+          "symbol": "hosted_mode_rejects_wrong_audience_in_claims",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "aca_request_auth::tests::hosted_mode_rejects_wrong_audience_in_claims"
+        }
       ],
       "positive_controls": [
-        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/aca_request_auth.rs", "symbol": "hosted_mode_full_verifier_accepts_valid_assertion"}
+        {
+          "package": "tandem-enterprise-contract",
+          "source": "crates/tandem-enterprise-contract/src/aca_request_auth.rs",
+          "symbol": "hosted_mode_full_verifier_accepts_valid_assertion",
+          "binary_id": "tandem-enterprise-contract",
+          "test_name": "aca_request_auth::tests::hosted_mode_full_verifier_accepts_valid_assertion"
+        }
       ]
     }
   ]

--- a/docs/SECURITY_BOUNDARY_RETEST_MATRIX.json
+++ b/docs/SECURITY_BOUNDARY_RETEST_MATRIX.json
@@ -1,0 +1,219 @@
+{
+  "schema_version": 1,
+  "scope": "Focused dynamic retest for confirmed findings TA-01 through TA-17",
+  "fixture_catalog": {
+    "synthetic_tenants": ["org-a/workspace-a", "org-b/workspace-b"],
+    "roles": ["ordinary_member", "deployment_admin", "independent_reviewer"],
+    "disposable_resources": ["temporary_workspace", "temporary_git_repository", "temporary_pack_root"],
+    "canaries": ["marker_provider_credential", "marker_channel_credential", "marker_audit_value"],
+    "network": ["fake_private_dns_answer", "fake_cloud_metadata_address", "fake_redirect_service", "chunked_over_budget_service"],
+    "failure_injection": ["protected_audit_unwritable", "state_persistence_failure", "two_replay_store_instances"]
+  },
+  "findings": [
+    {
+      "id": "TA-01",
+      "title": "Authenticated OS command execution and process-global Windows PTY",
+      "fixture_tags": ["ordinary_member", "temporary_workspace"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/action_authorization.rs", "symbol": "broad_role_does_not_authorize_host_effect"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "legacy_command_payloads_cannot_supply_an_executable_or_arguments"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "command_presets_do_not_accept_executables_or_interpreters"}
+      ]
+    },
+    {
+      "id": "TA-02",
+      "title": "Arbitrary-root file content search and resource exhaustion",
+      "fixture_tags": ["temporary_workspace", "marker_audit_value"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "workspace_path_resolution_blocks_absolute_and_symlink_escapes"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "descriptor_relative_open_rejects_symlink_swaps"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/system_api_hardened.rs", "symbol": "bounded_file_listing_honors_the_server_owned_result_limit"}
+      ]
+    },
+    {
+      "id": "TA-03",
+      "title": "Process-global permission/question queues permit cross-tenant decisions",
+      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "independent_reviewer"],
+      "negative_controls": [
+        {"package": "tandem-core", "source": "crates/tandem-core/src/permissions.rs", "symbol": "tenant_scoped_permission_state_cannot_be_discovered_or_decided_cross_tenant"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/permissions.rs", "symbol": "question_reply_rejects_requester_self_review"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/permissions.rs", "symbol": "permission_reply_route_applies_and_persists_allow_rule"}
+      ]
+    },
+    {
+      "id": "TA-04",
+      "title": "Legacy workflow gates can be approved by an unrelated tenant actor",
+      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "independent_reviewer"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/workflows.rs", "symbol": "workflow_gate_hosted_visibility_and_review_are_actor_scoped"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/workflows.rs", "symbol": "workflow_gate_rejects_stale_and_expired_requests_without_resuming"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/workflows.rs", "symbol": "workflow_gate_pauses_run_and_resumes_after_human_approval"}
+      ]
+    },
+    {
+      "id": "TA-05",
+      "title": "Governance grants and lifecycle mutations lack tenant/resource authorization",
+      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "protected_audit_unwritable"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/governance_parts/part01.rs", "symbol": "governance_approval_rejects_cross_tenant_approve_replay"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/governance_parts/part01.rs", "symbol": "governance_grant_audit_failure_leaves_state_unchanged"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/governance.rs", "symbol": "automations_v2_grant_revoke_pauses_automation_and_requests_dependency_review"}
+      ]
+    },
+    {
+      "id": "TA-06",
+      "title": "Global provider endpoint poisoning and shared transport-token rotation",
+      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "marker_provider_credential"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/providers.rs", "symbol": "hosted_admin_cannot_configure_private_local_provider_origin"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/providers.rs", "symbol": "tenant_a_cannot_list_update_or_delete_tenant_b_provider_api_key"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/providers.rs", "symbol": "standalone_loopback_owner_can_configure_private_local_provider_origin"}
+      ]
+    },
+    {
+      "id": "TA-07",
+      "title": "Channel endpoint changes exfiltrate preserved shared bot credentials",
+      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "marker_channel_credential"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/channels.rs", "symbol": "channel_identity_authority_is_admin_only_tenant_exact_and_locally_compatible"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/channels.rs", "symbol": "slack_sender_inventory_requires_deployment_admin"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/channels.rs", "symbol": "channels_put_protected_audit_records_shape_without_raw_credentials"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/channels.rs", "symbol": "channel_identity_authority_is_admin_only_tenant_exact_and_locally_compatible"}
+      ]
+    },
+    {
+      "id": "TA-08",
+      "title": "Global MCP mutation/deletion and unrestricted server-side requests",
+      "fixture_tags": ["ordinary_member", "temporary_workspace", "marker_audit_value"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/mcp_admin_hardening.rs", "symbol": "private_mcp_oauth_requires_standalone_listener_posture"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/mcp_admin_hardening.rs", "symbol": "stopped_listener_posture_blocks_actual_private_mcp_request"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/mcp_admin_hardening.rs", "symbol": "mcp_registration_audit_records_header_names_without_values"}
+      ]
+    },
+    {
+      "id": "TA-09",
+      "title": "Destructive process-global and arbitrary-repository operations",
+      "fixture_tags": ["temporary_git_repository", "org-a/workspace-a", "org-b/workspace-b"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/global_parts/part07.rs", "symbol": "managed_worktree_create_rejects_external_path_override"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/global_parts/part07.rs", "symbol": "managed_worktree_mutations_require_matching_active_lease"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/global_parts/part07.rs", "symbol": "managed_worktree_endpoints_are_idempotent_and_cleanup_branch"}
+      ]
+    },
+    {
+      "id": "TA-10",
+      "title": "Pack install/export path escape, SSRF, and unbounded download",
+      "fixture_tags": ["temporary_pack_root", "fake_private_dns_answer", "fake_cloud_metadata_address", "fake_redirect_service", "chunked_over_budget_service"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/outbound_http.rs", "symbol": "fake_dns_and_cloud_metadata_answers_fail_closed"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/outbound_http.rs", "symbol": "fake_redirect_and_streaming_budget_service_is_contained"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/pack_manager_tests.rs", "symbol": "safe_extract_blocks_traversal"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/packs.rs", "symbol": "packs_install_list_and_uninstall_roundtrip"}
+      ]
+    },
+    {
+      "id": "TA-11",
+      "title": "Configurable Web UI prefix can exempt API routes from authentication",
+      "fixture_tags": ["ordinary_member", "marker_audit_value"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/middleware.rs", "symbol": "web_ui_bypass_is_method_and_segment_exact"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/global_parts/part01.rs", "symbol": "global_health_route_returns_only_minimal_public_shape"}
+      ]
+    },
+    {
+      "id": "TA-12",
+      "title": "Security-relevant effects can precede protected audit durability",
+      "fixture_tags": ["protected_audit_unwritable", "state_persistence_failure", "marker_audit_value"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/action_authorization.rs", "symbol": "audit_persistence_failure_prevents_grant_issuance"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/workflows.rs", "symbol": "workflow_gate_persistence_failure_keeps_nonce_pending"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/providers.rs", "symbol": "provider_auth_set_writes_protected_audit_record"}
+      ]
+    },
+    {
+      "id": "TA-13",
+      "title": "Public webhook rejection path enables disk/write amplification",
+      "fixture_tags": ["chunked_over_budget_service", "marker_audit_value"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/automation_webhooks/security.rs", "symbol": "bad_signature_load_is_throttled_and_retained_within_explicit_ceilings"},
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/automation_webhooks/security.rs", "symbol": "public_webhook_body_limits_apply_before_collection_and_vary_by_provider"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/http/tests/automation_webhooks.rs", "symbol": "public_automation_webhook_accepts_signed_request_without_transport_auth"}
+      ]
+    },
+    {
+      "id": "TA-14",
+      "title": "Browser sidecar installer executes unsigned, unbounded release artifacts",
+      "fixture_tags": ["temporary_workspace", "marker_audit_value"],
+      "negative_controls": [
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "rejects_tampered_manifest_bytes"},
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "digest_verifier_rejects_oversize_before_hashing"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "verifies_signed_manifest_and_exact_target"}
+      ]
+    },
+    {
+      "id": "TA-15",
+      "title": "Desktop engine sidecar and release chain lack artifact integrity",
+      "fixture_tags": ["temporary_workspace", "marker_audit_value"],
+      "negative_controls": [
+        {"package": "tandem-server", "source": "crates/tandem-server/src/browser_parts/artifact_install.rs", "symbol": "failed_version_probe_restores_previous_binary"},
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "rejects_wrong_release_after_valid_signature"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/artifact_integrity.rs", "symbol": "digest_verifier_accepts_exact_bytes"}
+      ]
+    },
+    {
+      "id": "TA-16",
+      "title": "Context-assertion replay cache is process-local",
+      "fixture_tags": ["two_replay_store_instances", "org-a/workspace-a", "org-b/workspace-b"],
+      "negative_controls": [
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/context_assertion_security_tests.rs", "symbol": "persistent_replay_store_coordinates_one_shot_and_bound_across_instances"},
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/context_assertion_security_tests.rs", "symbol": "concurrent_one_shot_race_has_exactly_one_winner"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/context_assertion_security_tests.rs", "symbol": "replay_expiry_namespace_and_capacity_limits_are_enforced"}
+      ]
+    },
+    {
+      "id": "TA-17",
+      "title": "ACA verifier accepts materially under-validated identity claims",
+      "fixture_tags": ["org-a/workspace-a", "org-b/workspace-b", "marker_audit_value"],
+      "negative_controls": [
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/aca_request_auth.rs", "symbol": "hosted_mode_rejects_identity_issuer_version_and_lifetime_drift"},
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/aca_request_auth.rs", "symbol": "hosted_mode_rejects_wrong_audience_in_claims"}
+      ],
+      "positive_controls": [
+        {"package": "tandem-enterprise-contract", "source": "crates/tandem-enterprise-contract/src/aca_request_auth.rs", "symbol": "hosted_mode_full_verifier_accepts_valid_assertion"}
+      ]
+    }
+  ]
+}

--- a/docs/SECURITY_CONTAINMENT_ADVISORY_2026.md
+++ b/docs/SECURITY_CONTAINMENT_ADVISORY_2026.md
@@ -43,9 +43,10 @@ API-overlapping, encoded-separator, traversal, and non-reserved prefixes back to
 
 ## Edge containment
 
-Until the final focused retest records an allow decision, an upstream edge must
-deny these route families if the engine is reachable beyond its standalone
-loopback owner:
+Until the final shared/hosted release decision records an allow decision after
+the focused retest and the assurance, dependency, and deployment gates all
+pass, an upstream edge must deny these route families if the engine is
+reachable beyond its standalone loopback owner:
 
 - pack install, update, uninstall, export, detection, and file access;
 - MCP definition and connection mutation;

--- a/docs/SECURITY_CONTAINMENT_ADVISORY_2026.md
+++ b/docs/SECURITY_CONTAINMENT_ADVISORY_2026.md
@@ -1,8 +1,23 @@
 # Security containment advisory (2026 audit)
 
-This advisory applies while the security-audit remediation project is open. It
-describes a temporary deployment boundary, not a statement that all audit
-findings are resolved.
+This advisory applies while the security-audit remediation project is open. All
+confirmed finding implementations have merged, but the cross-cutting inventory,
+dynamic retest, assurance scan, and final release decision remain open. This is
+a temporary deployment boundary, not a final release decision.
+
+## Deployment scope recorded for this audit
+
+No enterprise or shared Tandem server has been deployed. The audit therefore
+does not identify a running customer, enterprise, or shared-engine instance that
+was exposed by these findings, and it does not assert that a standalone local
+engine was remotely exposed.
+
+Credential rotation is **not required solely because a source finding existed**
+when there was no deployed/shared runtime and no real credential was placed in
+one. Rotation remains mandatory if deployment records, operator evidence, or a
+later incident review shows that a runtime was reachable/shared or held a real
+credential outside the supported standalone posture. This scope decision must
+be re-evaluated before the first hosted, shared, or enterprise deployment.
 
 ## Supported interim posture
 
@@ -28,14 +43,15 @@ API-overlapping, encoded-separator, traversal, and non-reserved prefixes back to
 
 ## Edge containment
 
-Until the corresponding remediation issue is merged and retested, an upstream
-edge must deny these route families if the engine is reachable beyond its
-standalone loopback owner:
+Until the final focused retest records an allow decision, an upstream edge must
+deny these route families if the engine is reachable beyond its standalone
+loopback owner:
 
 - pack install, update, uninstall, export, detection, and file access;
 - MCP definition and connection mutation;
 - provider and global configuration mutation, including token rotation;
 - channel configuration, credential, reload, and destination mutation;
+- channel enrollment, step-up grants, and sender-inventory reads;
 - permission/question decisions and workflow/governance approval mutation; and
 - browser-sidecar download or installation.
 
@@ -65,7 +81,8 @@ close symlink-swap races at open time.
 Do not place production provider, channel, signing, or deployment credentials
 in a shared runtime while this advisory is active.
 
-For any runtime that was previously reachable or shared:
+For any runtime that was previously reachable/shared, or that held real shared
+credentials:
 
 1. remove it from service and preserve logs needed for incident review;
 2. inventory transport, provider, channel, webhook, OAuth, signing, and sidecar
@@ -99,7 +116,10 @@ After starting:
    or any hosted pack host-path operation; and
 6. verify an ordinary authenticated principal cannot invoke browser install,
    browser smoke testing, storage repair, global disposal, or destructive
-   worktree mutation.
+   worktree mutation; and
+7. verify channel enrollment, channel step-up grants, and Slack sender inventory
+   reject an ordinary tenant principal, reject cross-tenant targets, and allow
+   only an exact deployment-admin grant or the direct standalone loopback owner.
 
 ## Rollback
 

--- a/docs/SECURITY_CONTAINMENT_ADVISORY_2026.md
+++ b/docs/SECURITY_CONTAINMENT_ADVISORY_2026.md
@@ -26,8 +26,9 @@ address. Keep generated transport authentication enabled. Do not expose the
 engine port through a public listener, shared reverse proxy, tunnel, container
 port publication, or multi-tenant service.
 
-The following postures remain blocked until the focused security retest records
-a release decision:
+The following postures remain blocked until the final shared/hosted release
+decision records an allow decision after the focused retest and the assurance,
+dependency, and deployment gates all pass:
 
 - remotely reachable engine API;
 - shared or multi-tenant engine process;

--- a/docs/SECURITY_ROUTE_POLICY_INVENTORY.json
+++ b/docs/SECURITY_ROUTE_POLICY_INVENTORY.json
@@ -756,10 +756,10 @@
       "method": "GET",
       "path": "/audit/ledger/export",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:136"
       ]
@@ -769,10 +769,10 @@
       "method": "HEAD",
       "path": "/audit/ledger/export",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:136"
       ]
@@ -782,10 +782,10 @@
       "method": "GET",
       "path": "/audit/ledger/manifest",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:132"
       ]
@@ -795,10 +795,10 @@
       "method": "HEAD",
       "path": "/audit/ledger/manifest",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:132"
       ]
@@ -808,10 +808,10 @@
       "method": "GET",
       "path": "/audit/protected",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:124"
       ]
@@ -821,10 +821,10 @@
       "method": "HEAD",
       "path": "/audit/protected",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:124"
       ]
@@ -834,10 +834,10 @@
       "method": "GET",
       "path": "/audit/stream",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:128"
       ]
@@ -847,10 +847,10 @@
       "method": "HEAD",
       "path": "/audit/stream",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:128"
       ]
@@ -3356,10 +3356,10 @@
       "method": "PATCH",
       "path": "/config",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
-      "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.config.manage",
+      "resolver": "tenant_project_config",
+      "policy_origin": "admin.deployment",
       "sources": [
         "crates/tandem-server/src/http/routes_config_providers.rs:13"
       ]
@@ -3395,10 +3395,10 @@
       "method": "PATCH",
       "path": "/config/identity",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
-      "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.config.manage",
+      "resolver": "tenant_project_config",
+      "policy_origin": "admin.deployment",
       "sources": [
         "crates/tandem-server/src/http/routes_config_providers.rs:14"
       ]

--- a/docs/SECURITY_ROUTE_POLICY_INVENTORY.json
+++ b/docs/SECURITY_ROUTE_POLICY_INVENTORY.json
@@ -1,0 +1,11051 @@
+{
+  "schema_version": 2,
+  "generated_by": "node scripts/verify-route-policy-inventory.mjs --write",
+  "scope": {
+    "included": [
+      "engine API route registrars",
+      "enterprise route extensions",
+      "configured Web UI GET/HEAD surface",
+      "loopback OpenAI Codex OAuth callback listener"
+    ],
+    "excluded": [
+      "cfg(test) fixture routers",
+      "feature-gated loopback ACME demo Slack mock",
+      "outbound provider URLs"
+    ],
+    "middleware_surfaces": [
+      {
+        "method": "OPTIONS",
+        "path": "{registered_engine_api_path}",
+        "policy": "CORS preflight only; auth_gate bypass does not dispatch an application handler"
+      }
+    ]
+  },
+  "route_count": 848,
+  "policies": [
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "{web_ui_prefix}",
+      "ingress_policy": "public_web_ui_get_head",
+      "authorization_policy": "static_admin_shell_only",
+      "capability": null,
+      "resolver": "configured_reserved_web_ui_prefix",
+      "policy_origin": "public.web_ui",
+      "sources": [
+        "crates/tandem-server/src/webui/mod.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "{web_ui_prefix}",
+      "ingress_policy": "public_web_ui_get_head",
+      "authorization_policy": "static_admin_shell_only",
+      "capability": null,
+      "resolver": "configured_reserved_web_ui_prefix",
+      "policy_origin": "public.web_ui",
+      "sources": [
+        "crates/tandem-server/src/webui/mod.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "{web_ui_prefix}/",
+      "ingress_policy": "public_web_ui_get_head",
+      "authorization_policy": "static_admin_shell_only",
+      "capability": null,
+      "resolver": "configured_reserved_web_ui_prefix",
+      "policy_origin": "public.web_ui",
+      "sources": [
+        "crates/tandem-server/src/webui/mod.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "{web_ui_prefix}/",
+      "ingress_policy": "public_web_ui_get_head",
+      "authorization_policy": "static_admin_shell_only",
+      "capability": null,
+      "resolver": "configured_reserved_web_ui_prefix",
+      "policy_origin": "public.web_ui",
+      "sources": [
+        "crates/tandem-server/src/webui/mod.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "{web_ui_prefix}/{*path}",
+      "ingress_policy": "public_web_ui_get_head",
+      "authorization_policy": "static_admin_shell_only",
+      "capability": null,
+      "resolver": "configured_reserved_web_ui_prefix",
+      "policy_origin": "public.web_ui",
+      "sources": [
+        "crates/tandem-server/src/webui/mod.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "{web_ui_prefix}/{*path}",
+      "ingress_policy": "public_web_ui_get_head",
+      "authorization_policy": "static_admin_shell_only",
+      "capability": null,
+      "resolver": "configured_reserved_web_ui_prefix",
+      "policy_origin": "public.web_ui",
+      "sources": [
+        "crates/tandem-server/src/webui/mod.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/admin/reload-config",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/agent",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:71"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/agent",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:71"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/agent-standup/compose",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/agent-team/approvals",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/agent-team/approvals",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/agent-team/approvals/spawn/{id}/approve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/agent-team/approvals/spawn/{id}/deny",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:35"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/agent-team/instance/{id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:40"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/agent-team/instances",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/agent-team/instances",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/agent-team/mission/{id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/agent-team/missions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:29"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/agent-team/missions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:29"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/agent-team/spawn",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:39"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/agent-team/templates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/agent-team/templates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/agent-team/templates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/agent-team/templates/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/agent-team/templates/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/engine/webhooks/automations/{public_path_token}",
+      "ingress_policy": "public_capability_webhook",
+      "authorization_policy": "path_capability_signature_nonce_and_tenant_binding",
+      "capability": "automation.webhook.trigger",
+      "resolver": "automation_trigger_from_public_capability",
+      "policy_origin": "public.automation_webhook",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhooks.rs:53"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/engine/webhooks/automations/{public_path_token}/{setup_nonce}",
+      "ingress_policy": "public_capability_webhook",
+      "authorization_policy": "path_capability_signature_nonce_and_tenant_binding",
+      "capability": "automation.webhook.trigger",
+      "resolver": "automation_trigger_from_public_capability",
+      "policy_origin": "public.automation_webhook",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhooks.rs:57"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/api/providers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/api/providers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/api/run/{id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:49"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/api/run/{id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:49"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/api/session",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/api/session",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/session",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/api/session/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/api/session/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/api/session/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/api/session/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/session/{id}/attach",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/session/{id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:54"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/api/session/{id}/message",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:40"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/api/session/{id}/message",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:40"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/session/{id}/message",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:40"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/session/{id}/prompt_async",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:47"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/session/{id}/prompt_sync",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:49"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/api/session/{id}/run",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:51"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/api/session/{id}/run",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:51"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/session/{id}/run/{run_id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:56"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/api/session/{id}/todo",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/api/session/{id}/todo",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/api/session/{id}/workspace/override",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:32"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/approvals/pending",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_approvals.rs:76"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/approvals/pending",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_approvals.rs:76"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/audit/data-boundary/monitoring",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:140"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/audit/data-boundary/monitoring",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:140"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/audit/ledger/export",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:136"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/audit/ledger/export",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:136"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/audit/ledger/manifest",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:132"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/audit/ledger/manifest",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:132"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/audit/protected",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:124"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/audit/protected",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:124"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/audit/stream",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:128"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/audit/stream",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:128"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/auth/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/auth/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/auth/token",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/auth/token",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/auth/token/{token_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:48"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/auth/token/generate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:46"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/auth/tokens",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:47"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/auth/tokens",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:47"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/automations/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:39"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/automations/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:39"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/{id}/history",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/{id}/history",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/{id}/run_now",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:43"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/{id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:46"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/{id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:46"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/channel-drafts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_channel_automation_drafts.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/channel-drafts/{draft_id}/answer",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_channel_automation_drafts.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/channel-drafts/{draft_id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_channel_automation_drafts.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/channel-drafts/{draft_id}/confirm",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_channel_automation_drafts.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/channel-drafts/pending",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_channel_automation_drafts.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/channel-drafts/pending",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_channel_automation_drafts.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/compose/monitor",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/compose/standup",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:38"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:38"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:47"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:47"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/runs/{run_id}/approve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:48"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/runs/{run_id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:64"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/runs/{run_id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:64"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/runs/{run_id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:64"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/runs/{run_id}/deny",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:52"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/runs/{run_id}/pause",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:56"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/runs/{run_id}/resume",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:60"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:68"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:68"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:68"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/automations/v2/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:73"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:73"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:73"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/automations/v2/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:73"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/extend",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:374"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/{id}/governance",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:354"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/{id}/governance",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:354"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/{id}/grants",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:358"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/{id}/grants",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:358"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/grants",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:358"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/automations/v2/{id}/grants/{grant_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:362"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/{id}/handoffs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:83"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/{id}/handoffs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:83"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/pause",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:81"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/restore",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:366"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/resume",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:82"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/retire",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:370"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/run_now",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:79"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/{id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:88"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/{id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:88"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/share",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:80"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/{id}/webhook-triggers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/{id}/webhook-triggers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/webhook-triggers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}/deliveries",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:57"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}/deliveries",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:57"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}/deliveries/{delivery_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:61"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}/deliveries/{delivery_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:61"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}/disable",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:37"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}/import-secret",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:53"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}/reset-verification",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:49"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}/reveal-verification-token",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/{id}/webhook-triggers/{trigger_id}/rotate-secret",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:41"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:72"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:72"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/graduation/summary",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:130"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/graduation/summary",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:130"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:87"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:87"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:89"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:89"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/backlog/tasks/{task_id}/claim",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:134"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/backlog/tasks/{task_id}/requeue",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:138"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:98"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/gate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:142"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/pause",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:90"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/recover",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:102"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/repair",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:106"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/resume",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:94"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/tasks/{node_id}/continue",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:118"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/automations/v2/runs/{run_id}/tasks/{node_id}/disposition",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:126"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/tasks/{node_id}/requeue",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:122"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/runs/{run_id}/tasks/{node_id}/reset_preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:114"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/runs/{run_id}/tasks/{node_id}/reset_preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:114"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/automations/v2/runs/{run_id}/tasks/{node_id}/retry",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:110"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/runs/{run_id}/webhook-events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:70"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/runs/{run_id}/webhook-events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:70"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/webhook-events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:65"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/webhook-events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:65"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/automations/v2/webhook-events/{event_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:66"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/automations/v2/webhook-events/{event_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhook_management.rs:66"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/browser/install",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/browser/smoke-test",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/browser/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:29"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/browser/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:29"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/capabilities/bindings",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_capabilities.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/capabilities/bindings",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_capabilities.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/capabilities/bindings",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_capabilities.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/capabilities/bindings/refresh-builtins",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_capabilities.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/capabilities/bindings/reset-to-builtins",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_capabilities.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/capabilities/discovery",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_capabilities.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/capabilities/discovery",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_capabilities.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/capabilities/readiness",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_capabilities.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/capabilities/resolve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_capabilities.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/channels/{name}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:55"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/channels/{name}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:55"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/channels/{name}/scopes",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:53"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/channels/{name}/scopes",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:53"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/channels/{name}/tool-preferences",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:59"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/channels/{name}/tool-preferences",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:59"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/channels/{name}/tool-preferences",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:59"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/channels/{name}/verify",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:54"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/channels/config",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:51"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/channels/config",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:51"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/channels/discord/interactions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "channel_signature_identity_and_tenant_binding",
+      "capability": "channel.interaction",
+      "resolver": "signed_channel_installation_user_tenant",
+      "policy_origin": "channel.signed_interaction",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:168"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/channels/enroll",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:148"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/channels/slack/events",
+      "ingress_policy": "public_signed_webhook",
+      "authorization_policy": "slack_signature_installation_and_tenant_binding",
+      "capability": "channel.message.ingress",
+      "resolver": "slack_signature_installation_sender_tenant",
+      "policy_origin": "public.slack_events",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:164"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/channels/slack/interactions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "channel_signature_identity_and_tenant_binding",
+      "capability": "channel.interaction",
+      "resolver": "signed_channel_installation_user_tenant",
+      "policy_origin": "channel.signed_interaction",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:160"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/channels/slack/senders",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:156"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/channels/slack/senders",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:156"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/channels/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:52"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/channels/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:52"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/channels/step-up",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:152"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/channels/telegram/interactions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "channel_signature_identity_and_tenant_binding",
+      "capability": "channel.interaction",
+      "resolver": "signed_channel_installation_user_tenant",
+      "policy_origin": "channel.signed_interaction",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:172"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/projects",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/projects",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/projects/{project_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/projects/{project_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/projects/{project_id}/bindings",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/projects/{project_id}/bindings",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/coder/projects/{project_id}/bindings",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/projects/{project_id}/github-project/inbox",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/projects/{project_id}/github-project/inbox",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/projects/{project_id}/github-project/intake",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/projects/{project_id}/policy",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/projects/{project_id}/policy",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/coder/projects/{project_id}/policy",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/projects/{project_id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/projects/{project_id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/projects/{project_id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:35"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:35"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:35"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/runs/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:36"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/runs/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:36"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/approve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:46"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/runs/{id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:48"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/runs/{id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:48"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:47"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/execute-all",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:41"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/execute-next",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:37"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/follow-on-run",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:42"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/issue-fix-summary",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:74"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/issue-fix-validation-report",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:70"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/runs/{id}/memory-candidates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:98"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/runs/{id}/memory-candidates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:98"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/memory-candidates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:98"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/memory-candidates/{candidate_id}/promote",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:102"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/runs/{id}/memory-hits",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:49"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/runs/{id}/memory-hits",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:49"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/merge-readiness-report",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:86"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/merge-recommendation-summary",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:90"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/merge-submit",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:94"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/pr-draft",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:78"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/pr-review-evidence",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:62"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/pr-review-summary",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:66"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/pr-submit",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:82"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/triage-inspection-report",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:50"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/triage-reproduction-report",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:54"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/coder/runs/{id}/triage-summary",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:58"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/coder/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/coder/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_coder.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/command",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.command.execute",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/command",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.command.execute",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/config",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/config",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/config",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/config/identity",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/config/identity",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/config/identity",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/config/incident-monitor",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:10"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/config/incident-monitor",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:10"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/config/incident-monitor",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:10"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/config/providers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/config/providers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/packs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/packs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/packs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/packs/{pack_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/packs/{pack_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/packs/{pack_id}/bind",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/packs/{pack_id}/revoke",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:29"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/packs/{pack_id}/supersede",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/context/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/blackboard",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:59"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/blackboard",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:59"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/blackboard/patches",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/blackboard/patches",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/blackboard/patches",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/checkpoints",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:79"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/checkpoints/latest",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:99"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/checkpoints/latest",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:99"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/checkpoints/mutations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:83"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/checkpoints/mutations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:83"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/checkpoints/mutations/rollback-execute",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:95"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/checkpoints/mutations/rollback-history",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:91"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/checkpoints/mutations/rollback-history",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:91"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/checkpoints/mutations/rollback-preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:87"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/checkpoints/mutations/rollback-preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:87"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/driver/next",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:104"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:38"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:38"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:38"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/events/stream",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:51"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/events/stream",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:51"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/governance-evidence",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:43"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/governance-evidence",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:43"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/lease/validate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:55"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/ledger",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:42"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/ledger",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:42"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/{run_id}/replay",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:103"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/{run_id}/replay",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:103"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/tasks",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:67"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/tasks/{task_id}/transition",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:75"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/tasks/claim",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:71"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/context/runs/{run_id}/todos/sync",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:47"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/context/runs/events/stream",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/context/runs/events/stream",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_context.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/doc",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:74"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/doc",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:74"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/connector-providers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:164"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/connector-providers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:164"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/connectors",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:172"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/connectors",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:172"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/connectors",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:172"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/enterprise/connectors/{connector_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:176"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/connectors/{connector_id}/credential-refs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:184"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/enterprise/connectors/{connector_id}/credential-refs/{credential_id}/rotate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:188"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/connectors/{connector_id}/impact",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:180"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/connectors/{connector_id}/impact",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:180"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/cross-tenant-grants",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs:71"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/cross-tenant-grants",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs:71"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/cross-tenant-grants",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs:71"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/cross-tenant-grants/{grant_id}/revoke",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs:79"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/cross-tenant-grants/inbound",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs:75"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/cross-tenant-grants/inbound",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_cross_tenant.rs:75"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/ingestion-jobs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:192"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/ingestion-jobs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:192"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/ingestion-quarantines",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:196"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/ingestion-quarantines",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:196"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/enterprise/ingestion-quarantines/{quarantine_id}/review",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:200"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/onboarding-plans/preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs:33"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/org-unit-access-grants",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:161"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/org-unit-access-grants",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:161"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/org-unit-access-grants",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:161"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/enterprise/org-unit-access-grants/{grant_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:169"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/org-unit-access-grants/effective",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:165"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/org-unit-access-grants/effective",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:165"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/org-unit-memberships",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:153"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/org-unit-memberships",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:153"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/org-unit-memberships",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:153"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/enterprise/org-unit-memberships/{membership_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:157"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/org-units",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:149"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/org-units",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:149"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/org-units",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:149"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/policies",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:92"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/policies",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:92"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/policies",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:92"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/policies/{policy_id}/disable",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:103"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/policies/{policy_id}/publish",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:99"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/policies/{policy_id}/supersede",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:107"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/enterprise/policies/{rule_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:98"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/policies/preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:97"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/policies/validate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:96"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/policy-templates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:111"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/policy-templates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:111"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/policy-templates/{template_id}/instantiate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:112"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/policy-templates/{template_id}/rollback",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:116"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/policy-templates/{template_id}/upgrade",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_policies.rs:120"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/readiness",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs:32"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/readiness",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs:32"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/source-bindings",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:168"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/source-bindings",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:168"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/source-bindings",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:168"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/enterprise/source-bindings/{binding_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:204"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/source-bindings/{binding_id}/google-drive/import",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:212"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/source-bindings/{binding_id}/google-drive/preflight",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:208"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/source-bindings/{binding_id}/google-drive/reindex",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:216"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/source-bindings/{binding_id}/source-objects",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:220"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/source-bindings/{binding_id}/source-objects",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:220"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/enterprise/source-bindings/{binding_id}/source-objects/{source_object_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:228"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/enterprise/source-bindings/{binding_id}/source-objects/{source_object_id}/reindex",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:224"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/enterprise/source-bindings/{binding_id}/source-objects/{source_object_id}/scope",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-enterprise-server/src/http/routes_enterprise.rs:232"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/enterprise/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/enterprise/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/event",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:33"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/event",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:33"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/external-actions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_external_actions.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/external-actions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_external_actions.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/external-actions/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_external_actions.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/external-actions/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_external_actions.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/file",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:17"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/file",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:17"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/file/content",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/file/content",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/file/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/file/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/find",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/find",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/find/file",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/find/file",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/find/symbol",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/find/symbol",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/formatter",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/formatter",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/global/config",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:39"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/global/config",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:39"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/global/config",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:39"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/global/diagnostics",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:26"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/global/diagnostics",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:26"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/global/dispose",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:43"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/global/event",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:32"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/global/event",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:32"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/global/health",
+      "ingress_policy": "public_exact_health",
+      "authorization_policy": "minimal_health_shape",
+      "capability": null,
+      "resolver": "none",
+      "policy_origin": "public.health",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/global/health",
+      "ingress_policy": "public_exact_health",
+      "authorization_policy": "minimal_health_shape",
+      "capability": null,
+      "resolver": "none",
+      "policy_origin": "public.health",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/global/lease/acquire",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/global/lease/release",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:36"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/global/lease/renew",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:35"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/global/storage/files",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:37"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/global/storage/files",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:37"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/global/storage/repair",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:38"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/global/workspace",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/global/workspace",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
+      "capability": "deployment.admin",
+      "resolver": "deployment_or_enterprise_state",
+      "policy_origin": "admin.deployment",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goal-capability-learning/decisions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_goal_capability_learning.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goal-capability-learning/decisions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_goal_capability_learning.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goal-capability-learning/decisions/{decision_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_goal_capability_learning.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goal-capability-learning/decisions/{decision_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_goal_capability_learning.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goal-capability-learning/discover",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_goal_capability_learning.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:271"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:271"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goals",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:271"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:275"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:275"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goals/{goal_id}/actions/{action_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:283"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:315"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:315"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/budgets",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:319"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/budgets",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:319"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goals/{goal_id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:295"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goals/{goal_id}/completion",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:331"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:307"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:307"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/events/stream",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:311"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/events/stream",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:311"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/graph",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:299"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/graph",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:299"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/handoffs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:323"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/handoffs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:323"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goals/{goal_id}/handoffs/{handoff_id}/decision",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:335"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goals/{goal_id}/pause",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:287"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/projection",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:279"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/projection",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:279"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goals/{goal_id}/resume",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:291"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:303"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:303"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goals/{goal_id}/transitions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:327"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/waits",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:339"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/waits",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:339"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/goals/{goal_id}/waits/{wait_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:343"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/goals/{goal_id}/waits/{wait_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:343"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/goals/{goal_id}/waits/{wait_id}/resolve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:347"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/governance/agents/{agent_id}/spend",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:346"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/governance/agents/{agent_id}/spend",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:346"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/governance/approvals",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:326"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/governance/approvals",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:326"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/governance/approvals",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:330"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/governance/approvals/{approval_id}/approve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:334"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/governance/approvals/{approval_id}/deny",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:338"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/governance/policy-decisions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:322"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/governance/policy-decisions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:322"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/governance/reviews",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:350"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/governance/reviews",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:350"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/governance/spend",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:342"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/governance/spend",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_governance.rs:342"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/debug",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/debug",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/drafts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:107"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/drafts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:107"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/incident-monitor/drafts/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:127"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/drafts/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:127"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/drafts/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:127"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/drafts/{id}/approve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:133"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/drafts/{id}/deny",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:139"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/drafts/{id}/issue-draft",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:193"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/drafts/{id}/publish",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:199"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/drafts/{id}/recheck-match",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:205"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/drafts/{id}/triage-run",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:181"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/drafts/{id}/triage-summary",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:187"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/drafts/bulk-delete",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:108"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/incidents",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:83"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/incidents",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:83"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/incident-monitor/incidents/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:95"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/incidents/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:95"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/incidents/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:95"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/incidents/{id}/replay",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:101"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/incidents/bulk-delete",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:89"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/intake/keys",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:157"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/intake/keys",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:157"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/intake/keys",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:157"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/intake/keys/{id}/disable",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:163"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/intake/report",
+      "ingress_policy": "runtime_mode_incident_intake",
+      "authorization_policy": "incident_intake_key_or_verified_tenant",
+      "capability": "incident.report.ingest",
+      "resolver": "incident_intake_key_or_context",
+      "policy_origin": "public.incident_intake",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:151"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/log-sources/{project_id}/{source_id}/replay-latest",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:175"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/log-sources/{project_id}/{source_id}/reset-offset",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:169"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/pause",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/posts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:114"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/posts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:114"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/incident-monitor/posts/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:121"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/posts/bulk-delete",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:115"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/report",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:145"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/resume",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:26"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/route-preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:77"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/security/assessment-probes",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:40"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/security/assessment-report",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:46"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/security/authority-inventory",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/security/authority-inventory",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/security/deployment-cards",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:52"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/security/governance-metrics",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:64"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/security/posture-checks",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/security/posture-checks",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/security/reassessments",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:70"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/security/reassessments",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:70"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/security/reassessments",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:70"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/security/scenario-packs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:58"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/security/scenario-packs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:58"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/security/scenario-packs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:58"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/incident-monitor/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/incident-monitor/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/incident-monitor/status/recompute",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_incident_monitor.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/instance/dispose",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:72"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/log",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:73"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/lsp",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/lsp",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/marketplace/catalog",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_marketplace.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/marketplace/catalog",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_marketplace.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/marketplace/packs/{pack_id}/files/{*path}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_marketplace.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/marketplace/packs/{pack_id}/files/{*path}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_marketplace.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/mcp",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/mcp",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mcp",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/mcp/{name}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/mcp/{name}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/mcp/{name}/auth",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mcp/{name}/auth",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mcp/{name}/auth/authenticate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/mcp/{name}/auth/callback",
+      "ingress_policy": "public_oauth_callback",
+      "authorization_policy": "oauth_state",
+      "capability": null,
+      "resolver": "pending_oauth_session",
+      "policy_origin": "public.oauth_callback",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/mcp/{name}/auth/callback",
+      "ingress_policy": "public_oauth_callback",
+      "authorization_policy": "oauth_state",
+      "capability": null,
+      "resolver": "pending_oauth_session",
+      "policy_origin": "public.oauth_callback",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mcp/{name}/auth/callback",
+      "ingress_policy": "public_oauth_callback",
+      "authorization_policy": "oauth_state",
+      "capability": null,
+      "resolver": "pending_oauth_session",
+      "policy_origin": "public.oauth_callback",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mcp/{name}/connect",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mcp/{name}/disconnect",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mcp/{name}/refresh",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/mcp/catalog",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/mcp/catalog",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/mcp/catalog/{slug}/toml",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/mcp/catalog/{slug}/toml",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mcp/request-capability",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:26"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/mcp/resources",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:35"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/mcp/resources",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:35"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/mcp/tools",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/mcp/tools",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mcp.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/memory",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:35"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/memory",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:35"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/memory/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:36"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/memory/audit",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/memory/audit",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:34"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/memory/context/distill",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:43"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/memory/context/layers/generate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:39"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/memory/context/resolve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:37"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/memory/context/tree",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:38"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/memory/context/tree",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:38"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/memory/demote",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:32"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/memory/import",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/memory/promote",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:31"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/memory/put",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:29"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/memory/search",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:33"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/metrics",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:144"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/metrics",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:144"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/mission",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/mission",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mission",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mission-builder/apply",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mission_builder.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mission-builder/compile-preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mission_builder.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mission-builder/generate-draft",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_mission_builder.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/mission/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/mission/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/mission/{id}/event",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_missions_teams.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/optimizations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/optimizations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/optimizations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/optimizations/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/optimizations/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/optimizations/{id}/actions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:17"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/optimizations/{id}/experiments",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/optimizations/{id}/experiments",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/optimizations/{id}/experiments/{experiment_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/optimizations/{id}/experiments/{experiment_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/optimizations/{id}/experiments/{experiment_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_optimizations.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/orchestrations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:226"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/orchestrations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:226"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/orchestrations",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:226"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/orchestrations/{orchestration_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:231"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/orchestrations/{orchestration_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:231"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/orchestrations/{orchestration_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:231"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/orchestrations/{orchestration_id}/archive",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:236"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/orchestrations/{orchestration_id}/dry-run",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:264"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/orchestrations/{orchestration_id}/publish",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:244"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/orchestrations/{orchestration_id}/refresh-references",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:260"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/orchestrations/{orchestration_id}/stale-references",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:256"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/orchestrations/{orchestration_id}/stale-references",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:256"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/orchestrations/{orchestration_id}/validate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:240"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/orchestrations/{orchestration_id}/versions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:248"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/orchestrations/{orchestration_id}/versions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:248"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/orchestrations/{orchestration_id}/versions/{version}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:252"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/orchestrations/{orchestration_id}/versions/{version}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:252"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/pack-builder/apply",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_pack_builder.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/pack-builder/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_pack_builder.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/pack-builder/pending",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_pack_builder.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/pack-builder/pending",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_pack_builder.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/pack-builder/preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_pack_builder.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/packs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/packs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/packs/{selector}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/packs/{selector}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/packs/{selector}/files/{*path}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/packs/{selector}/files/{*path}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/packs/{selector}/update",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/packs/{selector}/updates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/packs/{selector}/updates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/packs/detect",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/packs/export",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/packs/install",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/packs/install_from_attachment",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/packs/uninstall",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_packs.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/path",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:26"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/path",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:26"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/permission",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/permission",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/permission/{id}/reply",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/presets/capability_summary",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_presets.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/presets/compose/preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_presets.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/presets/export_overrides",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_presets.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/presets/fork",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_presets.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/presets/index",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_presets.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/presets/index",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_presets.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/presets/overrides/{kind}/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_presets.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/presets/overrides/{kind}/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_presets.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/project",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:50"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/project",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:50"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/provider",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/provider",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/provider/{id}/oauth/authorize",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/provider/{id}/oauth/callback",
+      "ingress_policy": "public_oauth_callback",
+      "authorization_policy": "oauth_state",
+      "capability": null,
+      "resolver": "pending_oauth_session",
+      "policy_origin": "public.oauth_callback",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/provider/{id}/oauth/callback",
+      "ingress_policy": "public_oauth_callback",
+      "authorization_policy": "oauth_state",
+      "capability": null,
+      "resolver": "pending_oauth_session",
+      "policy_origin": "public.oauth_callback",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/provider/{id}/oauth/callback",
+      "ingress_policy": "public_oauth_callback",
+      "authorization_policy": "oauth_state",
+      "capability": null,
+      "resolver": "pending_oauth_session",
+      "policy_origin": "public.oauth_callback",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/provider/{id}/oauth/session",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:40"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/provider/{id}/oauth/session/import",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:36"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/provider/{id}/oauth/session/local",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:32"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/provider/{id}/oauth/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/provider/{id}/oauth/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/provider/auth",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/provider/auth",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/providers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/providers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_config_providers.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/question",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/question",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/question/{id}/reject",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/question/{id}/reply",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_scoped_qualified_independent_reviewer",
+      "capability": "governance.review",
+      "resolver": "tenant_request_or_governance_record",
+      "policy_origin": "governance.review",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/resource",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_resources.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/resource",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_resources.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/resource/{*key}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_resources.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/resource/{*key}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_resources.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/resource/{*key}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_resources.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/resource/{*key}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_resources.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PUT",
+      "path": "/resource/{*key}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_resources.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/resource/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_resources.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/resource/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_resources.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/routines",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/routines",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/routines",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/routines/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/routines/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/routines/{id}/history",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/routines/{id}/history",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/routines/{id}/run_now",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/routines/{id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/routines/{id}/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/routines/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/routines/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/routines/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/routines/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/routines/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/routines/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/routines/runs/{run_id}/approve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/routines/runs/{run_id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/routines/runs/{run_id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/routines/runs/{run_id}/artifacts",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:30"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/routines/runs/{run_id}/deny",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/routines/runs/{run_id}/pause",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/routines/runs/{run_id}/resume",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_routines_automations.rs:29"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/run/{id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:48"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/run/{id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:48"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/runs/{run_id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:179"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/runs/{run_id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:179"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/scheduler/metrics",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/scheduler/metrics",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:27"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/session",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/session",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/session/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/session/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/session/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/session/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/abort",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:52"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/attach",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:53"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/session/{id}/children",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:69"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/session/{id}/children",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:69"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/command",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.command.execute",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/session/{id}/diff",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:68"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/session/{id}/diff",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:68"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/fork",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:60"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/init",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:70"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/session/{id}/message",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:36"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/session/{id}/message",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:36"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/message",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:36"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/prompt_async",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:46"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/prompt_sync",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:48"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/revert",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:61"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/session/{id}/run",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:50"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/session/{id}/run",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:50"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/run/{run_id}/cancel",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:55"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/session/{id}/share",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/share",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/shell",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.command.execute",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:25"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/summarize",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:67"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/session/{id}/todo",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/session/{id}/todo",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/unrevert",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:62"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/session/{id}/workspace/override",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/session/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/session/status",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_sessions.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/sessions/{session_id}/questions/{question_id}/answer",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/sessions/{session_id}/tools/{tool_call_id}/approve",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/sessions/{session_id}/tools/{tool_call_id}/deny",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_permissions_questions.rs:17"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/setup/understand",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_setup_understanding.rs:10"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/skill",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/skill",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/skills",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/skills",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/skills/{name}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/skills/{name}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/skills/{name}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/skills/catalog",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/skills/catalog",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/compile",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/evals/benchmark",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/evals/triggers",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/generate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/generate/install",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/import",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/import/preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/router/match",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:17"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/skills/templates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/skills/templates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:23"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/templates/{id}/install",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/skills/validate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/stateful-runtime/reliability",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:188"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/stateful-runtime/reliability",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:188"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/stateful-runtime/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:184"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/stateful-runtime/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:184"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/stateful-runtime/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:192"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/stateful-runtime/runs/{run_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:192"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/stateful-runtime/runs/{run_id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:211"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/stateful-runtime/runs/{run_id}/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:211"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/stateful-runtime/runs/{run_id}/observability",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:200"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/stateful-runtime/runs/{run_id}/observability",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:200"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/stateful-runtime/runs/{run_id}/reliability",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:196"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/stateful-runtime/runs/{run_id}/reliability",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:196"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/stateful-runtime/runs/{run_id}/resume-plan",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:206"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/stateful-runtime/runs/{run_id}/resume-plan",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:206"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/stateful-runtime/runs/{run_id}/resume-plan",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:206"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/stateful-runtime/runs/{run_id}/snapshots",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:215"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/stateful-runtime/runs/{run_id}/snapshots",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:215"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/stateful-runtime/runs/{run_id}/snapshots/{snapshot_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:219"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/stateful-runtime/runs/{run_id}/snapshots/{snapshot_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/router.rs:219"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/task-intake/preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_task_intake.rs:11"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/tool",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:46"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/tool",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:46"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/tool/execute",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:47"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/tool/ids",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/tool/ids",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/vcs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/vcs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.files.read",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_system_api.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/webhooks/automations/{public_path_token}",
+      "ingress_policy": "public_capability_webhook",
+      "authorization_policy": "path_capability_signature_nonce_and_tenant_binding",
+      "capability": "automation.webhook.trigger",
+      "resolver": "automation_trigger_from_public_capability",
+      "policy_origin": "public.automation_webhook",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhooks.rs:45"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/webhooks/automations/{public_path_token}/{setup_nonce}",
+      "ingress_policy": "public_capability_webhook",
+      "authorization_policy": "path_capability_signature_nonce_and_tenant_binding",
+      "capability": "automation.webhook.trigger",
+      "resolver": "automation_trigger_from_public_capability",
+      "policy_origin": "public.automation_webhook",
+      "sources": [
+        "crates/tandem-server/src/http/routes_automation_webhooks.rs:49"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflow-hooks",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflow-hooks",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:21"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/workflow-hooks/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:22"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflow-learning/candidates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflow-learning/candidates",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-learning/candidates/{candidate_id}/promote",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:52"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-learning/candidates/{candidate_id}/review",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:48"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-learning/candidates/{candidate_id}/spawn-revision",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_skills_memory.rs:56"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflow-plans/{plan_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:85"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflow-plans/{plan_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:85"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/apply",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:57"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/chat/message",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:59"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/chat/reset",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/chat/start",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:58"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/export/pack",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:64"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflow-plans/export/pack/download",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:68"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflow-plans/export/pack/download",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:68"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/import",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:84"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/import/pack",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:76"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/import/pack/preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:72"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/import/preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:80"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/preview",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:56"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflow-plans/sessions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflow-plans/sessions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/sessions",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/workflow-plans/sessions/{session_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:28"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflow-plans/sessions/{session_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflow-plans/sessions/{session_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "PATCH",
+      "path": "/workflow-plans/sessions/{session_id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:24"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/sessions/{session_id}/duplicate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:32"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/sessions/{session_id}/message",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:44"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/sessions/{session_id}/message-async",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:48"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/sessions/{session_id}/reset",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:52"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/sessions/{session_id}/start",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:36"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflow-plans/sessions/{session_id}/start-async",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflow_planner.rs:40"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflows",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflows",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:12"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflows/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflows/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:19"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflows/{id}/run",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:20"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflows/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflows/events",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:15"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflows/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflows/runs",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:16"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/workflows/runs/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:17"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/workflows/runs/{id}",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:17"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflows/runs/{id}/gate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:18"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflows/simulate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:14"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/workflows/validate",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "tenant_resource_owner_or_scoped_grant",
+      "capability": "resource.owner_or_grant",
+      "resolver": "tenant_resource_from_state",
+      "policy_origin": "tenant.resource",
+      "sources": [
+        "crates/tandem-server/src/http/routes_workflows.rs:13"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "DELETE",
+      "path": "/worktree",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.worktree.manage",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "GET",
+      "path": "/worktree",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.worktree.manage",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "HEAD",
+      "path": "/worktree",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.worktree.manage",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/worktree",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.worktree.manage",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:63"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/worktree/cleanup",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.worktree.manage",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:70"
+      ]
+    },
+    {
+      "listener": "engine_api",
+      "method": "POST",
+      "path": "/worktree/reset",
+      "ingress_policy": "runtime_auth_gate",
+      "authorization_policy": "direct_loopback_local_owner_and_exact_host_effect_grant",
+      "capability": "host.worktree.manage",
+      "resolver": "canonical_host_resource",
+      "policy_origin": "host.local_effect",
+      "sources": [
+        "crates/tandem-server/src/http/routes_global.rs:69"
+      ]
+    },
+    {
+      "listener": "loopback_oauth_callback",
+      "method": "GET",
+      "path": "{loopback_oauth_listener}/auth/callback",
+      "ingress_policy": "loopback_listener",
+      "authorization_policy": "oauth_state",
+      "capability": null,
+      "resolver": "pending_provider_oauth_session",
+      "policy_origin": "oauth.loopback_callback",
+      "sources": [
+        "crates/tandem-server/src/http/config_providers_parts/part02.rs:37"
+      ]
+    },
+    {
+      "listener": "loopback_oauth_callback",
+      "method": "HEAD",
+      "path": "{loopback_oauth_listener}/auth/callback",
+      "ingress_policy": "loopback_listener",
+      "authorization_policy": "oauth_state",
+      "capability": null,
+      "resolver": "pending_provider_oauth_session",
+      "policy_origin": "oauth.loopback_callback",
+      "sources": [
+        "crates/tandem-server/src/http/config_providers_parts/part02.rs:37"
+      ]
+    },
+    {
+      "listener": "loopback_oauth_callback",
+      "method": "POST",
+      "path": "{loopback_oauth_listener}/auth/callback",
+      "ingress_policy": "loopback_listener",
+      "authorization_policy": "oauth_state",
+      "capability": null,
+      "resolver": "pending_provider_oauth_session",
+      "policy_origin": "oauth.loopback_callback",
+      "sources": [
+        "crates/tandem-server/src/http/config_providers_parts/part02.rs:37"
+      ]
+    }
+  ]
+}

--- a/docs/SECURITY_ROUTE_POLICY_INVENTORY.json
+++ b/docs/SECURITY_ROUTE_POLICY_INVENTORY.json
@@ -730,10 +730,10 @@
       "method": "GET",
       "path": "/audit/data-boundary/monitoring",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:140"
       ]
@@ -743,10 +743,10 @@
       "method": "HEAD",
       "path": "/audit/data-boundary/monitoring",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "verified_tenant_context",
+      "authorization_policy": "api_token_or_control_panel_admin_source_and_tenant_scope",
       "capability": null,
-      "resolver": "verified_tenant_context",
-      "policy_origin": "tenant.authenticated",
+      "resolver": "request_principal_source_and_tenant_audit_ledger",
+      "policy_origin": "audit.admin",
       "sources": [
         "crates/tandem-server/src/http/router.rs:140"
       ]
@@ -3447,10 +3447,10 @@
       "method": "GET",
       "path": "/config/providers",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_config_providers.rs:18"
       ]
@@ -3460,10 +3460,10 @@
       "method": "HEAD",
       "path": "/config/providers",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_config_providers.rs:18"
       ]
@@ -4942,10 +4942,10 @@
       "method": "GET",
       "path": "/enterprise/status",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_global.rs:28"
       ]
@@ -4955,10 +4955,10 @@
       "method": "HEAD",
       "path": "/enterprise/status",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_global.rs:28"
       ]
@@ -5228,10 +5228,10 @@
       "method": "GET",
       "path": "/global/config",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_global.rs:39"
       ]
@@ -5241,10 +5241,10 @@
       "method": "HEAD",
       "path": "/global/config",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_global.rs:39"
       ]
@@ -5397,10 +5397,10 @@
       "method": "GET",
       "path": "/global/storage/files",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_global.rs:37"
       ]
@@ -5410,10 +5410,10 @@
       "method": "HEAD",
       "path": "/global/storage/files",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_global.rs:37"
       ]
@@ -5436,10 +5436,10 @@
       "method": "GET",
       "path": "/global/workspace",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_global.rs:27"
       ]
@@ -5449,10 +5449,10 @@
       "method": "HEAD",
       "path": "/global/workspace",
       "ingress_policy": "runtime_auth_gate",
-      "authorization_policy": "deployment_administrator_or_loopback_local_owner",
-      "capability": "deployment.admin",
-      "resolver": "deployment_or_enterprise_state",
-      "policy_origin": "admin.deployment",
+      "authorization_policy": "verified_tenant_context",
+      "capability": null,
+      "resolver": "verified_tenant_context",
+      "policy_origin": "tenant.authenticated",
       "sources": [
         "crates/tandem-server/src/http/routes_global.rs:27"
       ]

--- a/docs/SECURITY_ROUTE_POLICY_INVENTORY.md
+++ b/docs/SECURITY_ROUTE_POLICY_INVENTORY.md
@@ -1,0 +1,51 @@
+# Security route-policy inventory
+
+`SECURITY_ROUTE_POLICY_INVENTORY.json` is the review contract for Tandem's HTTP
+surface. It records every discovered listener, exact path, and effective method,
+including Axum's implicit `HEAD` dispatch for every `GET` handler. Each entry
+declares both the ingress policy and the application authorization policy, plus
+the required capability, server-side resource resolver, policy origin, and
+source registration.
+
+The inventory covers:
+
+- all engine API route registrar modules;
+- enterprise route extensions composed into the engine router;
+- the configured Web UI GET/HEAD surface; and
+- the separate loopback OpenAI Codex OAuth callback listener.
+
+It deliberately excludes `#[cfg(test)]` fixture routers, outbound provider
+URLs, and the feature-gated loopback ACME demo's deterministic Slack mock. Those
+exclusions are recorded in the generated JSON and the verifier fails if another
+production Axum registrar appears outside the known set.
+
+## Verification and drift
+
+Run:
+
+```bash
+node --test scripts/verify-route-policy-inventory.test.mjs
+node scripts/verify-route-policy-inventory.mjs --self-test
+node scripts/verify-route-policy-inventory.mjs
+```
+
+The final command regenerates the inventory in memory and byte-compares it with
+the committed file. Any route, method, source, listener, or policy drift fails
+CI. To intentionally update it:
+
+```bash
+node scripts/verify-route-policy-inventory.mjs --write
+git diff -- docs/SECURITY_ROUTE_POLICY_INVENTORY.json
+```
+
+Review every changed entry. The generated policy is an explicit expected
+contract and drift detector; it does not, by itself, prove the handler enforces
+the contract. Enforcement evidence comes from the centralized request/context
+gate, handler/state authorization boundaries, and the security retest matrix.
+
+## Middleware-only methods
+
+The engine auth gate permits `OPTIONS` so the CORS layer can answer preflight.
+This is recorded under `scope.middleware_surfaces`; it is not an application
+handler method. Unknown methods and paths still reach Axum's normal method/path
+rejection and do not inherit an application route policy.

--- a/scripts/run-security-boundary-retest.sh
+++ b/scripts/run-security-boundary-retest.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+node --test scripts/verify-security-retest-matrix.test.mjs
+node scripts/verify-security-retest-matrix.mjs --self-test
+node scripts/verify-security-retest-matrix.mjs
+
+security_filter="$(node scripts/verify-security-retest-matrix.mjs --print-nextest-filter)"
+cargo nextest run --workspace --exclude tandem \
+  --features tandem-ai/browser,tandem-server/premium-governance \
+  --profile ci \
+  -E "$security_filter"

--- a/scripts/verify-route-policy-inventory.mjs
+++ b/scripts/verify-route-policy-inventory.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from "node:fs";
+import { isIP } from "node:net";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -8,6 +9,13 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const inventoryPath = path.join(repoRoot, "docs", "SECURITY_ROUTE_POLICY_INVENTORY.json");
 const methodNames = ["delete", "get", "head", "options", "patch", "post", "put", "trace"];
+const runtimeAuthenticatedReadPaths = new Set([
+  "/config/providers",
+  "/enterprise/status",
+  "/global/config",
+  "/global/storage/files",
+  "/global/workspace",
+]);
 
 function lineNumber(source, index) {
   return source.slice(0, index).split("\n").length;
@@ -167,6 +175,18 @@ function callsNamed(source, token) {
   return calls;
 }
 
+function callIsInsideNamedFunction(source, callIndex, functionName) {
+  const matches = [...source.matchAll(new RegExp(`\\bfn\\s+${functionName}\\s*\\(`, "g"))];
+  if (matches.length !== 1) return false;
+  const signatureOpen = source.indexOf("(", matches[0].index);
+  const signatureClose = matchingDelimiter(source, signatureOpen);
+  if (signatureClose === -1) return false;
+  const bodyOpen = source.indexOf("{", signatureClose + 1);
+  if (bodyOpen === -1) return false;
+  const bodyClose = matchingDelimiter(source, bodyOpen, "{", "}");
+  return bodyClose !== -1 && callIndex > bodyOpen && callIndex < bodyClose;
+}
+
 export function extractRoutesFromRust(source, sourcePath = "fixture.rs") {
   const production = productionSource(source);
   const routes = [];
@@ -175,7 +195,12 @@ export function extractRoutesFromRust(source, sourcePath = "fixture.rs") {
     const args = splitTopLevelArguments(call.body);
     const routePath = args.length >= 2 ? rustStringLiteral(args[0]) : null;
     if (!routePath) {
-      if (/routes_incident_monitor\.rs$/.test(sourcePath) && args[0]?.trim() === "&path") continue;
+      const isCanonicalIncidentHelperRegistration =
+        /routes_incident_monitor\.rs$/.test(sourcePath) &&
+        args[0]?.trim() === "&path" &&
+        args[1]?.trim() === "method_router" &&
+        callIsInsideNamedFunction(production, call.index, "route_prefixed");
+      if (isCanonicalIncidentHelperRegistration) continue;
       unsupported.push(`${sourcePath}:${lineNumber(production, call.index)} dynamic route path ${args[0] ?? "<missing>"}`);
       continue;
     }
@@ -302,11 +327,17 @@ export function assertLoopbackCallbackAddress(source) {
     /const\s+OPENAI_CODEX_LOCAL_CALLBACK_ADDR\s*:\s*&str\s*=\s*"([^"]+)"\s*;/.exec(
       source,
     );
-  if (!match || !/^127(?:\.\d{1,3}){3}:\d+$/.test(match[1])) {
-    throw new Error("OpenAI Codex OAuth callback address is not statically loopback-only");
-  }
-  const [host] = match[1].split(":");
-  if (Number(host.split(".")[0]) !== 127) {
+  const socket = match ? /^([^:]+):(\d+)$/.exec(match[1]) : null;
+  const host = socket?.[1] ?? "";
+  const port = Number(socket?.[2]);
+  if (
+    !socket ||
+    isIP(host) !== 4 ||
+    Number(host.split(".")[0]) !== 127 ||
+    !Number.isSafeInteger(port) ||
+    port < 1 ||
+    port > 65_535
+  ) {
     throw new Error("OpenAI Codex OAuth callback address is not statically loopback-only");
   }
 }
@@ -375,7 +406,7 @@ export function classifyRoute(route) {
   }
   if (
     (method === "GET" || method === "HEAD") &&
-    /^\/audit\/(?:protected|stream|ledger\/(?:manifest|export))$/.test(routePath)
+    /^\/audit\/(?:protected|stream|data-boundary\/monitoring|ledger\/(?:manifest|export))$/.test(routePath)
   ) {
     return {
       ingress_policy: "runtime_auth_gate",
@@ -432,6 +463,19 @@ export function classifyRoute(route) {
       capability: "incident.report.ingest",
       resolver: "incident_intake_key_or_context",
       policy_origin: "public.incident_intake",
+    };
+  }
+
+  if (
+    (method === "GET" || method === "HEAD") &&
+    runtimeAuthenticatedReadPaths.has(routePath)
+  ) {
+    return {
+      ingress_policy: "runtime_auth_gate",
+      authorization_policy: "verified_tenant_context",
+      capability: null,
+      resolver: "verified_tenant_context",
+      policy_origin: "tenant.authenticated",
     };
   }
 

--- a/scripts/verify-route-policy-inventory.mjs
+++ b/scripts/verify-route-policy-inventory.mjs
@@ -1,0 +1,596 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const inventoryPath = path.join(repoRoot, "docs", "SECURITY_ROUTE_POLICY_INVENTORY.json");
+const methodNames = ["delete", "get", "head", "options", "patch", "post", "put", "trace"];
+
+function lineNumber(source, index) {
+  return source.slice(0, index).split("\n").length;
+}
+
+function maskRangePreservingLines(source, start, end) {
+  return `${source.slice(0, start)}${source
+    .slice(start, end)
+    .replace(/[^\n]/g, " ")}${source.slice(end)}`;
+}
+
+function matchingDelimiter(source, openIndex, open = "(", close = ")") {
+  let depth = 0;
+  let blockCommentDepth = 0;
+  for (let index = openIndex; index < source.length; index += 1) {
+    const current = source[index];
+    const next = source[index + 1];
+    if (blockCommentDepth > 0) {
+      if (current === "/" && next === "*") {
+        blockCommentDepth += 1;
+        index += 1;
+      } else if (current === "*" && next === "/") {
+        blockCommentDepth -= 1;
+        index += 1;
+      }
+      continue;
+    }
+    if (current === "/" && next === "*") {
+      blockCommentDepth = 1;
+      index += 1;
+      continue;
+    }
+    if (current === "/" && next === "/") {
+      const newline = source.indexOf("\n", index + 2);
+      if (newline === -1) return -1;
+      index = newline;
+      continue;
+    }
+    if (current === '"') {
+      for (index += 1; index < source.length; index += 1) {
+        if (source[index] === "\\") index += 1;
+        else if (source[index] === '"') break;
+      }
+      continue;
+    }
+    if (current === "r" && (next === '"' || next === "#")) {
+      const raw = /^r(#+)?"/.exec(source.slice(index));
+      if (raw) {
+        const terminator = `"${raw[1] ?? ""}`;
+        const rawClose = source.indexOf(terminator, index + raw[0].length);
+        if (rawClose === -1) return -1;
+        index = rawClose + terminator.length - 1;
+        continue;
+      }
+    }
+    if (current === open) depth += 1;
+    if (current === close) {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function productionSource(source) {
+  let result = source;
+  const marker = /#\[cfg\s*\(\s*test\s*\)\s*\]\s*(?:pub\s+)?mod\s+[A-Za-z0-9_]+\s*\{/g;
+  for (const match of [...source.matchAll(marker)].reverse()) {
+    const open = source.indexOf("{", match.index);
+    const close = matchingDelimiter(source, open, "{", "}");
+    if (close !== -1) result = maskRangePreservingLines(result, match.index, close + 1);
+  }
+  return result;
+}
+
+function splitTopLevelArguments(source) {
+  const argumentsList = [];
+  let start = 0;
+  let parens = 0;
+  let braces = 0;
+  let brackets = 0;
+  let blockCommentDepth = 0;
+  for (let index = 0; index < source.length; index += 1) {
+    const current = source[index];
+    const next = source[index + 1];
+    if (blockCommentDepth > 0) {
+      if (current === "/" && next === "*") {
+        blockCommentDepth += 1;
+        index += 1;
+      } else if (current === "*" && next === "/") {
+        blockCommentDepth -= 1;
+        index += 1;
+      }
+      continue;
+    }
+    if (current === "/" && next === "*") {
+      blockCommentDepth = 1;
+      index += 1;
+      continue;
+    }
+    if (current === "/" && next === "/") {
+      const newline = source.indexOf("\n", index + 2);
+      if (newline === -1) break;
+      index = newline;
+      continue;
+    }
+    if (current === '"') {
+      for (index += 1; index < source.length; index += 1) {
+        if (source[index] === "\\") index += 1;
+        else if (source[index] === '"') break;
+      }
+      continue;
+    }
+    if (current === "(") parens += 1;
+    else if (current === ")") parens -= 1;
+    else if (current === "{") braces += 1;
+    else if (current === "}") braces -= 1;
+    else if (current === "[") brackets += 1;
+    else if (current === "]") brackets -= 1;
+    else if (current === "," && parens === 0 && braces === 0 && brackets === 0) {
+      argumentsList.push(source.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  argumentsList.push(source.slice(start).trim());
+  return argumentsList;
+}
+
+function rustStringLiteral(value) {
+  const match = /^"((?:\\.|[^"\\])*)"$/.exec(value.trim());
+  if (!match) return null;
+  return JSON.parse(`"${match[1]}"`);
+}
+
+function methodsFromRouterExpression(expression) {
+  const methods = new Set();
+  const matcher = new RegExp(`(?:^|[\\.:])(${methodNames.join("|")})\\s*\\(`, "g");
+  for (const match of expression.matchAll(matcher)) methods.add(match[1].toUpperCase());
+  // Axum dispatches every GET handler for HEAD and strips the response body.
+  // Inventory that implicit surface rather than recording only source tokens.
+  if (methods.has("GET")) methods.add("HEAD");
+  return [...methods].sort();
+}
+
+function callsNamed(source, token) {
+  const calls = [];
+  let cursor = 0;
+  while (cursor < source.length) {
+    const index = source.indexOf(token, cursor);
+    if (index === -1) break;
+    const open = index + token.length - 1;
+    const close = matchingDelimiter(source, open);
+    if (close === -1) throw new Error(`unterminated ${token} call at line ${lineNumber(source, index)}`);
+    calls.push({ index, body: source.slice(open + 1, close) });
+    cursor = close + 1;
+  }
+  return calls;
+}
+
+export function extractRoutesFromRust(source, sourcePath = "fixture.rs") {
+  const production = productionSource(source);
+  const routes = [];
+  const unsupported = [];
+  for (const call of callsNamed(production, ".route(")) {
+    const args = splitTopLevelArguments(call.body);
+    const routePath = args.length >= 2 ? rustStringLiteral(args[0]) : null;
+    if (!routePath) {
+      if (/routes_incident_monitor\.rs$/.test(sourcePath) && args[0]?.trim() === "&path") continue;
+      unsupported.push(`${sourcePath}:${lineNumber(production, call.index)} dynamic route path ${args[0] ?? "<missing>"}`);
+      continue;
+    }
+    const methods = methodsFromRouterExpression(args.slice(1).join(","));
+    if (methods.length === 0) {
+      unsupported.push(`${sourcePath}:${lineNumber(production, call.index)} route has no statically visible method`);
+      continue;
+    }
+    for (const method of methods) {
+      routes.push({ method, path: routePath, source: `${sourcePath}:${lineNumber(production, call.index)}` });
+    }
+  }
+
+  if (/routes_incident_monitor\.rs$/.test(sourcePath)) {
+    for (const call of callsNamed(production, "route_prefixed(")) {
+      const args = splitTopLevelArguments(call.body);
+      const suffix = args.length >= 4 ? rustStringLiteral(args[2]) : null;
+      if (!suffix) continue;
+      const methods = methodsFromRouterExpression(args.slice(3).join(","));
+      if (methods.length === 0) {
+        unsupported.push(`${sourcePath}:${lineNumber(production, call.index)} prefixed route has no statically visible method`);
+        continue;
+      }
+      for (const method of methods) {
+        routes.push({ method, path: `/incident-monitor${suffix}`, source: `${sourcePath}:${lineNumber(production, call.index)}` });
+      }
+    }
+  }
+  return { routes, unsupported };
+}
+
+function routeFiles() {
+  const serverRoutes = fs
+    .readdirSync(path.join(repoRoot, "crates", "tandem-server", "src", "http"))
+    .filter((name) => /^routes_.*\.rs$/.test(name))
+    .map((name) => path.join("crates", "tandem-server", "src", "http", name));
+  const enterpriseRoutes = fs
+    .readdirSync(path.join(repoRoot, "crates", "tandem-enterprise-server", "src", "http"))
+    .filter((name) => /^routes_enterprise.*\.rs$/.test(name))
+    .map((name) => path.join("crates", "tandem-enterprise-server", "src", "http", name));
+  return [path.join("crates", "tandem-server", "src", "http", "router.rs"), ...serverRoutes, ...enterpriseRoutes]
+    .filter((relativePath) => fs.existsSync(path.join(repoRoot, relativePath)))
+    .sort();
+}
+
+function walkRustFiles(relativeDirectory) {
+  const absoluteDirectory = path.join(repoRoot, relativeDirectory);
+  const result = [];
+  for (const entry of fs.readdirSync(absoluteDirectory, { withFileTypes: true })) {
+    const relativePath = path.join(relativeDirectory, entry.name);
+    if (entry.isDirectory()) result.push(...walkRustFiles(relativePath));
+    else if (entry.isFile() && entry.name.endsWith(".rs")) result.push(relativePath);
+  }
+  return result;
+}
+
+function webUiRoutes() {
+  const sourcePath = path.join("crates", "tandem-server", "src", "webui", "mod.rs");
+  const source = fs.readFileSync(path.join(repoRoot, sourcePath), "utf8");
+  const registrations = [
+    [".route(&base, get(serve_index))", "{web_ui_prefix}"],
+    [".route(&format!(\"{}/\", base), get(serve_index))", "{web_ui_prefix}/"],
+    [".route(&wildcard, get(serve_index))", "{web_ui_prefix}/{*path}"],
+  ];
+  return registrations.flatMap(([registration, routePath]) => {
+    const index = source.indexOf(registration);
+    if (index === -1) {
+      throw new Error(`web UI route registration drifted: ${registration}`);
+    }
+    const sourceLocation = `${sourcePath}:${lineNumber(source, index)}`;
+    return ["GET", "HEAD"].map((method) => ({
+      method,
+      path: routePath,
+      source: sourceLocation,
+      listener: "engine_api",
+    }));
+  });
+}
+
+function loopbackOAuthRoutes() {
+  const sourcePath = path.join(
+    "crates",
+    "tandem-server",
+    "src",
+    "http",
+    "config_providers_parts",
+    "part02.rs",
+  );
+  const source = fs.readFileSync(path.join(repoRoot, sourcePath), "utf8");
+  if (!source.includes("TcpListener::bind(OPENAI_CODEX_LOCAL_CALLBACK_ADDR)")) {
+    throw new Error("loopback OAuth callback listener binding drifted");
+  }
+  const extracted = extractRoutesFromRust(source, sourcePath);
+  if (extracted.unsupported.length > 0) {
+    throw new Error(`loopback OAuth route cannot be inventoried:\n${extracted.unsupported.join("\n")}`);
+  }
+  return extracted.routes.map((route) => ({
+    ...route,
+    path: `{loopback_oauth_listener}${route.path}`,
+    listener: "loopback_oauth_callback",
+  }));
+}
+
+function assertProductionRouteCoverage(files) {
+  const allowed = new Set([
+    ...files,
+    path.join("crates", "tandem-server", "src", "webui", "mod.rs"),
+    path.join(
+      "crates",
+      "tandem-server",
+      "src",
+      "http",
+      "config_providers_parts",
+      "part02.rs",
+    ),
+  ]);
+  const explicitExclusions = new Set([
+    // Feature-gated, loopback-only deterministic Slack API used by the ACME demo.
+    path.join("crates", "tandem-server", "src", "acme_demo", "live.rs"),
+  ]);
+  const roots = [
+    path.join("crates", "tandem-server", "src"),
+    path.join("crates", "tandem-enterprise-server", "src"),
+  ];
+  const untracked = [];
+  for (const sourcePath of roots.flatMap(walkRustFiles)) {
+    if (sourcePath.includes(`${path.sep}tests${path.sep}`)) continue;
+    const source = fs.readFileSync(path.join(repoRoot, sourcePath), "utf8");
+    if (!productionSource(source).includes(".route(")) continue;
+    if (!allowed.has(sourcePath) && !explicitExclusions.has(sourcePath)) untracked.push(sourcePath);
+  }
+  if (untracked.length > 0) {
+    throw new Error(`production Axum registrars are outside the route inventory:\n${untracked.join("\n")}`);
+  }
+}
+
+export function classifyRoute(route) {
+  const { method, path: routePath } = route;
+  if (route.listener === "loopback_oauth_callback") {
+    return {
+      ingress_policy: "loopback_listener",
+      authorization_policy: "oauth_state",
+      capability: null,
+      resolver: "pending_provider_oauth_session",
+      policy_origin: "oauth.loopback_callback",
+    };
+  }
+  if (routePath.startsWith("{web_ui_prefix}")) {
+    return {
+      ingress_policy: "public_web_ui_get_head",
+      authorization_policy: "static_admin_shell_only",
+      capability: null,
+      resolver: "configured_reserved_web_ui_prefix",
+      policy_origin: "public.web_ui",
+    };
+  }
+  if ((method === "GET" || method === "HEAD") && routePath === "/global/health") {
+    return {
+      ingress_policy: "public_exact_health",
+      authorization_policy: "minimal_health_shape",
+      capability: null,
+      resolver: "none",
+      policy_origin: "public.health",
+    };
+  }
+  if (method === "POST" && routePath === "/channels/slack/events") {
+    return {
+      ingress_policy: "public_signed_webhook",
+      authorization_policy: "slack_signature_installation_and_tenant_binding",
+      capability: "channel.message.ingress",
+      resolver: "slack_signature_installation_sender_tenant",
+      policy_origin: "public.slack_events",
+    };
+  }
+  if (
+    method === "POST" &&
+    (/^\/webhooks\/automations\//.test(routePath) ||
+      /^\/api\/engine\/webhooks\/automations\//.test(routePath))
+  ) {
+    return {
+      ingress_policy: "public_capability_webhook",
+      authorization_policy: "path_capability_signature_nonce_and_tenant_binding",
+      capability: "automation.webhook.trigger",
+      resolver: "automation_trigger_from_public_capability",
+      policy_origin: "public.automation_webhook",
+    };
+  }
+  if (/^\/(?:mcp\/[^/]+\/auth\/callback|provider\/[^/]+\/oauth\/callback)$/.test(routePath)) {
+    return {
+      ingress_policy: "public_oauth_callback",
+      authorization_policy: "oauth_state",
+      capability: null,
+      resolver: "pending_oauth_session",
+      policy_origin: "public.oauth_callback",
+    };
+  }
+  if (method === "POST" && routePath === "/incident-monitor/intake/report") {
+    return {
+      ingress_policy: "runtime_mode_incident_intake",
+      authorization_policy: "incident_intake_key_or_verified_tenant",
+      capability: "incident.report.ingest",
+      resolver: "incident_intake_key_or_context",
+      policy_origin: "public.incident_intake",
+    };
+  }
+
+  if (
+    method === "POST" &&
+    /^\/channels\/(?:slack|discord|telegram)\/interactions$/.test(routePath)
+  ) {
+    return {
+      ingress_policy: "runtime_auth_gate",
+      authorization_policy: "channel_signature_identity_and_tenant_binding",
+      capability: "channel.interaction",
+      resolver: "signed_channel_installation_user_tenant",
+      policy_origin: "channel.signed_interaction",
+    };
+  }
+
+  if (
+    /^(?:\/find(?:\/|$)|\/file(?:\/|$)|\/vcs$|\/lsp$|\/formatter$|\/command$|\/path$|\/scheduler\/metrics$|\/session\/\{id\}\/(?:command|shell)$|\/worktree(?:\/|$))/.test(routePath)
+  ) {
+    let capability = "host.files.read";
+    if (routePath.includes("command") || routePath.endsWith("/shell")) capability = "host.command.execute";
+    else if (routePath.startsWith("/worktree")) capability = "host.worktree.manage";
+    return {
+      ingress_policy: "runtime_auth_gate",
+      authorization_policy: "direct_loopback_local_owner_and_exact_host_effect_grant",
+      capability,
+      resolver: "canonical_host_resource",
+      policy_origin: "host.local_effect",
+    };
+  }
+
+  if (
+    /^(?:\/browser\/(?:install|smoke-test)|\/global\/(?:diagnostics|workspace|storage|config|dispose)|\/admin\/reload-config|\/auth(?:\/|$)|\/channels(?:\/|$)|\/config\/(?:provider|providers|channels)|\/enterprise(?:\/|$))/.test(routePath)
+  ) {
+    return {
+      ingress_policy: "runtime_auth_gate",
+      authorization_policy: "deployment_administrator_or_loopback_local_owner",
+      capability: "deployment.admin",
+      resolver: "deployment_or_enterprise_state",
+      policy_origin: "admin.deployment",
+    };
+  }
+
+  if (/^(?:\/permission(?:\/|$)|\/question(?:\/|$)|\/approvals?(?:\/|$)|\/governance(?:\/|$))/.test(routePath)) {
+    return {
+      ingress_policy: "runtime_auth_gate",
+      authorization_policy: "tenant_scoped_qualified_independent_reviewer",
+      capability: "governance.review",
+      resolver: "tenant_request_or_governance_record",
+      policy_origin: "governance.review",
+    };
+  }
+
+  const resourcePrefixes = [
+    "/agent", "/automation", "/capabilities", "/coder", "/context", "/external-actions",
+    "/goals", "/incident-monitor", "/marketplace", "/mcp", "/memory", "/mission-builder",
+    "/missions", "/optimizations", "/orchestrations", "/pack-builder", "/packs", "/presets",
+    "/project", "/resource", "/routines", "/run", "/runs", "/session", "/sessions", "/skills",
+    "/stateful-runtime", "/task-intake", "/team", "/tool", "/workflow", "/workflows",
+  ];
+  if (routePath.includes("{") || resourcePrefixes.some((prefix) => routePath === prefix || routePath.startsWith(`${prefix}/`))) {
+    return {
+      ingress_policy: "runtime_auth_gate",
+      authorization_policy: "tenant_resource_owner_or_scoped_grant",
+      capability: "resource.owner_or_grant",
+      resolver: "tenant_resource_from_state",
+      policy_origin: "tenant.resource",
+    };
+  }
+
+  return {
+    ingress_policy: "runtime_auth_gate",
+    authorization_policy: "verified_tenant_context",
+    capability: null,
+    resolver: "verified_tenant_context",
+    policy_origin: "tenant.authenticated",
+  };
+}
+
+export function buildInventory(files = routeFiles()) {
+  assertProductionRouteCoverage(files);
+  const routes = [];
+  const unsupported = [];
+  for (const relativePath of files) {
+    const source = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+    const extracted = extractRoutesFromRust(source, relativePath);
+    routes.push(
+      ...extracted.routes.map((route) => ({ ...route, listener: "engine_api" })),
+    );
+    unsupported.push(...extracted.unsupported);
+  }
+  if (unsupported.length > 0) throw new Error(`route inventory cannot classify dynamic registrations:\n${unsupported.join("\n")}`);
+
+  routes.push(...webUiRoutes(), ...loopbackOAuthRoutes());
+
+  const byKey = new Map();
+  for (const route of routes) {
+    const key = `${route.listener} ${route.method} ${route.path}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.sources.push(route.source);
+    } else {
+      const policy = classifyRoute(route);
+      byKey.set(key, {
+        listener: route.listener,
+        method: route.method,
+        path: route.path,
+        ...policy,
+        sources: [route.source],
+      });
+    }
+  }
+  const inventoryRoutes = [...byKey.values()]
+    .map((route) => ({ ...route, sources: [...new Set(route.sources)].sort() }))
+    .sort(
+      (left, right) =>
+        left.listener.localeCompare(right.listener) ||
+        left.path.localeCompare(right.path) ||
+        left.method.localeCompare(right.method),
+    );
+  return {
+    schema_version: 2,
+    generated_by: "node scripts/verify-route-policy-inventory.mjs --write",
+    scope: {
+      included: [
+        "engine API route registrars",
+        "enterprise route extensions",
+        "configured Web UI GET/HEAD surface",
+        "loopback OpenAI Codex OAuth callback listener",
+      ],
+      excluded: [
+        "cfg(test) fixture routers",
+        "feature-gated loopback ACME demo Slack mock",
+        "outbound provider URLs",
+      ],
+      middleware_surfaces: [
+        {
+          method: "OPTIONS",
+          path: "{registered_engine_api_path}",
+          policy: "CORS preflight only; auth_gate bypass does not dispatch an application handler",
+        },
+      ],
+    },
+    route_count: inventoryRoutes.length,
+    policies: inventoryRoutes,
+  };
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function verifyInventory(expectedText, inventory) {
+  const generated = stableJson(inventory);
+  if (expectedText !== generated) {
+    throw new Error("route policy inventory drifted; run node scripts/verify-route-policy-inventory.mjs --write and review every policy change");
+  }
+}
+
+function runSelfTest() {
+  const fixture = `
+    fn apply(router: Router<AppState>) -> Router<AppState> {
+      router.route("/items/{id}", get(read).patch(update))
+    }
+    #[cfg(test)] mod tests {
+      fn fixture() { Router::new().route("/test-only", post(handler)); }
+    }
+  `;
+  const extracted = extractRoutesFromRust(fixture, "routes_fixture.rs");
+  const keys = extracted.routes.map((route) => `${route.method} ${route.path}`).sort();
+  if (
+    JSON.stringify(keys) !==
+    JSON.stringify(["GET /items/{id}", "HEAD /items/{id}", "PATCH /items/{id}"])
+  ) {
+    throw new Error(`route extractor self-test failed: ${JSON.stringify(keys)}`);
+  }
+  let rejected = false;
+  try {
+    verifyInventory("{}\n", { schema_version: 1 });
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) throw new Error("inventory drift self-test failed to reject stale output");
+  process.stdout.write("route policy inventory self-test passed\n");
+}
+
+function main() {
+  if (process.argv.includes("--self-test")) {
+    runSelfTest();
+    return;
+  }
+  const inventory = buildInventory();
+  if (process.argv.includes("--write")) {
+    fs.writeFileSync(inventoryPath, stableJson(inventory));
+    process.stdout.write(`wrote ${inventory.route_count} route policies to ${path.relative(repoRoot, inventoryPath)}\n`);
+    return;
+  }
+  const expected = fs.readFileSync(inventoryPath, "utf8");
+  verifyInventory(expected, inventory);
+  const ingressCounts = inventory.policies.reduce((counts, policy) => {
+    counts[policy.ingress_policy] = (counts[policy.ingress_policy] ?? 0) + 1;
+    return counts;
+  }, {});
+  process.stdout.write(`${JSON.stringify({ route_count: inventory.route_count, ingress_counts: ingressCounts })}\n`);
+  process.stdout.write("route policy inventory verified\n");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-route-policy-inventory.mjs
+++ b/scripts/verify-route-policy-inventory.mjs
@@ -191,9 +191,16 @@ export function extractRoutesFromRust(source, sourcePath = "fixture.rs") {
 
   if (/routes_incident_monitor\.rs$/.test(sourcePath)) {
     for (const call of callsNamed(production, "route_prefixed(")) {
+      const beforeCall = production.slice(Math.max(0, call.index - 16), call.index);
+      if (/\bfn\s*$/.test(beforeCall)) continue;
       const args = splitTopLevelArguments(call.body);
       const suffix = args.length >= 4 ? rustStringLiteral(args[2]) : null;
-      if (!suffix) continue;
+      if (!suffix) {
+        unsupported.push(
+          `${sourcePath}:${lineNumber(production, call.index)} dynamic incident-monitor suffix ${args[2] ?? "<missing>"}`,
+        );
+        continue;
+      }
       const methods = methodsFromRouterExpression(args.slice(3).join(","));
       if (methods.length === 0) {
         unsupported.push(`${sourcePath}:${lineNumber(production, call.index)} prefixed route has no statically visible method`);
@@ -268,6 +275,17 @@ function loopbackOAuthRoutes() {
   if (!source.includes("TcpListener::bind(OPENAI_CODEX_LOCAL_CALLBACK_ADDR)")) {
     throw new Error("loopback OAuth callback listener binding drifted");
   }
+  const constantSourcePath = path.join(
+    "crates",
+    "tandem-server",
+    "src",
+    "http",
+    "config_providers_parts",
+    "part01.rs",
+  );
+  assertLoopbackCallbackAddress(
+    fs.readFileSync(path.join(repoRoot, constantSourcePath), "utf8"),
+  );
   const extracted = extractRoutesFromRust(source, sourcePath);
   if (extracted.unsupported.length > 0) {
     throw new Error(`loopback OAuth route cannot be inventoried:\n${extracted.unsupported.join("\n")}`);
@@ -277,6 +295,20 @@ function loopbackOAuthRoutes() {
     path: `{loopback_oauth_listener}${route.path}`,
     listener: "loopback_oauth_callback",
   }));
+}
+
+export function assertLoopbackCallbackAddress(source) {
+  const match =
+    /const\s+OPENAI_CODEX_LOCAL_CALLBACK_ADDR\s*:\s*&str\s*=\s*"([^"]+)"\s*;/.exec(
+      source,
+    );
+  if (!match || !/^127(?:\.\d{1,3}){3}:\d+$/.test(match[1])) {
+    throw new Error("OpenAI Codex OAuth callback address is not statically loopback-only");
+  }
+  const [host] = match[1].split(":");
+  if (Number(host.split(".")[0]) !== 127) {
+    throw new Error("OpenAI Codex OAuth callback address is not statically loopback-only");
+  }
 }
 
 function assertProductionRouteCoverage(files) {
@@ -339,6 +371,27 @@ export function classifyRoute(route) {
       capability: null,
       resolver: "none",
       policy_origin: "public.health",
+    };
+  }
+  if (
+    (method === "GET" || method === "HEAD") &&
+    /^\/audit\/(?:protected|stream|ledger\/(?:manifest|export))$/.test(routePath)
+  ) {
+    return {
+      ingress_policy: "runtime_auth_gate",
+      authorization_policy: "api_token_or_control_panel_admin_source_and_tenant_scope",
+      capability: null,
+      resolver: "request_principal_source_and_tenant_audit_ledger",
+      policy_origin: "audit.admin",
+    };
+  }
+  if (method === "PATCH" && /^\/config(?:\/identity)?$/.test(routePath)) {
+    return {
+      ingress_policy: "runtime_auth_gate",
+      authorization_policy: "deployment_administrator_or_loopback_local_owner",
+      capability: "deployment.config.manage",
+      resolver: "tenant_project_config",
+      policy_origin: "admin.deployment",
     };
   }
   if (method === "POST" && routePath === "/channels/slack/events") {

--- a/scripts/verify-route-policy-inventory.test.mjs
+++ b/scripts/verify-route-policy-inventory.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  classifyRoute,
+  extractRoutesFromRust,
+  verifyInventory,
+} from "./verify-route-policy-inventory.mjs";
+
+test("extracts every method from a chained Axum route", () => {
+  const source = `
+    fn apply(router: Router<AppState>) -> Router<AppState> {
+      router.route("/resource/{id}", get(read).put(replace).delete(remove))
+    }
+  `;
+  const result = extractRoutesFromRust(source, "routes_resources.rs");
+  assert.deepEqual(
+    result.routes.map((route) => `${route.method} ${route.path}`).sort(),
+    ["DELETE /resource/{id}", "GET /resource/{id}", "HEAD /resource/{id}", "PUT /resource/{id}"],
+  );
+  assert.deepEqual(result.unsupported, []);
+});
+
+test("classifies every automation webhook spelling as public capability ingress", () => {
+  for (const routePath of [
+    "/webhooks/automations/{public_path_token}",
+    "/api/engine/webhooks/automations/{public_path_token}/{setup_nonce}",
+  ]) {
+    const policy = classifyRoute({
+      listener: "engine_api",
+      method: "POST",
+      path: routePath,
+    });
+    assert.equal(policy.ingress_policy, "public_capability_webhook");
+    assert.equal(policy.capability, "automation.webhook.trigger");
+  }
+});
+
+test("keeps signed channel interactions behind runtime auth plus signature policy", () => {
+  const policy = classifyRoute({
+    listener: "engine_api",
+    method: "POST",
+    path: "/channels/discord/interactions",
+  });
+  assert.equal(policy.ingress_policy, "runtime_auth_gate");
+  assert.equal(
+    policy.authorization_policy,
+    "channel_signature_identity_and_tenant_binding",
+  );
+});
+
+test("ignores test-only routers", () => {
+  const source = `
+    fn apply(router: Router<AppState>) -> Router<AppState> {
+      router.route("/production", post(handler))
+    }
+    #[cfg(test)]
+    mod tests {
+      fn fixture() { Router::new().route("/fixture", get(handler)); }
+    }
+  `;
+  const result = extractRoutesFromRust(source, "routes_fixture.rs");
+  assert.deepEqual(
+    result.routes.map((route) => `${route.method} ${route.path}`).sort(),
+    ["POST /production"],
+  );
+});
+
+test("reports dynamic paths instead of silently omitting them", () => {
+  const source = `fn apply(router: Router<AppState>, path: &str) { router.route(path, get(handler)); }`;
+  const result = extractRoutesFromRust(source, "routes_dynamic.rs");
+  assert.equal(result.routes.length, 0);
+  assert.equal(result.unsupported.length, 1);
+  assert.match(result.unsupported[0], /dynamic route path/);
+});
+
+test("rejects a stale committed inventory", () => {
+  assert.throws(
+    () => verifyInventory("{}\n", { schema_version: 1, policies: [] }),
+    /inventory drifted/,
+  );
+});

--- a/scripts/verify-route-policy-inventory.test.mjs
+++ b/scripts/verify-route-policy-inventory.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  assertLoopbackCallbackAddress,
   classifyRoute,
   extractRoutesFromRust,
   verifyInventory,
@@ -72,6 +73,57 @@ test("reports dynamic paths instead of silently omitting them", () => {
   assert.equal(result.routes.length, 0);
   assert.equal(result.unsupported.length, 1);
   assert.match(result.unsupported[0], /dynamic route path/);
+});
+
+test("reports computed incident-monitor suffixes instead of silently omitting them", () => {
+  const source = `
+    fn apply(router: Router<AppState>, suffix: &str) -> Router<AppState> {
+      route_prefixed(router, "/api/engine", suffix, get(handler))
+    }
+  `;
+  const result = extractRoutesFromRust(source, "routes_incident_monitor.rs");
+  assert.equal(result.routes.length, 0);
+  assert.equal(result.unsupported.length, 1);
+  assert.match(result.unsupported[0], /dynamic incident-monitor suffix/);
+});
+
+test("rejects a wildcard OAuth callback bind even when the constant name is unchanged", () => {
+  assert.throws(
+    () =>
+      assertLoopbackCallbackAddress(
+        'const OPENAI_CODEX_LOCAL_CALLBACK_ADDR: &str = "0.0.0.0:1455";',
+      ),
+    /not statically loopback-only/,
+  );
+  assert.doesNotThrow(() =>
+    assertLoopbackCallbackAddress(
+      'const OPENAI_CODEX_LOCAL_CALLBACK_ADDR: &str = "127.0.0.1:1455";',
+    ),
+  );
+});
+
+test("classifies effective config mutation and protected audit policies", () => {
+  const config = classifyRoute({
+    listener: "engine_api",
+    method: "PATCH",
+    path: "/config",
+  });
+  assert.equal(config.policy_origin, "admin.deployment");
+  assert.equal(config.capability, "deployment.config.manage");
+
+  for (const path of [
+    "/audit/protected",
+    "/audit/stream",
+    "/audit/ledger/manifest",
+    "/audit/ledger/export",
+  ]) {
+    const audit = classifyRoute({ listener: "engine_api", method: "GET", path });
+    assert.equal(audit.policy_origin, "audit.admin");
+    assert.equal(
+      audit.authorization_policy,
+      "api_token_or_control_panel_admin_source_and_tenant_scope",
+    );
+  }
 });
 
 test("rejects a stale committed inventory", () => {

--- a/scripts/verify-route-policy-inventory.test.mjs
+++ b/scripts/verify-route-policy-inventory.test.mjs
@@ -87,6 +87,28 @@ test("reports computed incident-monitor suffixes instead of silently omitting th
   assert.match(result.unsupported[0], /dynamic incident-monitor suffix/);
 });
 
+test("only exempts the canonical incident-monitor dynamic helper registration", () => {
+  const source = `
+    fn route_prefixed(
+      router: Router<AppState>,
+      prefix: &str,
+      suffix: &str,
+      method_router: MethodRouter<AppState>,
+    ) -> Router<AppState> {
+      let path = format!("{prefix}{suffix}");
+      router.route(&path, method_router)
+    }
+
+    fn unrelated(router: Router<AppState>, path: &str) -> Router<AppState> {
+      router.route(&path, get(handler))
+    }
+  `;
+  const result = extractRoutesFromRust(source, "routes_incident_monitor.rs");
+  assert.equal(result.routes.length, 0);
+  assert.equal(result.unsupported.length, 1);
+  assert.match(result.unsupported[0], /dynamic route path &path/);
+});
+
 test("rejects a wildcard OAuth callback bind even when the constant name is unchanged", () => {
   assert.throws(
     () =>
@@ -102,6 +124,18 @@ test("rejects a wildcard OAuth callback bind even when the constant name is unch
   );
 });
 
+test("rejects invalid loopback socket octets and ports", () => {
+  for (const address of ["127.999.0.1:1455", "127.0.0.1:99999", "127.0.0.1:0"]) {
+    assert.throws(
+      () =>
+        assertLoopbackCallbackAddress(
+          `const OPENAI_CODEX_LOCAL_CALLBACK_ADDR: &str = "${address}";`,
+        ),
+      /not statically loopback-only/,
+    );
+  }
+});
+
 test("classifies effective config mutation and protected audit policies", () => {
   const config = classifyRoute({
     listener: "engine_api",
@@ -114,6 +148,7 @@ test("classifies effective config mutation and protected audit policies", () => 
   for (const path of [
     "/audit/protected",
     "/audit/stream",
+    "/audit/data-boundary/monitoring",
     "/audit/ledger/manifest",
     "/audit/ledger/export",
   ]) {
@@ -124,6 +159,30 @@ test("classifies effective config mutation and protected audit policies", () => 
       "api_token_or_control_panel_admin_source_and_tenant_scope",
     );
   }
+});
+
+test("does not overstate administrative authorization on authenticated reads", () => {
+  for (const path of [
+    "/config/providers",
+    "/enterprise/status",
+    "/global/config",
+    "/global/storage/files",
+    "/global/workspace",
+  ]) {
+    for (const method of ["GET", "HEAD"]) {
+      const policy = classifyRoute({ listener: "engine_api", method, path });
+      assert.equal(policy.policy_origin, "tenant.authenticated");
+      assert.equal(policy.authorization_policy, "verified_tenant_context");
+      assert.equal(policy.capability, null);
+    }
+  }
+
+  const mutation = classifyRoute({
+    listener: "engine_api",
+    method: "PATCH",
+    path: "/global/config",
+  });
+  assert.equal(mutation.policy_origin, "admin.deployment");
 });
 
 test("rejects a stale committed inventory", () => {

--- a/scripts/verify-security-retest-matrix.mjs
+++ b/scripts/verify-security-retest-matrix.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const matrixPath = path.join(repoRoot, "docs", "SECURITY_BOUNDARY_RETEST_MATRIX.json");
+const requiredIds = Array.from({ length: 17 }, (_, index) => `TA-${String(index + 1).padStart(2, "0")}`);
+const requiredFixtureValues = [
+  "org-a/workspace-a",
+  "org-b/workspace-b",
+  "ordinary_member",
+  "deployment_admin",
+  "independent_reviewer",
+  "temporary_workspace",
+  "temporary_git_repository",
+  "temporary_pack_root",
+  "marker_provider_credential",
+  "marker_channel_credential",
+  "marker_audit_value",
+  "fake_private_dns_answer",
+  "fake_cloud_metadata_address",
+  "fake_redirect_service",
+  "chunked_over_budget_service",
+  "protected_audit_unwritable",
+  "state_persistence_failure",
+  "two_replay_store_instances",
+];
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function loadMatrix() {
+  return JSON.parse(fs.readFileSync(matrixPath, "utf8"));
+}
+
+function allControls(matrix) {
+  return matrix.findings.flatMap((finding) => [
+    ...finding.negative_controls.map((control) => ({ ...control, finding: finding.id, polarity: "negative" })),
+    ...finding.positive_controls.map((control) => ({ ...control, finding: finding.id, polarity: "positive" })),
+  ]);
+}
+
+export function matrixSymbols(matrix) {
+  return [...new Set(allControls(matrix).map((control) => control.symbol))].sort();
+}
+
+export function validateMatrix(
+  matrix,
+  readSource = (sourcePath) => fs.readFileSync(path.join(repoRoot, sourcePath), "utf8"),
+) {
+  const errors = [];
+  if (matrix.schema_version !== 1) errors.push("schema_version must be 1");
+  if (!Array.isArray(matrix.findings)) errors.push("findings must be an array");
+  if (errors.length > 0) throw new Error(`security retest matrix invalid:\n${errors.join("\n")}`);
+
+  const ids = matrix.findings.map((finding) => finding.id);
+  if (JSON.stringify(ids) !== JSON.stringify(requiredIds)) {
+    errors.push(`finding ids must be exactly ${requiredIds.join(", ")} in order`);
+  }
+  const fixtureText = JSON.stringify(matrix.fixture_catalog ?? {});
+  for (const required of requiredFixtureValues) {
+    if (!fixtureText.includes(`"${required}"`)) errors.push(`fixture catalog missing ${required}`);
+  }
+
+  for (const finding of matrix.findings) {
+    if (typeof finding.title !== "string" || finding.title.trim().length < 12) {
+      errors.push(`${finding.id} must include its authoritative title`);
+    }
+    if (!Array.isArray(finding.fixture_tags) || finding.fixture_tags.length === 0) {
+      errors.push(`${finding.id} must name its dynamic fixtures`);
+    }
+    for (const polarity of ["negative_controls", "positive_controls"]) {
+      if (!Array.isArray(finding[polarity]) || finding[polarity].length === 0) {
+        errors.push(`${finding.id} must include at least one ${polarity}`);
+        continue;
+      }
+      for (const control of finding[polarity]) {
+        if (!/^[a-z0-9-]+$/.test(control.package ?? "")) {
+          errors.push(`${finding.id} has invalid package ${control.package ?? "<missing>"}`);
+        }
+        if (
+          typeof control.source !== "string" ||
+          path.isAbsolute(control.source) ||
+          control.source.split(/[\\/]/).includes("..")
+        ) {
+          errors.push(`${finding.id} has unsafe source path ${control.source ?? "<missing>"}`);
+          continue;
+        }
+        if (!/^[A-Za-z0-9_]+$/.test(control.symbol ?? "")) {
+          errors.push(`${finding.id} has invalid test symbol ${control.symbol ?? "<missing>"}`);
+          continue;
+        }
+        let source;
+        try {
+          source = readSource(control.source);
+        } catch {
+          errors.push(`${finding.id} source does not exist: ${control.source}`);
+          continue;
+        }
+        const declaration = new RegExp(
+          `(?:async\\s+)?fn\\s+${escapeRegExp(control.symbol)}\\s*\\(`,
+        );
+        if (!declaration.test(source)) {
+          errors.push(`${finding.id} test symbol not found in ${control.source}: ${control.symbol}`);
+        }
+      }
+    }
+  }
+  if (errors.length > 0) throw new Error(`security retest matrix invalid:\n${errors.join("\n")}`);
+  return { finding_count: matrix.findings.length, test_count: matrixSymbols(matrix).length };
+}
+
+export function verifyNextestEvidence(matrix, discoveredText, junitText) {
+  const errors = [];
+  const executedTestcases = [...junitText.matchAll(/<testcase\b[^>]*(?:\/>|>[\s\S]*?<\/testcase>)/g)]
+    .map((match) => match[0])
+    .filter((testcase) => !/<skipped\b/.test(testcase))
+    .join("\n");
+  for (const symbol of matrixSymbols(matrix)) {
+    const exactIdentifier = new RegExp(
+      `(?:^|[^A-Za-z0-9_])${escapeRegExp(symbol)}(?:$|[^A-Za-z0-9_])`,
+      "m",
+    );
+    if (!exactIdentifier.test(discoveredText)) errors.push(`not discovered: ${symbol}`);
+    if (!exactIdentifier.test(executedTestcases)) errors.push(`not executed: ${symbol}`);
+  }
+  if (errors.length > 0) {
+    throw new Error(`security retest execution evidence incomplete:\n${errors.join("\n")}`);
+  }
+}
+
+function optionValue(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? null : process.argv[index + 1] ?? null;
+}
+
+function runSelfTest() {
+  const matrix = loadMatrix();
+  validateMatrix(matrix);
+  const invalid = structuredClone(matrix);
+  invalid.findings[0].positive_controls = [];
+  let rejected = false;
+  try {
+    validateMatrix(invalid);
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) throw new Error("matrix self-test failed to reject missing positive controls");
+  process.stdout.write("security retest matrix self-test passed\n");
+}
+
+function main() {
+  if (process.argv.includes("--self-test")) {
+    runSelfTest();
+    return;
+  }
+  const matrix = loadMatrix();
+  const summary = validateMatrix(matrix);
+  if (process.argv.includes("--print-nextest-filter")) {
+    process.stdout.write(`${matrixSymbols(matrix).map((symbol) => `test(${symbol})`).join(" | ")}\n`);
+    return;
+  }
+  const discoveredPath = optionValue("--nextest-list");
+  const junitPath = optionValue("--junit");
+  if ((discoveredPath && !junitPath) || (!discoveredPath && junitPath)) {
+    throw new Error("--nextest-list and --junit must be provided together");
+  }
+  if (discoveredPath && junitPath) {
+    verifyNextestEvidence(
+      matrix,
+      fs.readFileSync(discoveredPath, "utf8"),
+      fs.readFileSync(junitPath, "utf8"),
+    );
+    process.stdout.write(`verified execution evidence for ${summary.test_count} security tests\n`);
+    return;
+  }
+  process.stdout.write(
+    `security retest matrix verified: ${summary.finding_count} findings, ${summary.test_count} unique tests\n`,
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-security-retest-matrix.mjs
+++ b/scripts/verify-security-retest-matrix.mjs
@@ -44,8 +44,17 @@ function allControls(matrix) {
   ]);
 }
 
-export function matrixSymbols(matrix) {
-  return [...new Set(allControls(matrix).map((control) => control.symbol))].sort();
+export function matrixTests(matrix) {
+  const byIdentity = new Map();
+  for (const control of allControls(matrix)) {
+    const key = `${control.binary_id}\0${control.test_name}`;
+    if (!byIdentity.has(key)) byIdentity.set(key, control);
+  }
+  return [...byIdentity.values()].sort(
+    (left, right) =>
+      left.binary_id.localeCompare(right.binary_id) ||
+      left.test_name.localeCompare(right.test_name),
+  );
 }
 
 export function validateMatrix(
@@ -94,6 +103,23 @@ export function validateMatrix(
           errors.push(`${finding.id} has invalid test symbol ${control.symbol ?? "<missing>"}`);
           continue;
         }
+        if (
+          typeof control.binary_id !== "string" ||
+          !/^[A-Za-z0-9_-]+(?:::[A-Za-z0-9_/-]+)?$/.test(control.binary_id) ||
+          !(
+            control.binary_id === control.package ||
+            control.binary_id.startsWith(`${control.package}::`)
+          )
+        ) {
+          errors.push(`${finding.id} has invalid binary_id ${control.binary_id ?? "<missing>"}`);
+        }
+        if (
+          typeof control.test_name !== "string" ||
+          !/^[A-Za-z0-9_]+(?:::[A-Za-z0-9_]+)*$/.test(control.test_name) ||
+          !control.test_name.endsWith(`::${control.symbol}`)
+        ) {
+          errors.push(`${finding.id} has invalid full test_name ${control.test_name ?? "<missing>"}`);
+        }
         let source;
         try {
           source = readSource(control.source);
@@ -111,22 +137,56 @@ export function validateMatrix(
     }
   }
   if (errors.length > 0) throw new Error(`security retest matrix invalid:\n${errors.join("\n")}`);
-  return { finding_count: matrix.findings.length, test_count: matrixSymbols(matrix).length };
+  return { finding_count: matrix.findings.length, test_count: matrixTests(matrix).length };
+}
+
+function xmlAttribute(tag, name) {
+  const match = new RegExp(`\\b${name}="([^"]*)"`).exec(tag);
+  if (!match) return null;
+  return match[1]
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
 }
 
 export function verifyNextestEvidence(matrix, discoveredText, junitText) {
   const errors = [];
-  const executedTestcases = [...junitText.matchAll(/<testcase\b[^>]*(?:\/>|>[\s\S]*?<\/testcase>)/g)]
-    .map((match) => match[0])
-    .filter((testcase) => !/<skipped\b/.test(testcase))
-    .join("\n");
-  for (const symbol of matrixSymbols(matrix)) {
-    const exactIdentifier = new RegExp(
-      `(?:^|[^A-Za-z0-9_])${escapeRegExp(symbol)}(?:$|[^A-Za-z0-9_])`,
-      "m",
-    );
-    if (!exactIdentifier.test(discoveredText)) errors.push(`not discovered: ${symbol}`);
-    if (!exactIdentifier.test(executedTestcases)) errors.push(`not executed: ${symbol}`);
+  let discovery;
+  try {
+    discovery = JSON.parse(discoveredText);
+  } catch {
+    throw new Error("security retest discovery evidence is not valid nextest JSON");
+  }
+  const suites = discovery["rust-suites"];
+  if (!suites || typeof suites !== "object") {
+    throw new Error("security retest discovery evidence has no rust-suites map");
+  }
+
+  const executed = new Set();
+  for (const match of junitText.matchAll(/<testcase\b[^>]*(?:\/>|>[\s\S]*?<\/testcase>)/g)) {
+    const testcase = match[0];
+    if (/<skipped\b/.test(testcase)) continue;
+    const tag = testcase.slice(0, testcase.indexOf(">") + 1);
+    const binaryId = xmlAttribute(tag, "classname");
+    const testName = xmlAttribute(tag, "name");
+    if (binaryId && testName) executed.add(`${binaryId}\0${testName}`);
+  }
+
+  for (const test of matrixTests(matrix)) {
+    const label = `${test.package} ${test.binary_id} ${test.test_name}`;
+    const suite = suites[test.binary_id];
+    if (
+      !suite ||
+      suite["package-name"] !== test.package ||
+      !Object.hasOwn(suite.testcases ?? {}, test.test_name)
+    ) {
+      errors.push(`not discovered: ${label}`);
+    }
+    if (!executed.has(`${test.binary_id}\0${test.test_name}`)) {
+      errors.push(`not executed: ${label}`);
+    }
   }
   if (errors.length > 0) {
     throw new Error(`security retest execution evidence incomplete:\n${errors.join("\n")}`);
@@ -161,7 +221,14 @@ function main() {
   const matrix = loadMatrix();
   const summary = validateMatrix(matrix);
   if (process.argv.includes("--print-nextest-filter")) {
-    process.stdout.write(`${matrixSymbols(matrix).map((symbol) => `test(${symbol})`).join(" | ")}\n`);
+    process.stdout.write(
+      `${matrixTests(matrix)
+        .map(
+          (test) =>
+            `(package(${test.package}) & binary_id(${test.binary_id}) & test(=${test.test_name}))`,
+        )
+        .join(" | ")}\n`,
+    );
     return;
   }
   const discoveredPath = optionValue("--nextest-list");

--- a/scripts/verify-security-retest-matrix.test.mjs
+++ b/scripts/verify-security-retest-matrix.test.mjs
@@ -3,12 +3,33 @@ import assert from "node:assert/strict";
 
 import {
   loadMatrix,
-  matrixSymbols,
+  matrixTests,
   validateMatrix,
   verifyNextestEvidence,
 } from "./verify-security-retest-matrix.mjs";
 
-test("the committed matrix covers TA-01 through TA-17 with real test symbols", () => {
+function discoveryFor(tests) {
+  const suites = {};
+  for (const control of tests) {
+    const suite = (suites[control.binary_id] ??= {
+      "package-name": control.package,
+      testcases: {},
+    });
+    suite.testcases[control.test_name] = { ignored: false };
+  }
+  return { "rust-suites": suites };
+}
+
+function junitFor(tests) {
+  return `<testsuites>${tests
+    .map(
+      (control) =>
+        `<testcase classname="${control.binary_id}" name="${control.test_name}"/>`,
+    )
+    .join("")}</testsuites>`;
+}
+
+test("the committed matrix covers TA-01 through TA-17 with exact test identities", () => {
   const matrix = loadMatrix();
   const summary = validateMatrix(matrix);
   assert.equal(summary.finding_count, 17);
@@ -27,36 +48,57 @@ test("stale test symbols fail closed", () => {
   assert.throws(() => validateMatrix(matrix), /test symbol not found/);
 });
 
+test("a lookalike binary prefix is not package-qualified evidence", () => {
+  const matrix = structuredClone(loadMatrix());
+  matrix.findings[0].negative_controls[0].binary_id = "tandem-server-lookalike";
+  assert.throws(() => validateMatrix(matrix), /invalid binary_id/);
+});
+
 test("nextest evidence requires discovery and execution", () => {
   const matrix = loadMatrix();
-  const symbols = matrixSymbols(matrix);
-  const discovered = symbols.join("\n");
-  const executed = `<testsuite>${symbols
-    .map((symbol) => `<testcase classname="security" name="${symbol}"/>`)
-    .join("")}</testsuite>`;
-  assert.doesNotThrow(() => verifyNextestEvidence(matrix, discovered, executed));
+  const tests = matrixTests(matrix);
+  const discovery = discoveryFor(tests);
+  const junit = junitFor(tests);
+  assert.doesNotThrow(() =>
+    verifyNextestEvidence(matrix, JSON.stringify(discovery), junit),
+  );
+
+  const first = tests[0];
+  const missingExecution = junit.replace(
+    `<testcase classname="${first.binary_id}" name="${first.test_name}"/>`,
+    "",
+  );
   assert.throws(
-    () => verifyNextestEvidence(matrix, discovered, executed.replace(symbols[0], "")),
+    () => verifyNextestEvidence(matrix, JSON.stringify(discovery), missingExecution),
     /not executed/,
   );
+
+  const wrongBinary = structuredClone(discovery);
+  delete wrongBinary["rust-suites"][first.binary_id].testcases[first.test_name];
+  wrongBinary["rust-suites"]["lookalike-package"] = {
+    "package-name": first.package,
+    testcases: { [first.test_name]: { ignored: false } },
+  };
   assert.throws(
     () =>
       verifyNextestEvidence(
         matrix,
-        discovered.replace(symbols[0], `${symbols[0]}_lookalike`),
-        executed,
+        JSON.stringify(wrongBinary),
+        junit,
       ),
     /not discovered/,
   );
+
+  const skipped = junit.replace(
+    `<testcase classname="${first.binary_id}" name="${first.test_name}"/>`,
+    `<testcase classname="${first.binary_id}" name="${first.test_name}"><skipped/></testcase>`,
+  );
   assert.throws(
     () =>
       verifyNextestEvidence(
         matrix,
-        discovered,
-        executed.replace(
-          `<testcase classname="security" name="${symbols[0]}"/>`,
-          `<testcase classname="security" name="${symbols[0]}"><skipped/></testcase>`,
-        ),
+        JSON.stringify(discovery),
+        skipped,
       ),
     /not executed/,
   );

--- a/scripts/verify-security-retest-matrix.test.mjs
+++ b/scripts/verify-security-retest-matrix.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  loadMatrix,
+  matrixSymbols,
+  validateMatrix,
+  verifyNextestEvidence,
+} from "./verify-security-retest-matrix.mjs";
+
+test("the committed matrix covers TA-01 through TA-17 with real test symbols", () => {
+  const matrix = loadMatrix();
+  const summary = validateMatrix(matrix);
+  assert.equal(summary.finding_count, 17);
+  assert.ok(summary.test_count >= 34);
+});
+
+test("missing positive controls fail closed", () => {
+  const matrix = structuredClone(loadMatrix());
+  matrix.findings[0].positive_controls = [];
+  assert.throws(() => validateMatrix(matrix), /positive_controls/);
+});
+
+test("stale test symbols fail closed", () => {
+  const matrix = structuredClone(loadMatrix());
+  matrix.findings[0].negative_controls[0].symbol = "removed_security_test";
+  assert.throws(() => validateMatrix(matrix), /test symbol not found/);
+});
+
+test("nextest evidence requires discovery and execution", () => {
+  const matrix = loadMatrix();
+  const symbols = matrixSymbols(matrix);
+  const discovered = symbols.join("\n");
+  const executed = `<testsuite>${symbols
+    .map((symbol) => `<testcase classname="security" name="${symbol}"/>`)
+    .join("")}</testsuite>`;
+  assert.doesNotThrow(() => verifyNextestEvidence(matrix, discovered, executed));
+  assert.throws(
+    () => verifyNextestEvidence(matrix, discovered, executed.replace(symbols[0], "")),
+    /not executed/,
+  );
+  assert.throws(
+    () =>
+      verifyNextestEvidence(
+        matrix,
+        discovered.replace(symbols[0], `${symbols[0]}_lookalike`),
+        executed,
+      ),
+    /not discovered/,
+  );
+  assert.throws(
+    () =>
+      verifyNextestEvidence(
+        matrix,
+        discovered,
+        executed.replace(
+          `<testcase classname="security" name="${symbols[0]}"/>`,
+          `<testcase classname="security" name="${symbols[0]}"><skipped/></testcase>`,
+        ),
+      ),
+    /not executed/,
+  );
+});


### PR DESCRIPTION
## Summary

- add a deterministic, CI-enforced inventory of all 848 discovered production listener/method/path policies, including Axum implicit HEAD and the separate loopback OAuth listener
- add a machine-checked TA-01 through TA-17 security retest matrix covering 51 unique positive and negative tests, and require exact non-skipped nextest/JUnit execution evidence
- close the route-inventory discovery that channel enrollment, step-up grants, and Slack sender inventory touched process-global authority without exact administrative authorization
- add deterministic fake DNS/private/metadata, redirect, and streamed-body-budget fixtures; document the remaining assurance and release gates

## Channel authority boundary

- deployment administrator capability is required for hosted enrollment issue/confirm, step-up grants, and sender inventory
- hosted targets must match the verified org/workspace; caller-supplied issuer/enroller labels are replaced with the verified actor
- confirmation resolves scope from the pending server-side record, denies cross-tenant confirmation without consuming the code, protected-audits the exact grant, and revalidates immediately before mutation
- pairing codes are represented in protected audit only by a canonical SHA-256 resource identity
- direct-loopback standalone-owner behavior remains compatible

## Deployment scope

No enterprise/shared Tandem server is deployed, and this PR does not assert that a running standalone engine was remotely exposed. Credential rotation is not required solely from these source findings absent evidence of a reachable shared runtime or a real credential in one. The prospective shared/hosted release gate remains closed.

## Local validation

- `cargo check -p tandem-server --tests --features browser,premium-governance`
- exact channel authority integration regression
- Slack sender inventory deployment-admin regression
- fake DNS/private/metadata and redirect/stream-budget regressions
- 10 Node verifier tests, both verifier self-tests, exact 848-route inventory drift verification, and 17-finding/51-test matrix verification
- `cargo fmt --all -- --check`
- `bash -n scripts/run-security-boundary-retest.sh`
- `git diff --check`
- `bash scripts/ci-file-size-check.sh` (passes; one advisory at 1,956 lines, below the 2,000-line hard cap)

## Linear

Groups TAN-792, TAN-793, TAN-794, and TAN-821. These remain open until the exact reviewed head is CI-green, thread-clean, and merged.
