### PR TITLE
TAN-840: harden panel identity and session boundaries

### DIFF
--- a/docs/PRIVATE_IDENTITY_FOUNDATION.md
+++ b/docs/PRIVATE_IDENTITY_FOUNDATION.md
@@ -1,0 +1,107 @@
+# Private identity foundation (TAN-840)
+
+This checkpoint hardens the existing panel identity boundary before adding
+private multi-user enrollment. It does **not** complete owner enrollment,
+invitations, recovery or a supported private identity provider. TAN-840 remains
+In Progress. A shared engine token still represents the existing local operator
+mode, not several individually verified Company Brain users.
+
+## Reused contract
+
+The current hosted adapter exchanges a one-time login code with the trusted
+control plane and receives a server-held user session and context assertion.
+The engine's existing `tandem-enterprise-contract` Ed25519 verifier, replay
+protection and governed authorization remain authoritative. The panel validates
+the response envelope; it does not replace signature verification or implement
+an account database. A private adapter must use this same verified runtime seam.
+
+The response must identify the expected deployment and a stable user and include
+nonempty `panel_session_token` and `context_assertion`, plus valid future
+`session_expires_at` and `context_assertion_expires_at` timestamps. These fields
+come only from the trusted control plane. Browser-submitted user/role fields are
+ignored. A malformed response cannot fall back to a root-token-only session.
+
+## Implemented behavior
+
+- The panel and scaffold remove browser-supplied context assertions, all three
+  runtime assertion aliases, raw actor/tenant aliases, and agent identity/source
+  headers from engine, OAuth callback and webhook proxies. Only server-held
+  session identity is attached to an authenticated engine request.
+- Internal engine helpers cannot override that identity or transport credential
+  through extra headers. Hosted browser sessions cannot opt into local agent
+  test mode.
+- Every authenticated panel route passes through hosted refresh before using
+  the session, including `/api/auth/me`. Absolute session expiry also applies
+  during pruning; activity alone cannot preserve an expired session.
+- Concurrent requests share one refresh. Successful refresh can rotate
+  credentials and update memberships/capabilities but cannot change the user or
+  deployment. Logout during refresh cannot recreate the removed session.
+- Failed refresh removes the affected session and returns 401. Other users'
+  panel sessions remain independent. Configuring another deployment invalidates
+  a session even while its previous assertion remains unexpired.
+- Cookies use `Secure` when the configured public URL is HTTPS. HttpOnly and
+  SameSite protection remain in place; configure the actual HTTPS public URL.
+- Hosted members/viewers cannot reach deployment-wide settings, raw shared
+  file/workspace routes, knowledgebase administration or ACA/swarm/orchestrator
+  sidecar handlers. Those paths currently use global resources or administrative
+  credentials. Existing owner/admin roles or hosted administrative capabilities
+  are required until a verified per-user implementation exists. Personal
+  preferences and engine-governed routes retain their existing access paths.
+
+This last restriction is intentional: authenticating a user does not authorize
+deployment-wide configuration edits or global files. Existing local operator
+behavior remains supported. Runtime routes retain their own policy/grant checks.
+
+## Verification
+
+After installing locked panel dependencies and building its existing frontend:
+
+```sh
+cd packages/tandem-control-panel
+pnpm install --frozen-lockfile
+pnpm build
+node --test --test-concurrency=1 tests/hosted-session.test.mjs tests/hosted-session-integration.test.mjs tests/engine-proxy-header-strip.test.mjs tests/smoke.test.mjs
+```
+
+The 22 tests cover the envelope and expiry boundary, identity/header spoofing,
+refresh concurrency, changed-user rejection, removal of one affected session,
+admin-route denial, scaffold parity, public callback/webhook behavior and existing
+local auth/proxy/swarm behavior. The integration tests start the real panel with
+synthetic control-plane and engine services. They test the panel seam; they do
+not prove cryptographic verification or private memory isolation end to end.
+
+The broader `capabilities-integration.test.mjs` suite's
+“Hosted install profile enables search and scheduler settings without a local
+engine URL” test failed here with engine-unavailable/502 when contacting
+`engine.localtest.me`. The same test and unchanged main `setup.js` reproduced
+that failure at `c628546a480dbdd94356fcbb94ab1a9fd2cabed4`. Its four other cases
+passed. This environment result is not a passing remote-host deployment gate.
+
+## Remaining TAN-840 acceptance
+
+1. Select and integrate the supported private identity adapter. Account and
+   session libraries must be maintained; reuse existing hosted interfaces where
+   compatible. Do not invent public-runtime invite/SCIM APIs or a second grant
+   engine. Models and solution manifests cannot provision their own authority.
+2. Deliver fresh instance -> first owner -> tenant/workspace -> second user ->
+   individual login through a documented UI/bootstrap path. First-owner setup
+   must be one-time, with operator-authorized recovery that cannot be reused for
+   account takeover.
+3. Verify stable principals across browser sessions, restart and credential
+   rotation. Define and test membership/revocation propagation and in-flight
+   execution behavior. Current assertions refresh near expiry; this patch does
+   not claim immediate revocation of an otherwise valid assertion.
+4. Complete per-user authorization and verified context propagation for every
+   enabled product surface. The temporary admin restrictions above must not be
+   removed until those handlers have that contract.
+5. Run real two-user and same-tenant two-department tests across governed memory,
+   tools, approvals, private retrieval and permitted sharing. Missing or spoofed
+   context must fail closed. Existing memory isolation and assertion-verifier
+   suites provide reusable fixtures.
+6. Expose readiness to TAN-827/TAN-834/TAN-836 that distinguishes uninitialized
+   identity, unauthenticated access, verified user identity and completion of
+   the supported multi-user deployment checks. Process health is insufficient.
+
+TAN-824's pure solution planner receives the verified context from this trusted
+host boundary. Planning never provisions accounts; apply must reauthorize the
+current user and recheck memberships, grants and bindings before every mutation.

--- a/packages/create-tandem-panel/template/bin/setup.js
+++ b/packages/create-tandem-panel/template/bin/setup.js
@@ -12,6 +12,7 @@ import { fileURLToPath } from "url";
 import { createRequire } from "module";
 import { homedir } from "os";
 import { ensureBootstrapEnv, resolveEnvLoadOrder } from "../lib/setup/env.js";
+import { isEngineIdentityHeader } from "../lib/setup/engine-identity-headers.js";
 import { createSwarmApiHandler } from "../server/routes/swarm.js";
 
 function parseDotEnv(content) {
@@ -1508,6 +1509,7 @@ async function proxyPublicEngineOAuthCallback(req, res) {
   for (const [key, value] of Object.entries(req.headers)) {
     if (!value) continue;
     const lower = key.toLowerCase();
+    if (isEngineIdentityHeader(lower)) continue;
     if (
       ["host", "content-length", "cookie", "authorization", "x-tandem-token", "x-forwarded-prefix"].includes(
         lower
@@ -1596,6 +1598,7 @@ async function proxyPublicEngineAutomationWebhook(req, res) {
   for (const [key, value] of Object.entries(req.headers)) {
     if (!value) continue;
     const lower = key.toLowerCase();
+    if (isEngineIdentityHeader(lower)) continue;
     if (
       [
         "host",
@@ -1693,6 +1696,7 @@ async function proxyEngineRequest(req, res, session) {
   for (const [key, value] of Object.entries(req.headers)) {
     if (!value) continue;
     const lower = key.toLowerCase();
+    if (isEngineIdentityHeader(lower)) continue;
     if (
       ["host", "content-length", "cookie", "authorization", "x-tandem-token", "x-forwarded-prefix"].includes(
         lower

--- a/packages/create-tandem-panel/template/lib/setup/engine-identity-headers.js
+++ b/packages/create-tandem-panel/template/lib/setup/engine-identity-headers.js
@@ -1,0 +1,37 @@
+// Browser requests never provide runtime identity. Only the server-held session
+// may attach a context assertion after these headers have been removed.
+const IDENTITY_HEADERS = new Set([
+  "x-tandem-context-assertion",
+  "x-tandem-context-jws",
+  "x-tandem-tenant-context-jws",
+  "x-tandem-org-id",
+  "x-tenant-org-id",
+  "x-tandem-workspace-id",
+  "x-tenant-workspace-id",
+  "x-tandem-deployment-id",
+  "x-tandem-actor-id",
+  "x-user-id",
+  "x-tandem-principal-id",
+  "x-tandem-roles",
+  "x-tandem-capabilities",
+  "x-tandem-agent-id",
+  "x-tandem-agent-ancestor-ids",
+  "x-tandem-request-source",
+]);
+
+export function isEngineIdentityHeader(name) {
+  return IDENTITY_HEADERS.has(String(name).toLowerCase());
+}
+
+export function sessionEngineHeaders(session, extraHeaders = {}) {
+  const headers = new Headers(extraHeaders);
+  for (const name of [...headers.keys()]) {
+    if (isEngineIdentityHeader(name)) headers.delete(name);
+  }
+  headers.set("authorization", `Bearer ${session.token}`);
+  headers.set("x-tandem-token", session.token);
+  if (session.context_assertion) {
+    headers.set("x-tandem-context-assertion", String(session.context_assertion));
+  }
+  return headers;
+}

--- a/packages/tandem-control-panel/bin/setup.js
+++ b/packages/tandem-control-panel/bin/setup.js
@@ -19,6 +19,8 @@ import {
   summarizeControlPanelConfig,
 } from "../lib/setup/control-panel-config.js";
 import { resolveControlPanelPrincipalIdentity } from "../lib/setup/control-panel-principal.js";
+import { isEngineIdentityHeader, sessionEngineHeaders } from "../lib/setup/engine-identity-headers.js";
+import { hostedSessionFields, hostedSessionExpired, assertSameHostedIdentity, hostedPanelRouteAllowed } from "../lib/setup/hosted-session.js";
 import { resolveControlPanelPreferencesPath } from "../lib/setup/control-panel-preferences.js";
 import { classifyStatusOnlyWorkspaceChange } from "../lib/setup/workspace-change-status.js";
 import { createSwarmApiHandler, getOrchestratorMetrics } from "../server/routes/swarm.js";
@@ -350,6 +352,7 @@ const FILE_BUCKET_PHYSICAL_NAMES = {
 const MAX_PREVIEW_BYTES = Math.max(1, Math.min(MAX_UPLOAD_BYTES, 2 * 1024 * 1024));
 
 const sessions = new Map();
+const hostedSessionRefreshes = new Map();
 let engineProcess = null;
 let server = null;
 let managedEngineToken = "";
@@ -1063,7 +1066,7 @@ function isLocalEngineUrl(url) {
 function pruneExpiredSessions() {
   const now = Date.now();
   for (const [sid, rec] of sessions.entries()) {
-    if (now - rec.lastSeenAt > SESSION_TTL_MS) sessions.delete(sid);
+    if (now - rec.lastSeenAt > SESSION_TTL_MS || hostedSessionExpired(rec, now)) sessions.delete(sid);
   }
 }
 
@@ -1098,6 +1101,7 @@ function setSessionCookie(res, sid) {
     "Path=/",
     `Max-Age=${Math.floor(SESSION_TTL_MS / 1000)}`,
   ];
+  if (controlPanelPublicBaseUrl().startsWith("https://")) attrs.push("Secure");
   res.setHeader("Set-Cookie", attrs.join("; "));
 }
 
@@ -2611,58 +2615,44 @@ async function exchangeHostedPanelCode(code) {
 }
 
 async function refreshHostedPanelSession(session) {
+  if (session?.hosted !== true) return session;
+  const current = sessions.get(session.sid);
+  if (!current || hostedSessionExpired(current)) throw new Error("Hosted panel session expired.");
   const auth = getHostedPanelAuthConfig();
-  if (!session?.hosted || !auth.managed || !auth.panelRefreshUrl) return session;
-  const currentExpiry = Date.parse(String(session.context_assertion_expires_at || ""));
-  if (Number.isFinite(currentExpiry) && currentExpiry - Date.now() > 60000) return session;
-  const hostAgentToken = readHostAgentToken();
-  if (!hostAgentToken) throw new Error("Hosted agent token is not available on this server.");
-  const upstream = await fetch(auth.panelRefreshUrl, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${hostAgentToken}`,
-    },
-    body: JSON.stringify({ panel_session_token: session.panel_session_token }),
-  });
-  const text = await upstream.text();
-  let payload = {};
+  if (!auth.managed || !auth.panelRefreshUrl) throw new Error("Hosted session refresh is not configured.");
+  if (current.principal_scope !== auth.deploymentId) throw new Error("Hosted deployment changed. Sign in again.");
+  const currentExpiry = Date.parse(String(current.context_assertion_expires_at || ""));
+  if (current.context_assertion && Number.isFinite(currentExpiry) && currentExpiry - Date.now() > 60000) {
+    return { sid: session.sid, ...current };
+  }
+  // Concurrent browser requests share one refresh, including rotating session
+  // tokens. A late response must never recreate a session removed by logout.
+  let pending = hostedSessionRefreshes.get(session.sid);
+  if (!pending) {
+    pending = (async () => {
+      const hostAgentToken = readHostAgentToken();
+      if (!hostAgentToken) throw new Error("Hosted agent token is not available on this server.");
+      const upstream = await fetch(auth.panelRefreshUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${hostAgentToken}` },
+        body: JSON.stringify({ panel_session_token: current.panel_session_token }),
+        signal: AbortSignal.timeout(8000),
+      });
+      if (!upstream.ok) throw new Error("Hosted panel session is no longer valid.");
+      const next = hostedSessionFields(await upstream.json(), { deploymentId: auth.deploymentId });
+      assertSameHostedIdentity(current, next);
+      const rec = sessions.get(session.sid);
+      if (!rec || hostedSessionExpired(rec)) throw new Error("Hosted panel session expired.");
+      Object.assign(rec, next);
+      return { sid: session.sid, ...rec };
+    })();
+    hostedSessionRefreshes.set(session.sid, pending);
+  }
   try {
-    payload = text ? JSON.parse(text) : {};
-  } catch {
-    payload = {};
+    return await pending;
+  } finally {
+    if (hostedSessionRefreshes.get(session.sid) === pending) hostedSessionRefreshes.delete(session.sid);
   }
-  if (!upstream.ok) {
-    throw new Error(payload?.error || text || `Hosted panel session refresh failed (${upstream.status})`);
-  }
-  const rec = sessions.get(session.sid);
-  if (!rec) return session;
-  Object.assign(rec, hostedSessionFields(payload));
-  return { sid: session.sid, ...rec };
-}
-
-function hostedSessionFields(payload) {
-  return {
-    hosted: true,
-    panel_session_token: String(payload?.panel_session_token || ""),
-    context_assertion: String(payload?.context_assertion || ""),
-    context_assertion_expires_at: String(payload?.context_assertion_expires_at || ""),
-    session_expires_at: String(payload?.session_expires_at || ""),
-    hosted_role: String(payload?.role || ""),
-    hosted_roles: Array.isArray(payload?.roles) ? payload.roles.map((role) => String(role)) : [],
-    hosted_org_units: Array.isArray(payload?.org_units) ? payload.org_units : [],
-    hosted_capabilities: Array.isArray(payload?.capabilities)
-      ? payload.capabilities.map((capability) => String(capability))
-      : [],
-    hosted_policy_version:
-      payload?.policy_version === null || payload?.policy_version === undefined
-        ? null
-        : Number(payload.policy_version),
-    hosted_user: payload?.user || null,
-    principal_id: String(payload?.user?.id || ""),
-    principal_source: "tandem-hosted",
-    principal_scope: String(payload?.deployment_id || ""),
-  };
 }
 
 async function handleHostedAuthExchange(req, res) {
@@ -2684,7 +2674,7 @@ async function handleHostedAuthExchange(req, res) {
       token: engineToken,
       createdAt: Date.now(),
       lastSeenAt: Date.now(),
-      ...hostedSessionFields(payload),
+      ...hostedSessionFields(payload, { deploymentId: getHostedPanelAuthConfig().deploymentId }),
     });
     setSessionCookie(res, sid);
     sendJson(res, 200, {
@@ -2702,13 +2692,27 @@ async function handleHostedAuthExchange(req, res) {
   }
 }
 
-function requireSession(req, res) {
+async function requireSession(req, res) {
   const session = getSession(req);
   if (!session) {
+    clearSessionCookie(res);
     sendJson(res, 401, { ok: false, error: "Unauthorized" });
     return null;
   }
-  return session;
+  try {
+    const refreshed = await refreshHostedPanelSession(session);
+    const pathname = new URL(req.url, "http://127.0.0.1").pathname;
+    if (!hostedPanelRouteAllowed(refreshed, pathname)) {
+      sendJson(res, 403, { ok: false, error: "This deployment administration route requires an owner or administrator." });
+      return null;
+    }
+    return refreshed;
+  } catch {
+    sessions.delete(session.sid);
+    clearSessionCookie(res);
+    sendJson(res, 401, { ok: false, error: "Hosted panel session expired. Sign in again." });
+    return null;
+  }
 }
 
 function isPublicEngineOAuthCallbackPath(pathname) {
@@ -2743,6 +2747,7 @@ async function proxyPublicEngineOAuthCallback(req, res) {
   for (const [key, value] of Object.entries(req.headers)) {
     if (!value) continue;
     const lower = key.toLowerCase();
+    if (isEngineIdentityHeader(lower)) continue;
     if (["host", "content-length", "cookie", "authorization", "x-tandem-token"].includes(lower)) {
       continue;
     }
@@ -2825,6 +2830,7 @@ async function proxyPublicEngineAutomationWebhook(req, res) {
   for (const [key, value] of Object.entries(req.headers)) {
     if (!value) continue;
     const lower = key.toLowerCase();
+    if (isEngineIdentityHeader(lower)) continue;
     if (
       [
         "host",
@@ -2962,7 +2968,7 @@ async function proxyEngineRequest(req, res, session) {
   const forwardedProto = forwarded.proto;
   const requestedSource = String(req.headers["x-tandem-request-source"] || "").trim();
   const requestedAgentId = String(req.headers["x-tandem-agent-id"] || "").trim();
-  const agentTestMode = (() => {
+  const agentTestMode = session?.hosted !== true && (() => {
     const raw = String(
       req.headers["x-tandem-agent-test-mode"] || req.headers["x-tandem-control-panel-agent-mode"] || ""
     ).trim()
@@ -2977,6 +2983,7 @@ async function proxyEngineRequest(req, res, session) {
   for (const [key, value] of Object.entries(req.headers)) {
     if (!value) continue;
     const lower = key.toLowerCase();
+    if (isEngineIdentityHeader(lower)) continue;
     if (
       [
         "host",
@@ -3157,15 +3164,10 @@ async function engineRequestJson(session, path, options = {}) {
     try {
       response = await fetch(`${ENGINE_URL}${path}`, {
         method,
-        headers: {
-          authorization: `Bearer ${session.token}`,
-          "x-tandem-token": session.token,
-          ...(session.context_assertion
-            ? { "x-tandem-context-assertion": String(session.context_assertion) }
-            : {}),
+        headers: sessionEngineHeaders(session, {
           ...(body ? { "content-type": "application/json" } : {}),
           ...(options.headers || {}),
-        },
+        }),
         body: body ? JSON.stringify(body) : undefined,
         signal: AbortSignal.timeout(options.timeoutMs || 8000),
       });
@@ -6192,14 +6194,14 @@ async function handleApi(req, res) {
   }
 
   if (pathname === "/api/system/search-settings" && req.method === "GET") {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     sendJson(res, 200, readManagedSearchSettings());
     return true;
   }
 
   if (pathname === "/api/system/search-settings" && req.method === "PATCH") {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     try {
       const payload = await readJsonBody(req);
@@ -6215,7 +6217,7 @@ async function handleApi(req, res) {
   }
 
   if (pathname === "/api/system/search-settings/test" && req.method === "POST") {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     try {
       const payload = await readJsonBody(req);
@@ -6258,14 +6260,14 @@ async function handleApi(req, res) {
   }
 
   if (pathname === "/api/system/scheduler-settings" && req.method === "GET") {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     sendJson(res, 200, getManagedSchedulerSettings());
     return true;
   }
 
   if (pathname === "/api/system/scheduler-settings" && req.method === "PATCH") {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     try {
       const payload = await readJsonBody(req);
@@ -6303,7 +6305,7 @@ async function handleApi(req, res) {
 
   if (pathname === "/api/auth/me" && req.method === "GET") {
     res.setHeader("cache-control", "no-store, max-age=0");
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     const probe = await probeEngineHealth(session.token);
     if (!probe.ok) {
@@ -6358,7 +6360,7 @@ async function handleApi(req, res) {
     pathname === "/api/control-panel/preferences" &&
     (req.method === "GET" || req.method === "PATCH")
   ) {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     return handleControlPanelPreferences(req, res, session);
   }
@@ -6367,37 +6369,37 @@ async function handleApi(req, res) {
     pathname === "/api/control-panel/config" &&
     (req.method === "GET" || req.method === "PATCH")
   ) {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     return handleControlPanelConfig(req, res);
   }
 
   if (pathname.startsWith("/api/knowledgebase")) {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     return handleKnowledgebaseApi(req, res);
   }
 
   if (pathname.startsWith("/api/swarm") || pathname.startsWith("/api/orchestrator")) {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     return handleSwarmApi(req, res, session);
   }
 
   if (pathname.startsWith("/api/aca")) {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     return handleAcaApi(req, res);
   }
 
   if (pathname.startsWith("/api/files")) {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     return handleFilesApi(req, res, session);
   }
 
   if (pathname.startsWith("/api/workspace/files")) {
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     return handleWorkspaceFilesApi(req, res, session);
   }
@@ -6415,7 +6417,7 @@ async function handleApi(req, res) {
       await proxyPublicEngineOAuthCallback(req, res);
       return true;
     }
-    const session = requireSession(req, res);
+    const session = await requireSession(req, res);
     if (!session) return true;
     await proxyEngineRequest(req, res, session);
     return true;

--- a/packages/tandem-control-panel/lib/setup/engine-identity-headers.js
+++ b/packages/tandem-control-panel/lib/setup/engine-identity-headers.js
@@ -1,0 +1,37 @@
+// Browser requests never provide runtime identity. Only the server-held session
+// may attach a context assertion after these headers have been removed.
+const IDENTITY_HEADERS = new Set([
+  "x-tandem-context-assertion",
+  "x-tandem-context-jws",
+  "x-tandem-tenant-context-jws",
+  "x-tandem-org-id",
+  "x-tenant-org-id",
+  "x-tandem-workspace-id",
+  "x-tenant-workspace-id",
+  "x-tandem-deployment-id",
+  "x-tandem-actor-id",
+  "x-user-id",
+  "x-tandem-principal-id",
+  "x-tandem-roles",
+  "x-tandem-capabilities",
+  "x-tandem-agent-id",
+  "x-tandem-agent-ancestor-ids",
+  "x-tandem-request-source",
+]);
+
+export function isEngineIdentityHeader(name) {
+  return IDENTITY_HEADERS.has(String(name).toLowerCase());
+}
+
+export function sessionEngineHeaders(session, extraHeaders = {}) {
+  const headers = new Headers(extraHeaders);
+  for (const name of [...headers.keys()]) {
+    if (isEngineIdentityHeader(name)) headers.delete(name);
+  }
+  headers.set("authorization", `Bearer ${session.token}`);
+  headers.set("x-tandem-token", session.token);
+  if (session.context_assertion) {
+    headers.set("x-tandem-context-assertion", String(session.context_assertion));
+  }
+  return headers;
+}

--- a/packages/tandem-control-panel/lib/setup/hosted-session.js
+++ b/packages/tandem-control-panel/lib/setup/hosted-session.js
@@ -1,0 +1,63 @@
+// Validates the trusted control-plane response envelope. Signature/replay and
+// authorization verification still belong to the engine's existing verifier.
+// This module must not accept a browser-provided user/profile/assertion payload.
+export function hostedSessionExpired(session, now = Date.now()) {
+  if (session?.hosted !== true) return false;
+  const expiry = Date.parse(String(session.session_expires_at || ""));
+  return !Number.isFinite(expiry) || expiry <= now;
+}
+
+export function hostedSessionFields(payload, { deploymentId, now = Date.now() } = {}) {
+  const assertionExpiry = Date.parse(String(payload?.context_assertion_expires_at || ""));
+  const sessionExpiry = Date.parse(String(payload?.session_expires_at || ""));
+  const userId = String(payload?.user?.id || "").trim();
+  const payloadDeployment = String(payload?.deployment_id || "").trim();
+  const assertion = String(payload?.context_assertion || "").trim();
+  const sessionToken = String(payload?.panel_session_token || "").trim();
+  if (!deploymentId || payloadDeployment !== deploymentId || !userId || !assertion ||
+      !sessionToken || !Number.isFinite(assertionExpiry) || assertionExpiry <= now ||
+      !Number.isFinite(sessionExpiry) || sessionExpiry <= now) {
+    throw new Error("Hosted login did not return a current user, deployment and verified-session envelope.");
+  }
+  return {
+    hosted: true,
+    panel_session_token: sessionToken,
+    context_assertion: assertion,
+    context_assertion_expires_at: String(payload.context_assertion_expires_at),
+    session_expires_at: String(payload.session_expires_at),
+    hosted_role: String(payload?.role || ""),
+    hosted_roles: Array.isArray(payload?.roles) ? payload.roles.map(String) : [],
+    hosted_org_units: Array.isArray(payload?.org_units) ? payload.org_units : [],
+    hosted_capabilities: Array.isArray(payload?.capabilities) ? payload.capabilities.map(String) : [],
+    hosted_policy_version: payload?.policy_version == null ? null : Number(payload.policy_version),
+    hosted_user: payload.user,
+    principal_id: userId,
+    principal_source: "tandem-hosted",
+    principal_scope: payloadDeployment,
+  };
+}
+
+export function assertSameHostedIdentity(previous, next) {
+  if (previous.principal_id !== next.principal_id || previous.principal_scope !== next.principal_scope) {
+    throw new Error("Hosted session refresh changed user or deployment; sign in again.");
+  }
+}
+
+// These local/sidecar handlers currently use deployment-wide files, settings or
+// administrative credentials, rather than per-user runtime authorization.
+// Until they gain a governed user path, a hosted member must not reach them.
+const ADMIN_ROUTES = [
+  "/api/control-panel/config", "/api/system/search-settings", "/api/system/scheduler-settings",
+  "/api/knowledgebase", "/api/aca", "/api/swarm", "/api/orchestrator",
+  "/api/files", "/api/workspace/files",
+];
+
+export function hostedPanelRouteAllowed(session, pathname) {
+  if (session?.hosted !== true) return true;
+  // Match the existing router's prefix checks, including unusual suffixes.
+  const administrative = ADMIN_ROUTES.some((path) => pathname.startsWith(path));
+  if (!administrative) return true;
+  const role = String(session.hosted_role || "").toLowerCase();
+  const capabilities = new Set((session.hosted_capabilities || []).map((value) => String(value).toLowerCase()));
+  return role === "owner" || role === "admin" || capabilities.has("hosted.owner") || capabilities.has("hosted.admin");
+}

--- a/packages/tandem-control-panel/tests/engine-proxy-header-strip.test.mjs
+++ b/packages/tandem-control-panel/tests/engine-proxy-header-strip.test.mjs
@@ -64,6 +64,10 @@ test("control panel engine proxy strips browser agent headers", async (t) => {
         auth: String(req.headers.authorization || ""),
         xToken: String(req.headers["x-tandem-token"] || ""),
         forwardedPrefix: String(req.headers["x-forwarded-prefix"] || ""),
+        identityHeaders: Object.keys(req.headers).filter((name) =>
+          ["x-tandem-context-assertion", "x-tandem-context-jws", "x-tandem-tenant-context-jws",
+            "x-tandem-org-id", "x-tenant-org-id", "x-tandem-workspace-id", "x-tenant-workspace-id",
+            "x-tandem-actor-id", "x-user-id", "x-tandem-roles"].includes(name)),
       });
 
       if (url.pathname === "/global/health") {
@@ -108,6 +112,16 @@ test("control panel engine proxy strips browser agent headers", async (t) => {
     cookie,
     headers: {
       "x-tandem-agent-id": "agent-should-not-forward",
+      "x-tandem-context-assertion": "forged",
+      "x-tandem-context-jws": "forged-alias",
+      "x-tandem-tenant-context-jws": "forged-tenant-alias",
+      "x-tandem-org-id": "other-org",
+      "x-tenant-org-id": "other-org-alias",
+      "x-tandem-workspace-id": "other-workspace",
+      "x-tenant-workspace-id": "other-workspace-alias",
+      "x-tandem-actor-id": "other-actor",
+      "x-user-id": "other-user",
+      "x-tandem-roles": "admin",
     },
   });
   assert.equal(response.status, 200);
@@ -119,6 +133,7 @@ test("control panel engine proxy strips browser agent headers", async (t) => {
   assert.equal(forwarded?.agentId, "");
   assert.equal(forwarded?.requestSource, "control_panel");
   assert.equal(forwarded?.forwardedPrefix, "/api/engine");
+  assert.deepEqual(forwarded?.identityHeaders, []);
 });
 
 test("control panel engine proxy forwards public origin for MCP OAuth", async (t) => {
@@ -205,6 +220,7 @@ test("control panel proxies OAuth callbacks without a panel session", async (t) 
         auth: String(req.headers.authorization || ""),
         xToken: String(req.headers["x-tandem-token"] || ""),
         cookie: String(req.headers.cookie || ""),
+        identity: String(req.headers["x-tandem-context-jws"] || ""),
       });
 
       if (url.pathname === "/global/health") {
@@ -250,6 +266,7 @@ test("control panel proxies OAuth callbacks without a panel session", async (t) 
     {
       headers: {
         cookie: "tcp_sid=browser-session-should-not-forward",
+        "x-tandem-context-jws": "forged-callback-context",
       },
     }
   );
@@ -261,6 +278,7 @@ test("control panel proxies OAuth callbacks without a panel session", async (t) 
   assert.equal(forwarded?.auth, `Bearer ${engineToken}`);
   assert.equal(forwarded?.xToken, engineToken);
   assert.equal(forwarded?.cookie, "");
+  assert.equal(forwarded?.identity, "");
 });
 
 test("control panel proxies automation webhooks without a panel session", async (t) => {
@@ -283,6 +301,7 @@ test("control panel proxies automation webhooks without a panel session", async 
         auth: String(req.headers.authorization || ""),
         xToken: String(req.headers["x-tandem-token"] || ""),
         cookie: String(req.headers.cookie || ""),
+        identity: String(req.headers["x-tandem-context-jws"] || ""),
         signature: String(req.headers["x-tandem-webhook-signature"] || ""),
         eventId: String(req.headers["x-tandem-webhook-event-id"] || ""),
         forwardedHost: String(req.headers["x-forwarded-host"] || ""),
@@ -355,6 +374,7 @@ test("control panel proxies automation webhooks without a panel session", async 
         "x-forwarded-prefix": "/caller-controlled",
         "x-tandem-webhook-signature": "t=123,v1=abc",
         "x-tandem-webhook-event-id": "evt-public-proxy",
+        "x-tandem-context-jws": "forged-webhook-context",
       },
       body: { ok: true },
     }
@@ -367,6 +387,7 @@ test("control panel proxies automation webhooks without a panel session", async 
   assert.equal(forwarded?.auth, "");
   assert.equal(forwarded?.xToken, "");
   assert.equal(forwarded?.cookie, "");
+  assert.equal(forwarded?.identity, "");
   assert.equal(forwarded?.signature, "t=123,v1=abc");
   assert.equal(forwarded?.eventId, "evt-public-proxy");
   assert.equal(forwarded?.forwardedHost, "testing.tandem.ac");

--- a/packages/tandem-control-panel/tests/hosted-session-integration.test.mjs
+++ b/packages/tandem-control-panel/tests/hosted-session-integration.test.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+async function listen(t, handler) {
+  const server = createServer(handler);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+function send(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+async function setup(t, { refresh = "valid", invalidExchange = false } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "tandem-hosted-identity-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const requests = [];
+  const refreshCalls = [];
+  const engine = await listen(t, (req, res) => {
+    requests.push({ path: req.url, headers: req.headers });
+    send(res, 200, { ready: true, healthy: true, version: "identity-fixture" });
+  });
+  const envelope = (user, { fresh = false } = {}) => ({
+    deployment_id: "deployment-a", user: { id: user }, role: "member",
+    roles: ["workspace:user"], org_units: [fresh ? "finance" : "engineering"],
+    policy_version: fresh ? 2 : 1,
+    panel_session_token: `server-session-${user}`,
+    context_assertion: `server-assertion-${user}${fresh ? "-refreshed" : ""}`,
+    context_assertion_expires_at: new Date(Date.now() + (fresh || user === "bob" ? 300_000 : 30_000)).toISOString(),
+    session_expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+  });
+  const controlPlane = await listen(t, async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = JSON.parse(Buffer.concat(chunks).toString() || "{}");
+    if (req.headers.authorization !== "Bearer host-fixture-token") return send(res, 401, {});
+    if (req.url === "/exchange") {
+      const payload = envelope(body.code);
+      if (invalidExchange) delete payload.user;
+      return send(res, 200, payload);
+    }
+    if (req.url === "/refresh") {
+      refreshCalls.push(body.panel_session_token);
+      if (refresh === "revoked") return send(res, 403, { error: "fixture revocation" });
+      const user = refresh === "changed-user" ? "mallory" : "alice";
+      return send(res, 200, envelope(user, { fresh: true }));
+    }
+    send(res, 404, {});
+  });
+  const tokenPath = join(root, "host-token");
+  await writeFile(tokenPath, "host-fixture-token", { mode: 0o600 });
+  const configPath = join(root, "panel.json");
+  await writeFile(configPath, JSON.stringify({
+    version: 1,
+    hosted: {
+      managed: true, deployment_id: "deployment-a", public_url: "https://private.example.test",
+      control_plane_url: controlPlane,
+      auth: { mode: "hosted", panel_exchange_url: `${controlPlane}/exchange`, panel_refresh_url: `${controlPlane}/refresh`, host_agent_token_file: tokenPath },
+    },
+  }));
+  // Reserve and release a port without fixed-port cross-test collisions.
+  const reservation = createServer();
+  await new Promise((resolve) => reservation.listen(0, "127.0.0.1", resolve));
+  const port = reservation.address().port;
+  await new Promise((resolve) => reservation.close(resolve));
+  const url = `http://127.0.0.1:${port}`;
+  const panel = spawn(process.execPath, ["bin/setup.js"], {
+    cwd: new URL("..", import.meta.url),
+    env: { ...process.env, TANDEM_CONTROL_PANEL_PORT: String(port), TANDEM_ENGINE_URL: engine,
+      TANDEM_CONTROL_PANEL_AUTO_START_ENGINE: "0", TANDEM_API_TOKEN: "engine-fixture-token",
+      TANDEM_CONTROL_PANEL_CONFIG_FILE: configPath, TANDEM_CONTROL_PANEL_STATE_DIR: root },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  panel.stdout.on("data", (chunk) => { output += chunk; });
+  panel.stderr.on("data", (chunk) => { output += chunk; });
+  t.after(async () => {
+    if (panel.exitCode !== null) return;
+    const exited = new Promise((resolve) => panel.once("exit", resolve));
+    panel.kill("SIGTERM");
+    await exited;
+  });
+  let ready = false;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try { if ((await fetch(`${url}/api/system/health`)).ok) { ready = true; break; } } catch {}
+    if (panel.exitCode !== null) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.equal(ready, true, `panel did not start: ${output}`);
+  async function login(user) {
+    const response = await fetch(`${url}/api/auth/hosted/exchange`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code: user, user: { id: "browser-forged-user" }, role: "owner" }),
+    });
+    const setCookie = response.headers.get("set-cookie") || "";
+    const body = await response.json();
+    return { status: response.status, cookie: setCookie.split(";")[0], setCookie, body };
+  }
+  return { url, login, requests, refreshCalls };
+}
+
+test("hosted requests use only the server identity and refreshed memberships", async (t) => {
+  const app = await setup(t);
+  const alice = await app.login("alice");
+  assert.equal(alice.status, 200);
+  assert.match(alice.setCookie, /; Secure/);
+  assert.equal(alice.body.user.id, "alice");
+  assert.equal(alice.body.role, "member");
+  assert.equal(JSON.stringify(alice.body).includes("server-session"), false);
+  const [first, second] = await Promise.all([
+    fetch(`${app.url}/api/auth/me`, { headers: { cookie: alice.cookie } }),
+    fetch(`${app.url}/api/engine/global/health`, { headers: {
+      cookie: alice.cookie, "x-tandem-context-assertion": "browser-forged",
+      "x-tandem-context-jws": "browser-forged-alias", "x-tandem-tenant-context-jws": "forged",
+      "x-tandem-actor-id": "mallory", "x-user-id": "mallory",
+      "x-tandem-agent-id": "forged-agent", "x-tandem-agent-test-mode": "true",
+      "x-tandem-request-source": "agent",
+    } }),
+  ]);
+  assert.equal(first.status, 200);
+  assert.equal(second.status, 200);
+  const me = await first.json();
+  assert.equal(me.principal_id, "alice");
+  assert.deepEqual(me.org_units, ["finance"]);
+  assert.equal(me.policy_version, 2);
+  assert.equal(app.refreshCalls.length, 1);
+  const forwarded = app.requests.find((request) => request.headers["x-tandem-context-assertion"]);
+  assert.equal(forwarded.headers["x-tandem-context-assertion"], "server-assertion-alice-refreshed");
+  assert.equal(forwarded.headers["x-tandem-context-jws"], undefined);
+  assert.equal(forwarded.headers["x-tandem-tenant-context-jws"], undefined);
+  assert.equal(forwarded.headers["x-tandem-actor-id"], undefined);
+  assert.equal(forwarded.headers["x-user-id"], undefined);
+  assert.equal(forwarded.headers["x-tandem-agent-id"], undefined);
+  assert.equal(forwarded.headers["x-tandem-request-source"], "control_panel");
+  assert.equal(forwarded.headers.authorization, "Bearer engine-fixture-token");
+});
+
+test("failed refresh removes only the affected user's panel session", async (t) => {
+  const app = await setup(t, { refresh: "revoked" });
+  const alice = await app.login("alice");
+  const bob = await app.login("bob");
+  assert.equal(alice.status, 200);
+  assert.equal(bob.status, 200);
+  const denied = await fetch(`${app.url}/api/auth/me`, { headers: { cookie: alice.cookie } });
+  assert.equal(denied.status, 401);
+  assert.match(denied.headers.get("set-cookie"), /Max-Age=0/);
+  const again = await fetch(`${app.url}/api/engine/global/health`, { headers: { cookie: alice.cookie } });
+  assert.equal(again.status, 401);
+  const allowed = await fetch(`${app.url}/api/auth/me`, { headers: { cookie: bob.cookie } });
+  assert.equal(allowed.status, 200);
+  assert.equal((await allowed.json()).principal_id, "bob");
+  assert.equal(app.refreshCalls.length, 1);
+});
+
+test("hosted members cannot change deployment auth or reach shared administrative handlers", async (t) => {
+  const app = await setup(t);
+  const bob = await app.login("bob");
+  for (const [path, method] of [
+    ["/api/control-panel/config", "GET"], ["/api/control-panel/config", "PATCH"],
+    ["/api/system/scheduler-settings", "PATCH"], ["/api/system/search-settings/test", "POST"],
+    ["/api/workspace/files", "GET"], ["/api/files", "GET"], ["/api/aca/run", "POST"],
+    ["/api/swarm/start", "POST"], ["/api/knowledgebase/admin/collections", "GET"],
+  ]) {
+    const response = await fetch(`${app.url}${path}`, { method, headers: { cookie: bob.cookie } });
+    assert.equal(response.status, 403, `${method} ${path}`);
+  }
+  const valid = await fetch(`${app.url}/api/auth/me`, { headers: { cookie: bob.cookie } });
+  assert.equal(valid.status, 200);
+});
+
+test("refresh cannot replace a signed-in user with another user", async (t) => {
+  const app = await setup(t, { refresh: "changed-user" });
+  const alice = await app.login("alice");
+  const response = await fetch(`${app.url}/api/engine/global/health`, { headers: { cookie: alice.cookie } });
+  assert.equal(response.status, 401);
+  assert.equal(app.requests.some((request) => request.headers["x-tandem-context-assertion"]), false);
+});
+
+test("incomplete control-plane exchange cannot create a token-backed fallback session", async (t) => {
+  const app = await setup(t, { invalidExchange: true });
+  const response = await app.login("alice");
+  assert.equal(response.status, 401);
+  assert.equal(response.cookie, "");
+  const me = await fetch(`${app.url}/api/auth/me`);
+  assert.equal(me.status, 401);
+});

--- a/packages/tandem-control-panel/tests/hosted-session.test.mjs
+++ b/packages/tandem-control-panel/tests/hosted-session.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+import { hostedSessionFields, hostedSessionExpired, assertSameHostedIdentity, hostedPanelRouteAllowed } from "../lib/setup/hosted-session.js";
+import { isEngineIdentityHeader, sessionEngineHeaders } from "../lib/setup/engine-identity-headers.js";
+
+const now = Date.parse("2026-09-04T00:00:00Z");
+const payload = () => ({
+  deployment_id: "deployment-a", user: { id: "user-a" },
+  panel_session_token: "server-only-session", context_assertion: "server-only-assertion",
+  context_assertion_expires_at: new Date(now + 300_000).toISOString(),
+  session_expires_at: new Date(now + 3_600_000).toISOString(),
+  role: "member", org_units: ["engineering"], policy_version: 1,
+});
+
+test("hosted envelope requires current identity, deployment and expiration", () => {
+  const options = { deploymentId: "deployment-a", now };
+  const session = hostedSessionFields(payload(), options);
+  assert.equal(session.principal_id, "user-a");
+  assert.equal(session.principal_scope, "deployment-a");
+  for (const field of ["user", "deployment_id", "panel_session_token", "context_assertion", "context_assertion_expires_at", "session_expires_at"]) {
+    const incomplete = payload();
+    delete incomplete[field];
+    assert.throws(() => hostedSessionFields(incomplete, options), /current user/);
+  }
+  assert.throws(() => hostedSessionFields(payload(), { deploymentId: "deployment-b", now }), /current user/);
+  for (const field of ["context_assertion_expires_at", "session_expires_at"]) {
+    assert.throws(() => hostedSessionFields({ ...payload(), [field]: new Date(now).toISOString() }, options), /current user/);
+  }
+});
+
+test("refresh permits credential and membership rotation but cannot change identity", () => {
+  const options = { deploymentId: "deployment-a", now };
+  const previous = hostedSessionFields(payload(), options);
+  const next = hostedSessionFields({ ...payload(), panel_session_token: "rotated", context_assertion: "rotated-assertion", org_units: ["finance"], policy_version: 2 }, options);
+  assert.doesNotThrow(() => assertSameHostedIdentity(previous, next));
+  assert.throws(() => assertSameHostedIdentity(previous, { ...next, principal_id: "user-b" }), /changed user/);
+  assert.throws(() => assertSameHostedIdentity(previous, { ...next, principal_scope: "deployment-b" }), /changed user/);
+});
+
+test("absolute hosted session expiry cannot be extended by activity", () => {
+  const session = hostedSessionFields(payload(), { deploymentId: "deployment-a", now });
+  assert.equal(hostedSessionExpired(session, now), false);
+  assert.equal(hostedSessionExpired({ ...session, lastSeenAt: now + 3_600_000 }, now + 3_600_000), true);
+  assert.equal(hostedSessionExpired({ ...session, session_expires_at: "invalid" }, now), true);
+  assert.equal(hostedSessionExpired({ token: "local-operator" }, now), false);
+});
+
+test("deployment-wide handlers require hosted administration without restricting personal preferences", () => {
+  const member = hostedSessionFields(payload(), { deploymentId: "deployment-a", now });
+  for (const path of ["/api/control-panel/config", "/api/files/upload", "/api/workspace/files", "/api/knowledgebase/admin/collections", "/api/knowledgebase-suffix", "/api/aca/run", "/api/swarm/start", "/api/orchestrator", "/api/system/search-settings/test", "/api/system/scheduler-settings"]) {
+    assert.equal(hostedPanelRouteAllowed(member, path), false, path);
+    assert.equal(hostedPanelRouteAllowed({ ...member, hosted_role: "owner" }, path), true, path);
+    assert.equal(hostedPanelRouteAllowed({ ...member, hosted_capabilities: ["hosted.admin"] }, path), true, path);
+    assert.equal(hostedPanelRouteAllowed({ token: "local-operator" }, path), true, path);
+  }
+  assert.equal(hostedPanelRouteAllowed(member, "/api/control-panel/preferences"), true);
+  assert.equal(hostedPanelRouteAllowed(member, "/api/engine/memory/search"), true);
+});
+
+test("server session headers override credentials and all browser identity aliases", () => {
+  const extras = {
+    authorization: "Bearer forged", "x-tandem-token": "forged",
+    "X-Tandem-Context-Assertion": "forged", "x-tandem-context-jws": "forged",
+    "x-tandem-tenant-context-jws": "forged", "x-user-id": "other-user",
+    "x-tenant-org-id": "other-org", "x-tenant-workspace-id": "other-workspace",
+    "x-tandem-actor-id": "other-actor", "x-tandem-roles": "admin",
+    "x-tandem-agent-id": "other-agent", "x-tandem-request-source": "agent",
+    "content-type": "application/json",
+  };
+  const headers = sessionEngineHeaders({ token: "transport-token", context_assertion: "verified-context" }, extras);
+  assert.equal(headers.get("authorization"), "Bearer transport-token");
+  assert.equal(headers.get("x-tandem-token"), "transport-token");
+  assert.equal(headers.get("x-tandem-context-assertion"), "verified-context");
+  for (const name of Object.keys(extras)) {
+    if (isEngineIdentityHeader(name) && name.toLowerCase() !== "x-tandem-context-assertion") assert.equal(headers.get(name), null);
+  }
+  assert.equal(headers.get("content-type"), "application/json");
+  const local = sessionEngineHeaders({ token: "local-token" }, extras);
+  assert.equal(local.get("x-tandem-context-assertion"), null);
+});
+
+test("newly scaffolded panels keep the same identity-header boundary", async () => {
+  const source = await readFile(new URL("../lib/setup/engine-identity-headers.js", import.meta.url), "utf8");
+  const scaffold = await readFile(new URL("../../create-tandem-panel/template/lib/setup/engine-identity-headers.js", import.meta.url), "utf8");
+  assert.equal(scaffold, source);
+});


### PR DESCRIPTION
Superseded by #1932, which preserves this implementation, fixes CI metadata/fixture issues and corrects the author-matching DCO sign-off. This original branch is retained without rewriting its published history.

Private Company Brain setup needs individually verified users. Before adding enrollment, the existing panel boundary needs to prevent browser identity injection, stale hosted sessions and member access to deployment-wide administrative handlers.

This first TAN-840 slice:
- Strips all existing runtime assertion/tenant/actor aliases from browser proxies, including OAuth callbacks and webhooks; only server-held session identity is forwarded.
- Prevents extra internal-request headers from replacing the session identity or transport credential; hosted browsers cannot enable local agent test mode.
- Validates hosted exchange/refresh envelopes and absolute expiry, refreshes before every authenticated panel route, coalesces concurrent refreshes and rejects changed-user/deployment refreshes.
- Removes only the affected session after refresh failure and prevents a late refresh from recreating a logged-out session.
- Requires existing owner/admin authority for deployment settings, shared files and administrative sidecars that do not yet have per-user authorization. Personal preferences and engine-governed routes retain their existing access paths.
- Sets Secure cookies for a configured HTTPS public URL and carries the header boundary into the panel scaffold.

Validation:
- Focused hosted/session/header tests plus existing auth/proxy/swarm smoke: 22 passed.
- Frontend build and JavaScript syntax/diff checks passed.
- Four other capability integration cases passed. The remote-host case using engine.localtest.me failed with engine-unavailable/502 here; the same test against unchanged main setup.js reproduces that failure. This is documented rather than counted as passing.
- Published GitHub tree equals the locally tested tree; commit has the required DCO sign-off.

Scope remains incomplete: this does not create a private identity provider, first owner, invitations or recovery, and does not prove end-to-end private memory isolation. Existing assertion refresh timing does not provide immediate revocation. Real owner/second-user bootstrap and per-user product-surface integration remain open in TAN-840. See docs/PRIVATE_IDENTITY_FOUNDATION.md.

Linear: https://linear.app/frumu/issue/TAN-840
Related solution contract: https://github.com/frumu-ai/tandem/pull/1929