### PR TITLE
TAN-834: enforce current hosted policy at runtime dispatch

### DIFF
--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -30,6 +30,8 @@ jobs:
         run: cargo test -p tandem-core hosted_policy --lib
       - name: Check formatting
         run: cargo fmt --check
+      - name: Check enterprise server compatibility
+        run: cargo check -p tandem-enterprise-server
       - name: Verify provider retry revocation and request isolation
         run: cargo test -p tandem-providers --lib
       - name: Verify MCP revocation after readiness and before network dispatch

--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -41,6 +41,8 @@ jobs:
         run: cargo check -p tandem-enterprise-server
       - name: Verify hosted registry ownership boundary
         run: cargo test -p tandem-enterprise-server hosted_policy --lib
+      - name: Verify native organization registry HTTP compatibility
+        run: cargo test -p tandem-enterprise-server --test enterprise_http enterprise_org_unit
       - name: Verify provider retry revocation and request isolation
         run: cargo test -p tandem-providers --lib
       - name: Verify MCP revocation after readiness and before network dispatch

--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -31,4 +31,6 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
       - name: Verify provider retry revocation and request isolation
-        run: cargo test -p tandem-providers hosted_policy --lib
+        run: cargo test -p tandem-providers --lib
+      - name: Verify MCP revocation after readiness and before network dispatch
+        run: cargo test -p tandem-runtime mcp --lib

--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -33,6 +33,8 @@ jobs:
           cargo test -p tandem-server session_run_retry --lib
           cargo test -p tandem-server workflow_planner_transport --lib
           cargo test -p tandem-server mission_builder_host --lib
+      - name: Verify production approval route with scoped dispatch
+        run: cargo test -p tandem-server acme_slack_demo --lib
       - name: Check formatting
         run: cargo fmt --check
       - name: Check enterprise server compatibility

--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -34,7 +34,7 @@ jobs:
           cargo test -p tandem-server workflow_planner_transport --lib
           cargo test -p tandem-server mission_builder_host --lib
       - name: Verify production approval route with scoped dispatch
-        run: cargo test -p tandem-server acme_slack_demo --lib
+        run: cargo test -p tandem-server --features acme-demo acme_slack_demo --lib
       - name: Check formatting
         run: cargo fmt --check
       - name: Check enterprise server compatibility

--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -30,3 +30,5 @@ jobs:
         run: cargo test -p tandem-core hosted_policy --lib
       - name: Check formatting
         run: cargo fmt --check
+      - name: Verify provider retry revocation and request isolation
+        run: cargo test -p tandem-providers hosted_policy --lib

--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -32,6 +32,8 @@ jobs:
         run: cargo fmt --check
       - name: Check enterprise server compatibility
         run: cargo check -p tandem-enterprise-server
+      - name: Verify hosted registry ownership boundary
+        run: cargo test -p tandem-enterprise-server hosted_policy --lib
       - name: Verify provider retry revocation and request isolation
         run: cargo test -p tandem-providers --lib
       - name: Verify MCP revocation after readiness and before network dispatch

--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -28,6 +28,11 @@ jobs:
         run: cargo test -p tandem-server hosted_policy --lib
       - name: Verify revocation after approval and before provider dispatch
         run: cargo test -p tandem-core hosted_policy --lib
+      - name: Verify direct provider and recovery compatibility
+        run: |
+          cargo test -p tandem-server session_run_retry --lib
+          cargo test -p tandem-server workflow_planner_transport --lib
+          cargo test -p tandem-server mission_builder_host --lib
       - name: Check formatting
         run: cargo fmt --check
       - name: Check enterprise server compatibility

--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -1,0 +1,30 @@
+name: Hosted policy authority
+on:
+  pull_request:
+    paths:
+      - 'crates/**'
+      - '.github/workflows/hosted-policy.yml'
+  push:
+    branches: ['codex/tan-834-hosted-policy']
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: hosted-policy-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  policy:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-profile: hosted-policy
+          components: rustfmt
+      - name: Validate hosted policy contract
+        run: cargo test -p tandem-enterprise-contract hosted_policy --lib
+      - name: Validate current runtime authority and persisted revision
+        run: cargo test -p tandem-server hosted_policy --lib
+      - name: Check formatting
+        run: cargo fmt --check

--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -26,5 +26,7 @@ jobs:
         run: cargo test -p tandem-enterprise-contract hosted_policy --lib
       - name: Validate current runtime authority and persisted revision
         run: cargo test -p tandem-server hosted_policy --lib
+      - name: Verify revocation after approval and before provider dispatch
+        run: cargo test -p tandem-core hosted_policy --lib
       - name: Check formatting
         run: cargo fmt --check

--- a/crates/tandem-core/src/engine_loop.rs
+++ b/crates/tandem-core/src/engine_loop.rs
@@ -1484,6 +1484,7 @@ impl EngineLoop {
                 obj.insert("tool_calls".to_string(), Value::Array(governed_calls));
             }
         }
+        self.revalidate_session_authority(session_id).await?;
         let result = match self
             .execute_tool_with_timeout(
                 session_id,

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -1074,6 +1074,7 @@ impl EngineLoop {
                     streamed_tool_calls.clear();
                     provider_usage = None;
                     accepted_tool_calls_in_cycle = 0;
+                    self.revalidate_session_authority(&session_id).await?;
                     let stream_result = tokio::time::timeout(
                         provider_connect_timeout,
                         self.providers.stream_with_egress_permit(

--- a/crates/tandem-core/src/engine_loop/prompt_execution.rs
+++ b/crates/tandem-core/src/engine_loop/prompt_execution.rs
@@ -1077,22 +1077,25 @@ impl EngineLoop {
                     self.revalidate_session_authority(&session_id).await?;
                     let stream_result = tokio::time::timeout(
                         provider_connect_timeout,
-                        self.providers.stream_with_egress_permit(
-                            &provider_egress_permit,
-                            Some(provider_id.as_str()),
-                            Some(model_id_value.as_str()),
-                            messages.clone(),
-                            provider_tool_mode_for_selected_tools(
-                                &requested_tool_mode,
-                                tool_schemas.len(),
+                        self.scope_provider_authority(
+                            &session_id,
+                            self.providers.stream_with_egress_permit(
+                                &provider_egress_permit,
+                                Some(provider_id.as_str()),
+                                Some(model_id_value.as_str()),
+                                messages.clone(),
+                                provider_tool_mode_for_selected_tools(
+                                    &requested_tool_mode,
+                                    tool_schemas.len(),
+                                ),
+                                if tool_schemas.is_empty() {
+                                    None
+                                } else {
+                                    Some(tool_schemas.clone())
+                                },
+                                sampling,
+                                cancel.clone(),
                             ),
-                            if tool_schemas.is_empty() {
-                                None
-                            } else {
-                                Some(tool_schemas.clone())
-                            },
-                            sampling,
-                            cancel.clone(),
                         ),
                     )
                     .await

--- a/crates/tandem-core/src/engine_loop/tests.rs
+++ b/crates/tandem-core/src/engine_loop/tests.rs
@@ -16,6 +16,7 @@ fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
 }
 
 mod fallback_correlation;
+mod hosted_policy;
 mod suite_a;
 mod suite_b;
 

--- a/crates/tandem-core/src/engine_loop/tests/hosted_policy.rs
+++ b/crates/tandem-core/src/engine_loop/tests/hosted_policy.rs
@@ -1,0 +1,163 @@
+use super::*;
+use std::sync::atomic::AtomicBool;
+
+struct MutableAuthority {
+    revoked: Arc<AtomicBool>,
+    initial_checks: Arc<AtomicUsize>,
+}
+
+impl ToolPolicyHook for MutableAuthority {
+    fn evaluate_tool(
+        &self,
+        _ctx: ToolPolicyContext,
+    ) -> futures::future::BoxFuture<'static, anyhow::Result<ToolPolicyDecision>> {
+        self.initial_checks.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async {
+            Ok(ToolPolicyDecision {
+                allowed: true,
+                reason: None,
+                policy_decision_id: None,
+                dispatch_decision: None,
+            })
+        })
+    }
+
+    fn revalidate_session(
+        &self,
+        _verified: Option<tandem_types::VerifiedTenantContext>,
+    ) -> futures::future::BoxFuture<'static, anyhow::Result<()>> {
+        let revoked = self.revoked.clone();
+        Box::pin(async move {
+            anyhow::ensure!(!revoked.load(Ordering::SeqCst), "hosted membership revoked");
+            Ok(())
+        })
+    }
+}
+
+struct CountedTool(Arc<AtomicUsize>);
+
+#[async_trait]
+impl Tool for CountedTool {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new("counted_tool", "Synthetic effect counter", json!({}))
+    }
+    async fn execute(&self, _args: Value) -> anyhow::Result<ToolResult> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(ToolResult {
+            output: "effect executed".into(),
+            metadata: json!({}),
+        })
+    }
+}
+
+#[tokio::test]
+async fn hosted_policy_revocation_during_permission_wait_prevents_effect() {
+    let temp = tempfile::tempdir().unwrap();
+    let provider = Arc::new(SamplingCaptureProvider {
+        captured: Arc::new(Mutex::new(None)),
+    });
+    let (engine, bus, storage) = engine_loop_with_scripted_provider(temp.path(), provider).await;
+    let engine = Arc::new(engine);
+    let session = Session::new(
+        Some("revocation during approval".into()),
+        Some(temp.path().display().to_string()),
+    );
+    let session_id = session.id.clone();
+    storage.save_session(session).await.unwrap();
+    let effects = Arc::new(AtomicUsize::new(0));
+    engine
+        .tools
+        .register_tool(
+            "counted_tool".into(),
+            Arc::new(CountedTool(effects.clone())),
+        )
+        .await;
+    let revoked = Arc::new(AtomicBool::new(false));
+    let initial_checks = Arc::new(AtomicUsize::new(0));
+    engine
+        .set_tool_policy_hook(Arc::new(MutableAuthority {
+            revoked: revoked.clone(),
+            initial_checks: initial_checks.clone(),
+        }))
+        .await;
+    let mut events = bus.subscribe();
+    let task_engine = engine.clone();
+    let task = tokio::spawn(async move {
+        task_engine
+            .execute_tool_with_permission(
+                &session_id,
+                "message-1",
+                None,
+                "counted_tool".into(),
+                json!({}),
+                Some("call-1".into()),
+                None,
+                "test approved effect",
+                false,
+                None,
+                CancellationToken::new(),
+            )
+            .await
+    });
+    let permission_id = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = events.recv().await.unwrap();
+            if event.event_type == "permission.asked" {
+                break event.properties["requestID"].as_str().unwrap().to_string();
+            }
+        }
+    })
+    .await
+    .expect("permission barrier reached");
+    assert_eq!(initial_checks.load(Ordering::SeqCst), 1);
+    assert_eq!(effects.load(Ordering::SeqCst), 0);
+    revoked.store(true, Ordering::SeqCst);
+    assert!(engine.permissions.reply(&permission_id, "once").await);
+    let error = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert!(error.to_string().contains("revoked"));
+    assert_eq!(effects.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        initial_checks.load(Ordering::SeqCst),
+        1,
+        "final check must not repeat approval-producing policy"
+    );
+}
+
+#[tokio::test]
+async fn hosted_policy_revocation_prevents_tool_free_provider_dispatch() {
+    let temp = tempfile::tempdir().unwrap();
+    let captured = Arc::new(Mutex::new(None));
+    let provider = Arc::new(PostToolCaptureProvider {
+        captured: captured.clone(),
+    });
+    let (engine, _, storage) = engine_loop_with_scripted_provider(temp.path(), provider).await;
+    let session = Session::new(Some("revoked synthesis".into()), None);
+    let session_id = session.id.clone();
+    storage.save_session(session).await.unwrap();
+    engine
+        .set_tool_policy_hook(Arc::new(MutableAuthority {
+            revoked: Arc::new(AtomicBool::new(true)),
+            initial_checks: Arc::new(AtomicUsize::new(0)),
+        }))
+        .await;
+    let agent = engine.agents.get(None).await;
+    let error = engine
+        .generate_final_narrative_without_tools(
+            &session_id,
+            None,
+            &agent,
+            Some("scripted-provider-stream"),
+            Some("scripted-model"),
+            Default::default(),
+            CancellationToken::new(),
+            &["synthetic tool output".into()],
+        )
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("revoked"));
+    assert!(captured.lock().unwrap().is_none());
+}

--- a/crates/tandem-core/src/engine_loop/tool_execution.rs
+++ b/crates/tandem-core/src/engine_loop/tool_execution.rs
@@ -6,16 +6,26 @@ use tandem_tools::{
     ToolDispatchReceiptPhase, ToolDispatchSource, ToolDispatchStatus,
 };
 
-#[derive(Debug)]
-struct EnginePreauthorizedDispatchPolicy(ToolDispatchDecision);
+struct EnginePreauthorizedDispatchPolicy {
+    decision: ToolDispatchDecision,
+    authority: Option<Arc<dyn ToolPolicyHook>>,
+}
 
 #[async_trait::async_trait]
 impl ToolDispatchPolicy for EnginePreauthorizedDispatchPolicy {
+    async fn revalidate(&self, context: &ToolDispatchContext) -> anyhow::Result<()> {
+        if let Some(hook) = &self.authority {
+            hook.revalidate_session(context.verified_tenant_context.clone())
+                .await?;
+        }
+        Ok(())
+    }
+
     async fn evaluate(
         &self,
         _context: ToolDispatchPolicyContext,
     ) -> anyhow::Result<ToolDispatchDecision> {
-        Ok(self.0.clone())
+        Ok(self.decision.clone())
     }
 }
 
@@ -127,10 +137,11 @@ impl EngineLoop {
                     .message(message_id),
             )
             .with_scope_allowlist(scope_allowlist)
-            .with_policy(Arc::new(EnginePreauthorizedDispatchPolicy(
-                preauthorized_decision
+            .with_policy(Arc::new(EnginePreauthorizedDispatchPolicy {
+                decision: preauthorized_decision
                     .unwrap_or_else(|| ToolDispatchDecision::allow_with_id("engine_preflight")),
-            )))
+                authority: self.tool_policy_hook.read().await.clone(),
+            }))
             .with_ledger(tool_dispatch_ledger);
         if let Some(verified_tenant_context) = verified_tenant_context {
             dispatch_context =

--- a/crates/tandem-core/src/engine_loop/tool_execution.rs
+++ b/crates/tandem-core/src/engine_loop/tool_execution.rs
@@ -46,6 +46,22 @@ impl ToolDispatchLedger for EngineToolDispatchLedger {
 }
 
 impl EngineLoop {
+    pub(super) async fn scope_provider_authority<F: std::future::Future>(
+        &self,
+        session_id: &str,
+        future: F,
+    ) -> F::Output {
+        let engine = self.clone();
+        let session_id = session_id.to_owned();
+        tandem_providers::ProviderDispatchAuthority::new(move || {
+            let engine = engine.clone();
+            let session_id = session_id.clone();
+            async move { engine.revalidate_session_authority(&session_id).await }
+        })
+        .scope(future)
+        .await
+    }
+
     pub(super) async fn record_tool_preflight_denial(
         &self,
         session_id: &str,
@@ -668,16 +684,18 @@ impl EngineLoop {
         };
         self.revalidate_session_authority(session_id).await?;
         let stream = match self
-            .providers
-            .stream_with_egress_permit(
-                &provider_egress_permit,
-                Some(route.provider_id.as_str()),
-                route.model_id.as_deref(),
-                messages,
-                ToolMode::None,
-                None,
-                sampling,
-                cancel.clone(),
+            .scope_provider_authority(
+                session_id,
+                self.providers.stream_with_egress_permit(
+                    &provider_egress_permit,
+                    Some(route.provider_id.as_str()),
+                    route.model_id.as_deref(),
+                    messages,
+                    ToolMode::None,
+                    None,
+                    sampling,
+                    cancel.clone(),
+                ),
             )
             .await
         {

--- a/crates/tandem-core/src/engine_loop/tool_execution.rs
+++ b/crates/tandem-core/src/engine_loop/tool_execution.rs
@@ -468,6 +468,25 @@ impl EngineLoop {
         self.cancellations.remove(session_id).await;
     }
 
+    pub(super) async fn revalidate_session_authority(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<()> {
+        if let Some(hook) = self.tool_policy_hook.read().await.clone() {
+            let verified = self
+                .storage
+                .get_session(session_id)
+                .await
+                .and_then(|session| session.verified_tenant_context);
+            if let Err(error) = hook.revalidate_session(verified).await {
+                self.mark_session_run_failed(session_id, &error.to_string())
+                    .await;
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
     pub(super) async fn workspace_override_active(&self, session_id: &str) -> bool {
         let now = chrono::Utc::now().timestamp_millis().max(0) as u64;
         let mut overrides = self.workspace_overrides.write().await;
@@ -636,6 +655,7 @@ impl EngineLoop {
                 anyhow::bail!(reason);
             }
         };
+        self.revalidate_session_authority(session_id).await?;
         let stream = match self
             .providers
             .stream_with_egress_permit(

--- a/crates/tandem-core/src/engine_loop/types.rs
+++ b/crates/tandem-core/src/engine_loop/types.rs
@@ -155,6 +155,15 @@ pub trait SpawnAgentHook: Send + Sync {
 }
 
 pub trait ToolPolicyHook: Send + Sync {
+    /// Cheap final authority check after waits/approvals, also used for model
+    /// dispatch. Do not create approval requests or repeat the full audit hook.
+    fn revalidate_session(
+        &self,
+        _verified: Option<VerifiedTenantContext>,
+    ) -> BoxFuture<'static, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
     fn evaluate_tool(
         &self,
         ctx: ToolPolicyContext,

--- a/crates/tandem-enterprise-contract/src/hosted_policy.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy.rs
@@ -10,6 +10,13 @@ use crate::VerifiedTenantContext;
 
 mod projection;
 
+/// Reserved ownership namespace for control-plane-managed unit identities.
+pub const HOSTED_TAXONOMY_ID: &str = "hosted-control-plane";
+
+pub fn hosted_unit_principal(unit_id: &str) -> crate::PrincipalRef {
+    crate::PrincipalRef::organization_unit(format!("{HOSTED_TAXONOMY_ID}/{unit_id}"))
+}
+
 pub const MAX_POLICY_BYTES: usize = 4 * 1024 * 1024;
 pub const MAX_POLICY_AGE_MS: u64 = 120_000;
 const FUTURE_SKEW_MS: u64 = 5_000;

--- a/crates/tandem-enterprise-contract/src/hosted_policy.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy.rs
@@ -8,6 +8,8 @@ use sha2::{Digest, Sha256};
 
 use crate::VerifiedTenantContext;
 
+mod projection;
+
 pub const MAX_POLICY_BYTES: usize = 4 * 1024 * 1024;
 pub const MAX_POLICY_AGE_MS: u64 = 120_000;
 const FUTURE_SKEW_MS: u64 = 5_000;

--- a/crates/tandem-enterprise-contract/src/hosted_policy.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy.rs
@@ -9,6 +9,8 @@ use sha2::{Digest, Sha256};
 use crate::VerifiedTenantContext;
 
 mod projection;
+mod registry;
+pub use registry::HostedRegistryProjection;
 
 /// Reserved ownership namespace for control-plane-managed unit identities.
 pub const HOSTED_TAXONOMY_ID: &str = "hosted-control-plane";

--- a/crates/tandem-enterprise-contract/src/hosted_policy.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy.rs
@@ -1,0 +1,339 @@
+//! Hosted control-plane policy input. Transport authentication belongs to the
+//! fetcher; this contract validates a complete snapshot before publication.
+use std::collections::BTreeSet;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::VerifiedTenantContext;
+
+pub const MAX_POLICY_BYTES: usize = 4 * 1024 * 1024;
+pub const MAX_POLICY_AGE_MS: u64 = 120_000;
+const FUTURE_SKEW_MS: u64 = 5_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostedPolicyBundle {
+    pub schema_version: u32,
+    pub policy_version: u64,
+    pub organization_id: String,
+    pub deployment_id: String,
+    pub generated_at: DateTime<Utc>,
+    pub users: Vec<HostedPolicyUser>,
+    pub org_units: Vec<HostedPolicyUnit>,
+    pub org_unit_memberships: Vec<HostedPolicyMembership>,
+    pub deployment_grants: Vec<HostedPolicyGrant>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostedPolicyUser {
+    pub id: String,
+    pub email: Option<String>,
+    pub username: Option<String>,
+    pub role: String,
+    pub capabilities: Vec<String>,
+    pub is_active: bool,
+    pub email_verified: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostedPolicyUnit {
+    pub id: String,
+    pub slug: String,
+    pub display_name: String,
+    pub kind: String,
+    pub state: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostedPolicyMembership {
+    pub unit_id: String,
+    pub user_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostedPolicyGrant {
+    pub id: String,
+    pub deployment_id: Option<String>,
+    pub principal_kind: String,
+    pub principal_id: String,
+    pub resource_kind: String,
+    pub resource_id: String,
+    pub permissions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostedPolicyRevision {
+    pub version: u64,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidatedHostedPolicy {
+    bundle: HostedPolicyBundle,
+    revision: HostedPolicyRevision,
+    expires_at_ms: u64,
+}
+
+fn valid_id(id: &str) -> bool {
+    !id.is_empty() && id.len() <= 160 && id.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'-')
+}
+
+fn unique_ids<'a>(ids: impl Iterator<Item = &'a str>) -> Result<BTreeSet<&'a str>, &'static str> {
+    let mut seen = BTreeSet::new();
+    for id in ids {
+        if !valid_id(id) || !seen.insert(id) {
+            return Err("invalid_or_duplicate_policy_id");
+        }
+    }
+    Ok(seen)
+}
+
+impl HostedPolicyBundle {
+    pub fn from_json(bytes: &[u8]) -> Result<Self, &'static str> {
+        if bytes.len() > MAX_POLICY_BYTES {
+            return Err("hosted_policy_too_large");
+        }
+        serde_json::from_slice(bytes).map_err(|_| "invalid_hosted_policy_json")
+    }
+
+    pub fn validate(
+        mut self,
+        organization_id: &str,
+        deployment_id: &str,
+        now_ms: u64,
+        previous: Option<&HostedPolicyRevision>,
+    ) -> Result<ValidatedHostedPolicy, &'static str> {
+        if self.schema_version != 1 || self.policy_version == 0 {
+            return Err("unsupported_hosted_policy_version");
+        }
+        if self.organization_id != organization_id
+            || self.deployment_id != deployment_id
+            || !valid_id(organization_id)
+            || !valid_id(deployment_id)
+        {
+            return Err("hosted_policy_scope_mismatch");
+        }
+        let generated = u64::try_from(self.generated_at.timestamp_millis())
+            .map_err(|_| "invalid_hosted_policy_time")?;
+        let expires_at_ms = generated
+            .checked_add(MAX_POLICY_AGE_MS)
+            .ok_or("invalid_hosted_policy_time")?;
+        if generated > now_ms.saturating_add(FUTURE_SKEW_MS) || expires_at_ms <= now_ms {
+            return Err("hosted_policy_not_fresh");
+        }
+        let users = unique_ids(self.users.iter().map(|row| row.id.as_str()))?;
+        let units = unique_ids(self.org_units.iter().map(|row| row.id.as_str()))?;
+        unique_ids(self.deployment_grants.iter().map(|row| row.id.as_str()))?;
+        for user in &self.users {
+            if !matches!(user.role.as_str(), "owner" | "admin" | "member" | "viewer")
+                || user
+                    .capabilities
+                    .iter()
+                    .any(|cap| !role_capabilities(&user.role).contains(&cap.as_str()))
+            {
+                return Err("invalid_hosted_user_authority");
+            }
+        }
+        for unit in &self.org_units {
+            if !matches!(unit.state.as_str(), "active" | "archived")
+                || !matches!(
+                    unit.kind.as_str(),
+                    "group" | "department" | "team" | "custom"
+                )
+            {
+                return Err("invalid_hosted_unit");
+            }
+        }
+        let mut memberships = BTreeSet::new();
+        for row in &self.org_unit_memberships {
+            if !users.contains(row.user_id.as_str())
+                || !units.contains(row.unit_id.as_str())
+                || !memberships.insert((&row.unit_id, &row.user_id))
+            {
+                return Err("invalid_hosted_membership");
+            }
+        }
+        for grant in &self.deployment_grants {
+            let principal_exists = match grant.principal_kind.as_str() {
+                "member" => users.contains(grant.principal_id.as_str()),
+                "org_unit" => units.contains(grant.principal_id.as_str()),
+                _ => false,
+            };
+            let expected_resource = grant.deployment_id.as_deref().unwrap_or("*");
+            if !principal_exists
+                || grant.resource_kind != "deployment"
+                || grant.resource_id != expected_resource
+                || grant
+                    .deployment_id
+                    .as_deref()
+                    .is_some_and(|id| id != deployment_id)
+                || grant.permissions.is_empty()
+                || grant.permissions.iter().any(|p| {
+                    !matches!(
+                        p.as_str(),
+                        "hosted.view"
+                            | "hosted.use"
+                            | "hosted.admin"
+                            | "automation.read"
+                            | "automation.execute"
+                            | "automation.write"
+                            | "automation.share"
+                            | "workflow.read"
+                            | "workflow.share"
+                    )
+                })
+            {
+                return Err("invalid_hosted_grant");
+            }
+        }
+        // Authority tables have no API ordering guarantee. Ignore fetch time in
+        // the semantic digest while preserving every authority-bearing field.
+        self.users.sort_by(|a, b| a.id.cmp(&b.id));
+        self.org_units.sort_by(|a, b| a.id.cmp(&b.id));
+        self.org_unit_memberships
+            .sort_by(|a, b| (&a.unit_id, &a.user_id).cmp(&(&b.unit_id, &b.user_id)));
+        self.deployment_grants.sort_by(|a, b| a.id.cmp(&b.id));
+        for user in &mut self.users {
+            user.capabilities.sort();
+            user.capabilities.dedup();
+        }
+        for grant in &mut self.deployment_grants {
+            grant.permissions.sort();
+            grant.permissions.dedup();
+        }
+        let mut semantic = self.clone();
+        for user in &mut semantic.users {
+            user.email = None;
+            user.username = None;
+        }
+        semantic.generated_at =
+            DateTime::from_timestamp_millis(0).ok_or("invalid_hosted_policy_time")?;
+        let bytes = serde_json::to_vec(&semantic).map_err(|_| "invalid_hosted_policy_json")?;
+        let revision = HostedPolicyRevision {
+            version: self.policy_version,
+            digest: format!("{:x}", Sha256::digest(bytes)),
+        };
+        if let Some(previous) = previous {
+            if revision.version < previous.version {
+                return Err("hosted_policy_rollback");
+            }
+            if revision.version == previous.version && revision.digest != previous.digest {
+                return Err("hosted_policy_revision_conflict");
+            }
+        }
+        Ok(ValidatedHostedPolicy {
+            bundle: self,
+            revision,
+            expires_at_ms,
+        })
+    }
+}
+
+pub fn role_capabilities(role: &str) -> Vec<&'static str> {
+    let mut capabilities = vec!["hosted.panel", "hosted.view"];
+    if matches!(role, "member" | "admin" | "owner") {
+        capabilities.extend([
+            "hosted.use",
+            "automation.read",
+            "automation.execute",
+            "workflow.read",
+        ]);
+    }
+    if matches!(role, "admin" | "owner") {
+        capabilities.extend([
+            "hosted.admin",
+            "org.units.manage",
+            "org.invites.manage",
+            "automation.share",
+            "automation.write",
+            "workflow.share",
+        ]);
+    }
+    if role == "owner" {
+        capabilities.push("hosted.owner");
+    }
+    capabilities
+}
+
+impl ValidatedHostedPolicy {
+    pub fn revision(&self) -> &HostedPolicyRevision {
+        &self.revision
+    }
+    pub fn bundle(&self) -> &HostedPolicyBundle {
+        &self.bundle
+    }
+    pub fn expires_at_ms(&self) -> u64 {
+        self.expires_at_ms
+    }
+
+    pub fn authorize_identity(
+        &self,
+        verified: &VerifiedTenantContext,
+        now_ms: u64,
+    ) -> Result<(), &'static str> {
+        if now_ms >= self.expires_at_ms || verified.is_expired_at(now_ms) {
+            return Err("hosted_policy_or_identity_expired");
+        }
+        let tenant = &verified.tenant_context;
+        if tenant.org_id != self.bundle.organization_id
+            || tenant.workspace_id != self.bundle.deployment_id
+            || tenant.deployment_id.as_deref() != Some(self.bundle.deployment_id.as_str())
+            || tenant.actor_id.as_deref() != Some(verified.human_actor.actor_id.as_str())
+        {
+            return Err("hosted_identity_scope_mismatch");
+        }
+        if verified.policy_version != Some(self.revision.version) {
+            return Err("hosted_identity_policy_revision_changed");
+        }
+        let user = self
+            .bundle
+            .users
+            .iter()
+            .find(|row| row.id == verified.human_actor.actor_id)
+            .filter(|row| row.is_active && row.email_verified)
+            .ok_or("hosted_membership_revoked")?;
+        let mut roles = vec![
+            "hosted:panel".to_string(),
+            "hosted:view".to_string(),
+            format!("hosted:role:{}", user.role),
+        ];
+        if matches!(user.role.as_str(), "member" | "admin" | "owner") {
+            roles.push("hosted:use".into());
+        }
+        if matches!(user.role.as_str(), "admin" | "owner") {
+            roles.push("hosted:admin".into());
+        }
+        if user.role == "owner" {
+            roles.push("hosted:owner".into());
+        }
+        if verified.roles.iter().any(|role| !roles.contains(role))
+            || verified
+                .capabilities
+                .iter()
+                .any(|cap| !user.capabilities.contains(cap))
+            || verified.org_units.iter().any(|unit| {
+                !self.bundle.org_unit_memberships.iter().any(|row| {
+                    row.user_id == user.id
+                        && row.unit_id == *unit
+                        && self
+                            .bundle
+                            .org_units
+                            .iter()
+                            .any(|u| u.id == *unit && u.state == "active")
+                })
+            })
+        {
+            return Err("hosted_identity_authority_changed");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tandem-enterprise-contract/src/hosted_policy/projection.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy/projection.rs
@@ -1,0 +1,147 @@
+//! Translate hosted operation grants without manufacturing data or admin ACLs.
+use super::ValidatedHostedPolicy;
+use crate::{
+    AccessPermission, AssertionMetadata, GrantSource, OrganizationUnitMembership,
+    OrganizationUnitMembershipSource, PrincipalRef, ResourceKind, ResourceRef, ResourceScope,
+    ScopedGrant, StrictTenantContext, VerifiedTenantContext,
+};
+
+fn permission(value: &str) -> Option<AccessPermission> {
+    Some(match value {
+        "hosted.view" => AccessPermission::HostedView,
+        "hosted.use" => AccessPermission::HostedUse,
+        "hosted.admin" => AccessPermission::HostedAdmin,
+        "automation.read" => AccessPermission::HostedAutomationRead,
+        "automation.execute" => AccessPermission::HostedAutomationExecute,
+        "automation.write" => AccessPermission::HostedAutomationWrite,
+        "automation.share" => AccessPermission::HostedAutomationShare,
+        "workflow.read" => AccessPermission::HostedWorkflowRead,
+        "workflow.share" => AccessPermission::HostedWorkflowShare,
+        _ => return None,
+    })
+}
+
+impl ValidatedHostedPolicy {
+    pub fn deployment_resource(&self) -> ResourceRef {
+        ResourceRef::new(
+            &self.bundle.organization_id,
+            &self.bundle.deployment_id,
+            ResourceKind::HostedDeployment,
+            &self.bundle.deployment_id,
+        )
+    }
+
+    /// Memberships come from this immutable revision, never a retained local
+    /// copy. Signed unit claims may narrow this set but cannot expand it.
+    pub fn memberships_for_identity(
+        &self,
+        verified: &VerifiedTenantContext,
+        now_ms: u64,
+    ) -> Result<Vec<OrganizationUnitMembership>, &'static str> {
+        self.authorize_identity(verified, now_ms)?;
+        let expires = self.expires_at_ms.min(verified.expires_at_ms);
+        Ok(self
+            .bundle
+            .org_unit_memberships
+            .iter()
+            .filter(|row| {
+                row.user_id == verified.human_actor.actor_id
+                    && verified.org_units.contains(&row.unit_id)
+                    && self
+                        .bundle
+                        .org_units
+                        .iter()
+                        .any(|unit| unit.id == row.unit_id && unit.state == "active")
+            })
+            .map(|row| {
+                OrganizationUnitMembership::active(
+                    format!(
+                        "hosted:{}:{}:{}",
+                        self.bundle.deployment_id, row.unit_id, row.user_id
+                    ),
+                    verified.tenant_context.clone(),
+                    PrincipalRef::organization_unit(&row.unit_id),
+                    PrincipalRef::human_user(&row.user_id),
+                    OrganizationUnitMembershipSource::HostedControlPlane,
+                    self.bundle.generated_at.timestamp_millis() as u64,
+                )
+                .with_expires_at_ms(expires)
+            })
+            .collect())
+    }
+
+    pub fn project_identity(
+        &self,
+        verified: &VerifiedTenantContext,
+        now_ms: u64,
+    ) -> Result<StrictTenantContext, &'static str> {
+        let memberships = self.memberships_for_identity(verified, now_ms)?;
+        let principal = PrincipalRef::human_user(&verified.human_actor.actor_id);
+        let resource = self.deployment_resource();
+        let expires = self.expires_at_ms.min(verified.expires_at_ms);
+        // The control plane signs identity/role capabilities. It does not
+        // supply arbitrary strict grants; those must come from policy stores.
+        let mut grants = vec![ScopedGrant::new(
+            format!("hosted:{}:role:{}", self.bundle.deployment_id, principal.id),
+            principal.clone(),
+            resource.clone(),
+            GrantSource::Direct,
+        )
+        .with_permissions(
+            verified
+                .capabilities
+                .iter()
+                .filter_map(|cap| permission(cap))
+                .collect(),
+        )
+        .with_expires_at_ms(expires)];
+        for grant in &self.bundle.deployment_grants {
+            let source = match grant.principal_kind.as_str() {
+                "member" if grant.principal_id == principal.id => None,
+                "org_unit"
+                    if memberships
+                        .iter()
+                        .any(|row| row.unit.id == grant.principal_id) =>
+                {
+                    Some(PrincipalRef::organization_unit(&grant.principal_id))
+                }
+                _ => continue,
+            };
+            let mut projected = ScopedGrant::new(
+                format!("hosted:{}:grant:{}", self.bundle.deployment_id, grant.id),
+                principal.clone(),
+                resource.clone(),
+                if source.is_some() {
+                    GrantSource::OrganizationUnitMembership
+                } else {
+                    GrantSource::Direct
+                },
+            )
+            .with_permissions(
+                grant
+                    .permissions
+                    .iter()
+                    .filter_map(|p| permission(p))
+                    .collect(),
+            )
+            .with_expires_at_ms(expires);
+            projected.source_principal = source;
+            grants.push(projected);
+        }
+        let mut assertion = AssertionMetadata::from(verified);
+        assertion.expires_at_ms = expires;
+        Ok(StrictTenantContext::new(
+            verified.tenant_context.clone(),
+            principal,
+            verified.authority_chain.clone(),
+            ResourceScope::root(ResourceRef::new(
+                &self.bundle.organization_id,
+                &self.bundle.deployment_id,
+                ResourceKind::Workspace,
+                &self.bundle.deployment_id,
+            )),
+            assertion,
+        )
+        .with_grants(grants))
+    }
+}

--- a/crates/tandem-enterprise-contract/src/hosted_policy/projection.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy/projection.rs
@@ -1,5 +1,5 @@
 //! Translate hosted operation grants without manufacturing data or admin ACLs.
-use super::ValidatedHostedPolicy;
+use super::{hosted_unit_principal, ValidatedHostedPolicy};
 use crate::{
     AccessPermission, AssertionMetadata, DataClass, GrantSource, OrganizationUnitMembership,
     OrganizationUnitMembershipSource, PrincipalRef, ResourceKind, ResourceRef, ResourceScope,
@@ -60,7 +60,7 @@ impl ValidatedHostedPolicy {
                         self.bundle.deployment_id, row.unit_id, row.user_id
                     ),
                     verified.tenant_context.clone(),
-                    PrincipalRef::organization_unit(&row.unit_id),
+                    hosted_unit_principal(&row.unit_id),
                     PrincipalRef::human_user(&row.user_id),
                     OrganizationUnitMembershipSource::HostedControlPlane,
                     self.bundle.generated_at.timestamp_millis() as u64,
@@ -102,9 +102,9 @@ impl ValidatedHostedPolicy {
                 "org_unit"
                     if memberships
                         .iter()
-                        .any(|row| row.unit.id == grant.principal_id) =>
+                        .any(|row| row.unit == hosted_unit_principal(&grant.principal_id)) =>
                 {
-                    Some(PrincipalRef::organization_unit(&grant.principal_id))
+                    Some(hosted_unit_principal(&grant.principal_id))
                 }
                 _ => continue,
             };

--- a/crates/tandem-enterprise-contract/src/hosted_policy/projection.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy/projection.rs
@@ -1,7 +1,7 @@
 //! Translate hosted operation grants without manufacturing data or admin ACLs.
 use super::ValidatedHostedPolicy;
 use crate::{
-    AccessPermission, AssertionMetadata, GrantSource, OrganizationUnitMembership,
+    AccessPermission, AssertionMetadata, DataClass, GrantSource, OrganizationUnitMembership,
     OrganizationUnitMembershipSource, PrincipalRef, ResourceKind, ResourceRef, ResourceScope,
     ScopedGrant, StrictTenantContext, VerifiedTenantContext,
 };
@@ -94,6 +94,7 @@ impl ValidatedHostedPolicy {
                 .filter_map(|cap| permission(cap))
                 .collect(),
         )
+        .with_data_classes(vec![DataClass::Internal])
         .with_expires_at_ms(expires)];
         for grant in &self.bundle.deployment_grants {
             let source = match grant.principal_kind.as_str() {
@@ -124,6 +125,7 @@ impl ValidatedHostedPolicy {
                     .filter_map(|p| permission(p))
                     .collect(),
             )
+            .with_data_classes(vec![DataClass::Internal])
             .with_expires_at_ms(expires);
             projected.source_principal = source;
             grants.push(projected);

--- a/crates/tandem-enterprise-contract/src/hosted_policy/projection.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy/projection.rs
@@ -6,7 +6,7 @@ use crate::{
     ScopedGrant, StrictTenantContext, VerifiedTenantContext,
 };
 
-fn permission(value: &str) -> Option<AccessPermission> {
+pub(super) fn permission(value: &str) -> Option<AccessPermission> {
     Some(match value {
         "hosted.view" => AccessPermission::HostedView,
         "hosted.use" => AccessPermission::HostedUse,

--- a/crates/tandem-enterprise-contract/src/hosted_policy/registry.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy/registry.rs
@@ -1,0 +1,121 @@
+//! Ephemeral registry projection. Its sole owner is the accepted control-plane
+//! snapshot; callers must never persist these rows into locally authored stores.
+use super::{
+    hosted_unit_principal, projection::permission, ValidatedHostedPolicy, HOSTED_TAXONOMY_ID,
+};
+use crate::{
+    DataClass, OrganizationUnit, OrganizationUnitAccessGrant, OrganizationUnitKind,
+    OrganizationUnitMembership, OrganizationUnitMembershipSource, OrganizationUnitState,
+    PrincipalKind, PrincipalRef, TenantContext,
+};
+
+pub struct HostedRegistryProjection {
+    pub units: Vec<OrganizationUnit>,
+    pub memberships: Vec<OrganizationUnitMembership>,
+    pub access_grants: Vec<OrganizationUnitAccessGrant>,
+}
+
+impl ValidatedHostedPolicy {
+    pub fn registry_projection(
+        &self,
+        now_ms: u64,
+    ) -> Result<HostedRegistryProjection, &'static str> {
+        if now_ms >= self.expires_at_ms {
+            return Err("hosted_policy_not_fresh");
+        }
+        let tenant = TenantContext::explicit_user_workspace(
+            &self.bundle.organization_id,
+            &self.bundle.deployment_id,
+            Some(self.bundle.deployment_id.clone()),
+            "hosted-policy-agent",
+        );
+        let generated = self.bundle.generated_at.timestamp_millis() as u64;
+        let units = self
+            .bundle
+            .org_units
+            .iter()
+            .map(|row| {
+                let kind = match row.kind.as_str() {
+                    "department" => OrganizationUnitKind::Department,
+                    "team" => OrganizationUnitKind::Team,
+                    _ => OrganizationUnitKind::Custom,
+                };
+                OrganizationUnit::active(
+                    &row.id,
+                    tenant.clone(),
+                    &row.display_name,
+                    kind,
+                    PrincipalRef::new(PrincipalKind::ServiceAccount, "hosted-policy-agent"),
+                    generated,
+                )
+                .with_taxonomy_id(HOSTED_TAXONOMY_ID)
+                .with_state(
+                    if row.state == "active" {
+                        OrganizationUnitState::Active
+                    } else {
+                        OrganizationUnitState::Disabled
+                    },
+                    generated,
+                )
+            })
+            .collect();
+        let memberships =
+            self.bundle
+                .org_unit_memberships
+                .iter()
+                .map(|row| {
+                    let active = self.bundle.users.iter().any(|user| {
+                        user.id == row.user_id && user.is_active && user.email_verified
+                    }) && self
+                        .bundle
+                        .org_units
+                        .iter()
+                        .any(|unit| unit.id == row.unit_id && unit.state == "active");
+                    let mut membership = OrganizationUnitMembership::active(
+                        format!(
+                            "hosted:{}:{}:{}",
+                            self.bundle.deployment_id, row.unit_id, row.user_id
+                        ),
+                        tenant.clone(),
+                        hosted_unit_principal(&row.unit_id),
+                        PrincipalRef::human_user(&row.user_id),
+                        OrganizationUnitMembershipSource::HostedControlPlane,
+                        generated,
+                    )
+                    .with_expires_at_ms(self.expires_at_ms);
+                    if !active {
+                        membership.state = OrganizationUnitState::Disabled;
+                    }
+                    membership
+                })
+                .collect();
+        let access_grants = self
+            .bundle
+            .deployment_grants
+            .iter()
+            .filter(|row| row.principal_kind == "org_unit")
+            .map(|row| {
+                OrganizationUnitAccessGrant::active(
+                    format!("hosted:{}:grant:{}", self.bundle.deployment_id, row.id),
+                    tenant.clone(),
+                    hosted_unit_principal(&row.principal_id),
+                    self.deployment_resource(),
+                    generated,
+                )
+                .with_permissions(
+                    row.permissions
+                        .iter()
+                        .filter_map(|p| permission(p))
+                        .collect(),
+                )
+                .with_data_classes(vec![DataClass::Internal])
+                .with_expires_at_ms(self.expires_at_ms)
+            })
+            .collect();
+        Ok(HostedRegistryProjection {
+            units,
+            memberships,
+            access_grants,
+        })
+    }
+}

--- a/crates/tandem-enterprise-contract/src/hosted_policy/tests.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy/tests.rs
@@ -1,0 +1,184 @@
+use super::*;
+use crate::{
+    AuthorityChain, HumanActor, RequestPrincipal, TenantContext, TenantContextAssertionClaims,
+};
+
+const NOW: u64 = 1_800_000_000_000;
+
+fn bundle() -> HostedPolicyBundle {
+    HostedPolicyBundle::from_json(serde_json::json!({
+        "schema_version": 1, "policy_version": 4,
+        "organization_id": "org-a", "deployment_id": "dep-a",
+        "generated_at": DateTime::from_timestamp_millis(NOW as i64).unwrap(),
+        "users": [{"id": "alice", "email": "alice@example.com", "username": "alice",
+            "role": "member", "is_active": true, "email_verified": true,
+            "capabilities": ["hosted.panel", "hosted.view", "hosted.use"]},
+            {"id": "bob", "email": null, "username": null, "role": "viewer",
+            "is_active": true, "email_verified": true, "capabilities": ["hosted.panel", "hosted.view"]}],
+        "org_units": [{"id": "eng", "slug": "eng", "display_name": "Engineering", "kind": "department", "state": "active"}],
+        "org_unit_memberships": [{"unit_id": "eng", "user_id": "alice"}],
+        "deployment_grants": [{"id": "grant-a", "deployment_id": "dep-a", "principal_kind": "org_unit",
+            "principal_id": "eng", "resource_kind": "deployment", "resource_id": "dep-a", "permissions": ["hosted.use"]}]
+    }).to_string().as_bytes()).unwrap()
+}
+
+fn identity() -> VerifiedTenantContext {
+    let mut claims = TenantContextAssertionClaims::new_v1(
+        "tandem-web",
+        "tandem-runtime",
+        NOW,
+        NOW + 300_000,
+        "assertion-a",
+        TenantContext::explicit_user_workspace("org-a", "dep-a", Some("dep-a".into()), "alice"),
+        HumanActor::tandem_user("alice"),
+        AuthorityChain::from_request(RequestPrincipal::authenticated_user("alice", "tandem-web")),
+        vec!["hosted:role:member".into(), "hosted:use".into()],
+    );
+    claims.policy_version = Some(4);
+    claims.org_units = vec!["eng".into()];
+    claims.capabilities = vec!["hosted.use".into()];
+    claims.into()
+}
+
+#[test]
+fn validates_real_shaped_bundle_and_current_identity() {
+    let policy = bundle().validate("org-a", "dep-a", NOW, None).unwrap();
+    assert_eq!(policy.revision().version, 4);
+    assert_eq!(policy.expires_at_ms(), NOW + MAX_POLICY_AGE_MS);
+    assert_eq!(policy.authorize_identity(&identity(), NOW), Ok(()));
+    assert!(policy
+        .authorize_identity(&identity(), NOW + MAX_POLICY_AGE_MS)
+        .is_err());
+}
+
+#[test]
+fn rejects_wrong_scope_schema_and_freshness() {
+    assert!(bundle().validate("org-b", "dep-a", NOW, None).is_err());
+    assert!(bundle().validate("org-a", "dep-b", NOW, None).is_err());
+    assert!(bundle()
+        .validate("org-a", "dep-a", NOW + MAX_POLICY_AGE_MS, None)
+        .is_err());
+    assert!(bundle()
+        .validate("org-a", "dep-a", NOW - FUTURE_SKEW_MS - 1, None)
+        .is_err());
+    let mut value = bundle();
+    value.schema_version = 2;
+    assert!(value.validate("org-a", "dep-a", NOW, None).is_err());
+    let mut value = bundle();
+    value.policy_version = 0;
+    assert!(value.validate("org-a", "dep-a", NOW, None).is_err());
+    assert!(HostedPolicyBundle::from_json(&vec![b' '; MAX_POLICY_BYTES + 1]).is_err());
+}
+
+#[test]
+fn rejects_rollback_and_conflicting_equal_revision_but_accepts_fresh_refetch() {
+    let previous = bundle().validate("org-a", "dep-a", NOW, None).unwrap();
+    let mut next = bundle();
+    next.generated_at += chrono::Duration::seconds(20);
+    next.users.reverse();
+    next.users[0].email = Some("changed-profile@example.com".into());
+    assert_eq!(
+        next.validate("org-a", "dep-a", NOW + 20_000, Some(previous.revision()))
+            .unwrap()
+            .revision(),
+        previous.revision()
+    );
+    let mut next = bundle();
+    next.policy_version = 3;
+    assert_eq!(
+        next.validate("org-a", "dep-a", NOW, Some(previous.revision()))
+            .unwrap_err(),
+        "hosted_policy_rollback"
+    );
+    let mut next = bundle();
+    next.users[0].role = "admin".into();
+    assert_eq!(
+        next.validate("org-a", "dep-a", NOW, Some(previous.revision()))
+            .unwrap_err(),
+        "hosted_policy_revision_conflict"
+    );
+}
+
+#[test]
+fn removing_and_reinviting_cannot_restore_an_old_assertion() {
+    let old_identity = identity();
+    let mut removed = bundle();
+    removed.policy_version += 1;
+    removed.users.remove(0);
+    removed.org_unit_memberships.clear();
+    let policy = removed.validate("org-a", "dep-a", NOW, None).unwrap();
+    assert!(policy.authorize_identity(&old_identity, NOW).is_err());
+    let mut reinvited = bundle();
+    reinvited.policy_version += 2;
+    let policy = reinvited
+        .validate("org-a", "dep-a", NOW, Some(policy.revision()))
+        .unwrap();
+    assert!(policy.authorize_identity(&old_identity, NOW).is_err());
+    let mut fresh = old_identity;
+    fresh.policy_version = Some(6);
+    assert_eq!(policy.authorize_identity(&fresh, NOW), Ok(()));
+}
+
+#[test]
+fn rejects_elevated_role_capability_and_archived_unit() {
+    let policy = bundle().validate("org-a", "dep-a", NOW, None).unwrap();
+    let mut claims = identity();
+    claims.roles.push("hosted:admin".into());
+    assert!(policy.authorize_identity(&claims, NOW).is_err());
+    let mut claims = identity();
+    claims.capabilities.push("deployment.admin".into());
+    assert!(policy.authorize_identity(&claims, NOW).is_err());
+    let mut value = bundle();
+    value.org_units[0].state = "archived".into();
+    assert!(value
+        .validate("org-a", "dep-a", NOW, None)
+        .unwrap()
+        .authorize_identity(&identity(), NOW)
+        .is_err());
+    let mut value = bundle();
+    value.users[0].capabilities.push("deployment.admin".into());
+    assert!(value.validate("org-a", "dep-a", NOW, None).is_err());
+}
+
+#[test]
+fn rejects_inactive_unverified_missing_or_cross_tenant_human() {
+    for unverified in [false, true] {
+        let mut value = bundle();
+        if unverified {
+            value.users[0].email_verified = false;
+        } else {
+            value.users[0].is_active = false;
+        }
+        assert!(value
+            .validate("org-a", "dep-a", NOW, None)
+            .unwrap()
+            .authorize_identity(&identity(), NOW)
+            .is_err());
+    }
+    let policy = bundle().validate("org-a", "dep-a", NOW, None).unwrap();
+    let mut claims = identity();
+    claims.human_actor.actor_id = "bob".into();
+    assert!(policy.authorize_identity(&claims, NOW).is_err());
+    let mut claims = identity();
+    claims.tenant_context.org_id = "org-b".into();
+    assert!(policy.authorize_identity(&claims, NOW).is_err());
+    let mut claims = identity();
+    claims.policy_version = None;
+    assert!(policy.authorize_identity(&claims, NOW).is_err());
+}
+
+#[test]
+fn rejects_orphan_duplicate_and_cross_deployment_authority() {
+    let mut value = bundle();
+    value.users.push(value.users[0].clone());
+    assert!(value.validate("org-a", "dep-a", NOW, None).is_err());
+    let mut value = bundle();
+    value.org_unit_memberships[0].user_id = "missing".into();
+    assert!(value.validate("org-a", "dep-a", NOW, None).is_err());
+    let mut value = bundle();
+    value.deployment_grants[0].deployment_id = Some("dep-b".into());
+    assert!(value.validate("org-a", "dep-a", NOW, None).is_err());
+    let mut value = bundle();
+    value.deployment_grants[0].permissions = vec!["root".into()];
+    assert!(value.validate("org-a", "dep-a", NOW, None).is_err());
+}

--- a/crates/tandem-enterprise-contract/src/hosted_policy/tests.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy/tests.rs
@@ -6,6 +6,52 @@ use crate::{
 const NOW: u64 = 1_800_000_000_000;
 
 #[test]
+fn hosted_policy_membership_uses_existing_enterprise_taxonomy_identity() {
+    use crate::{
+        AccessPermission, OrganizationUnit, OrganizationUnitAccessGrant, OrganizationUnitKind,
+        PrincipalRef, ResourceKind, ResourceRef,
+    };
+    let verified = identity();
+    let policy = bundle().validate("org-a", "dep-a", NOW, None).unwrap();
+    let unit = OrganizationUnit::active(
+        "eng",
+        verified.tenant_context.clone(),
+        "Engineering",
+        OrganizationUnitKind::Department,
+        PrincipalRef::human_user("operator"),
+        NOW,
+    )
+    .with_taxonomy_id(HOSTED_TAXONOMY_ID);
+    let membership = policy
+        .memberships_for_identity(&verified, NOW)
+        .unwrap()
+        .remove(0);
+    assert_eq!(membership.unit, unit.principal_ref());
+    let grant = OrganizationUnitAccessGrant::active(
+        "native-grant",
+        verified.tenant_context.clone(),
+        unit.principal_ref(),
+        ResourceRef::new(
+            "org-a",
+            "dep-a",
+            ResourceKind::Document,
+            "engineering-document",
+        ),
+        NOW,
+    )
+    .with_permissions(vec![AccessPermission::Read]);
+    assert!(grant
+        .to_scoped_grant_for_membership(&membership, NOW)
+        .is_some());
+    assert!(policy
+        .project_identity(&verified, NOW)
+        .unwrap()
+        .grants
+        .iter()
+        .any(|grant| grant.source_principal.as_ref() == Some(&unit.principal_ref())));
+}
+
+#[test]
 fn hosted_policy_projection_does_not_confer_data_or_generic_administration() {
     use crate::{AccessDecision, AccessPermission, DataClass, ResourceKind, ResourceRef};
     let mut input = bundle();

--- a/crates/tandem-enterprise-contract/src/hosted_policy/tests.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy/tests.rs
@@ -5,6 +5,126 @@ use crate::{
 
 const NOW: u64 = 1_800_000_000_000;
 
+#[test]
+fn hosted_policy_projection_does_not_confer_data_or_generic_administration() {
+    use crate::{AccessDecision, AccessPermission, DataClass, ResourceKind, ResourceRef};
+    let mut input = bundle();
+    input.deployment_grants[0].permissions = vec!["hosted.admin".into(), "automation.write".into()];
+    let policy = input.validate("org-a", "dep-a", NOW, None).unwrap();
+    let projection = policy.project_identity(&identity(), NOW).unwrap();
+    for permission in [
+        AccessPermission::HostedUse,
+        AccessPermission::HostedAdmin,
+        AccessPermission::HostedAutomationWrite,
+    ] {
+        assert_eq!(
+            projection
+                .evaluate_access(
+                    &policy.deployment_resource(),
+                    permission,
+                    DataClass::Internal,
+                    NOW
+                )
+                .decision,
+            AccessDecision::Allow
+        );
+    }
+    let document = ResourceRef::new("org-a", "dep-a", ResourceKind::Document, "private-bob");
+    for permission in [
+        AccessPermission::View,
+        AccessPermission::Read,
+        AccessPermission::Edit,
+        AccessPermission::Execute,
+        AccessPermission::Admin,
+        AccessPermission::Delegate,
+    ] {
+        assert!(!projection.has_permission(permission));
+        assert_ne!(
+            projection
+                .evaluate_access(&document, permission, DataClass::Internal, NOW)
+                .decision,
+            AccessDecision::Allow
+        );
+    }
+    assert_ne!(
+        projection
+            .evaluate_access(
+                &document,
+                AccessPermission::HostedAdmin,
+                DataClass::Internal,
+                NOW
+            )
+            .decision,
+        AccessDecision::Allow
+    );
+    assert_eq!(projection.assertion.expires_at_ms, NOW + MAX_POLICY_AGE_MS);
+    assert!(policy
+        .project_identity(&identity(), NOW + MAX_POLICY_AGE_MS)
+        .is_err());
+}
+
+#[test]
+fn hosted_policy_projection_replaces_supplied_grants_and_removed_memberships() {
+    use crate::{AccessPermission, GrantSource, PrincipalRef, ScopedGrant};
+    let policy = bundle().validate("org-a", "dep-a", NOW, None).unwrap();
+    let mut verified = identity();
+    let mut supplied = policy.project_identity(&verified, NOW).unwrap();
+    supplied.grants.push(
+        ScopedGrant::new(
+            "injected-admin",
+            PrincipalRef::human_user("alice"),
+            policy.deployment_resource(),
+            GrantSource::Direct,
+        )
+        .with_permissions(vec![AccessPermission::Admin]),
+    );
+    verified.strict_projection = Some(supplied);
+    assert!(!policy
+        .project_identity(&verified, NOW)
+        .unwrap()
+        .has_permission(AccessPermission::Admin));
+    assert_eq!(
+        policy
+            .memberships_for_identity(&verified, NOW)
+            .unwrap()
+            .len(),
+        1
+    );
+    let mut next = bundle();
+    next.policy_version += 1;
+    next.org_unit_memberships.clear();
+    let next = next
+        .validate("org-a", "dep-a", NOW, Some(policy.revision()))
+        .unwrap();
+    assert!(next.project_identity(&verified, NOW).is_err());
+    verified.policy_version = Some(5);
+    verified.org_units.clear();
+    assert!(next
+        .memberships_for_identity(&verified, NOW)
+        .unwrap()
+        .is_empty());
+    assert!(next
+        .project_identity(&verified, NOW)
+        .unwrap()
+        .grants
+        .iter()
+        .all(|grant| grant.source_principal.is_none()));
+}
+
+#[test]
+fn hosted_policy_projection_cannot_share_another_members_direct_grant() {
+    use crate::AccessPermission;
+    let mut input = bundle();
+    input.deployment_grants[0].principal_kind = "member".into();
+    input.deployment_grants[0].principal_id = "bob".into();
+    input.deployment_grants[0].permissions = vec!["hosted.admin".into()];
+    let policy = input.validate("org-a", "dep-a", NOW, None).unwrap();
+    assert!(!policy
+        .project_identity(&identity(), NOW)
+        .unwrap()
+        .has_permission(AccessPermission::HostedAdmin));
+}
+
 fn bundle() -> HostedPolicyBundle {
     HostedPolicyBundle::from_json(serde_json::json!({
         "schema_version": 1, "policy_version": 4,

--- a/crates/tandem-enterprise-contract/src/hosted_policy/tests.rs
+++ b/crates/tandem-enterprise-contract/src/hosted_policy/tests.rs
@@ -6,6 +6,66 @@ use crate::{
 const NOW: u64 = 1_800_000_000_000;
 
 #[test]
+fn hosted_policy_registry_rows_follow_one_revision_and_expire() {
+    use crate::{OrganizationUnitMembershipSource, OrganizationUnitState, ResourceKind};
+    let mut input = bundle();
+    let accepted = input.clone().validate("org-a", "dep-a", NOW, None).unwrap();
+    let view = accepted.registry_projection(NOW).unwrap();
+    assert_eq!(view.units.len(), 1);
+    assert_eq!(view.memberships.len(), 1);
+    assert_eq!(view.access_grants.len(), 1);
+    assert_eq!(view.units[0].principal_ref(), view.memberships[0].unit);
+    assert_eq!(view.access_grants[0].unit, view.memberships[0].unit);
+    assert_eq!(
+        view.memberships[0].source,
+        OrganizationUnitMembershipSource::HostedControlPlane
+    );
+    assert_eq!(
+        view.access_grants[0].resource.resource_kind,
+        ResourceKind::HostedDeployment
+    );
+    assert!(view.access_grants[0]
+        .to_scoped_grant_for_membership(&view.memberships[0], NOW)
+        .is_some());
+    assert!(accepted
+        .registry_projection(NOW + MAX_POLICY_AGE_MS)
+        .is_err());
+    input.policy_version += 1;
+    input.users[0].is_active = false;
+    let disabled = input
+        .clone()
+        .validate("org-a", "dep-a", NOW, None)
+        .unwrap()
+        .registry_projection(NOW)
+        .unwrap();
+    assert_eq!(
+        disabled.memberships[0].state,
+        OrganizationUnitState::Disabled
+    );
+    assert!(disabled.access_grants[0]
+        .to_scoped_grant_for_membership(&disabled.memberships[0], NOW)
+        .is_none());
+    input.org_unit_memberships.clear();
+    input.deployment_grants.clear();
+    input.org_units.clear();
+    let removed = input
+        .validate("org-a", "dep-a", NOW, None)
+        .unwrap()
+        .registry_projection(NOW)
+        .unwrap();
+    assert!(
+        removed.units.is_empty()
+            && removed.memberships.is_empty()
+            && removed.access_grants.is_empty()
+    );
+    // Previously captured data has no ownership over the accepted revision.
+    assert_eq!(
+        accepted.registry_projection(NOW).unwrap().memberships.len(),
+        1
+    );
+}
+
+#[test]
 fn hosted_policy_membership_uses_existing_enterprise_taxonomy_identity() {
     use crate::{
         AccessPermission, OrganizationUnit, OrganizationUnitAccessGrant, OrganizationUnitKind,

--- a/crates/tandem-enterprise-contract/src/lib.rs
+++ b/crates/tandem-enterprise-contract/src/lib.rs
@@ -227,6 +227,8 @@ pub fn enterprise_scope_ids_match(left: &str, right: &str) -> bool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResourceKind {
+    /// Hosted operation surface; never an ancestor of tenant data resources.
+    HostedDeployment,
     Organization,
     Workspace,
     OrganizationUnit,
@@ -465,6 +467,15 @@ impl ResourceScope {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AccessPermission {
+    HostedView,
+    HostedUse,
+    HostedAdmin,
+    HostedAutomationRead,
+    HostedAutomationExecute,
+    HostedAutomationWrite,
+    HostedAutomationShare,
+    HostedWorkflowRead,
+    HostedWorkflowShare,
     View,
     Read,
     Edit,

--- a/crates/tandem-enterprise-contract/src/lib.rs
+++ b/crates/tandem-enterprise-contract/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cross_tenant;
 mod delegation;
 pub use delegation::*;
 pub mod governance;
+pub mod hosted_policy;
 pub mod policy_inheritance;
 pub mod policy_predicates;
 pub mod policy_templates;

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs
@@ -16,7 +16,7 @@ use tandem_enterprise_contract::{
 };
 
 use tandem_server::automation_v2::governance::GovernanceApprovalStatus;
-use tandem_server::AppState;
+use tandem_server::{now_ms, AppState};
 
 use super::routes_enterprise::{
     ingestion_quarantine_tenant_matches, storage_base, validate_enterprise_id,
@@ -223,45 +223,13 @@ async fn get_enterprise_readiness(
 ) -> EnterpriseResult<EnterpriseReadinessResponse> {
     require_enterprise_read_access(&request_principal, verified_tenant_context.as_deref())?;
 
-    let org_units = state
-        .enterprise
-        .org_units
-        .read()
+    let view = state
+        .enterprise_org_unit_view(&tenant_context)
         .await
-        .values()
-        .filter(|unit| {
-            unit.tenant_context.org_id == tenant_context.org_id
-                && unit.tenant_context.workspace_id == tenant_context.workspace_id
-                && unit.tenant_context.deployment_id == tenant_context.deployment_id
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    let memberships = state
-        .enterprise
-        .org_unit_memberships
-        .read()
-        .await
-        .values()
-        .filter(|membership| {
-            membership.tenant_context.org_id == tenant_context.org_id
-                && membership.tenant_context.workspace_id == tenant_context.workspace_id
-                && membership.tenant_context.deployment_id == tenant_context.deployment_id
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    let grants = state
-        .enterprise
-        .org_unit_access_grants
-        .read()
-        .await
-        .values()
-        .filter(|grant| {
-            grant.tenant_context.org_id == tenant_context.org_id
-                && grant.tenant_context.workspace_id == tenant_context.workspace_id
-                && grant.tenant_context.deployment_id == tenant_context.deployment_id
-        })
-        .cloned()
-        .collect::<Vec<_>>();
+        .map_err(super::routes_enterprise_org_units::registry_error)?;
+    let org_units = view.units;
+    let memberships = view.memberships;
+    let grants = view.access_grants;
     let connectors = state
         .enterprise
         .connectors
@@ -323,6 +291,15 @@ async fn get_enterprise_readiness(
         .iter()
         .filter(|unit| unit.state == OrganizationUnitState::Active)
         .count();
+    // Deployment operation permissions do not establish governed data access.
+    let has_data_membership_grant = memberships.iter().any(|membership| {
+        grants.iter().any(|grant| {
+            grant.resource.resource_kind != ResourceKind::HostedDeployment
+                && grant
+                    .to_scoped_grant_for_membership(membership, now_ms())
+                    .is_some()
+        })
+    });
     let active_connectors = connectors
         .iter()
         .filter(|connector| connector.state == ConnectorLifecycleState::Active)
@@ -348,7 +325,7 @@ async fn get_enterprise_readiness(
         ),
         readiness_check(
             "governance_skeleton",
-            if active_org_units > 0 && !memberships.is_empty() && !grants.is_empty() {
+            if active_org_units > 0 && has_data_membership_grant {
                 "ready"
             } else {
                 "attention"

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs
@@ -11,10 +11,10 @@ use axum::Router;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tandem_enterprise_contract::{
-    AccessEffect, AccessPermission, DataClass, OrganizationUnit, OrganizationUnitAccessGrant,
-    OrganizationUnitKind, OrganizationUnitMembership, OrganizationUnitMembershipSource,
-    OrganizationUnitState, PrincipalKind, PrincipalRef, RequestPrincipal, ResourceKind,
-    ResourceRef, ScopedGrant, TenantContext, VerifiedTenantContext,
+    hosted_policy::HOSTED_TAXONOMY_ID, AccessEffect, AccessPermission, DataClass, OrganizationUnit,
+    OrganizationUnitAccessGrant, OrganizationUnitKind, OrganizationUnitMembership,
+    OrganizationUnitMembershipSource, OrganizationUnitState, PrincipalKind, PrincipalRef,
+    RequestPrincipal, ResourceKind, ResourceRef, ScopedGrant, TenantContext, VerifiedTenantContext,
 };
 
 use tandem_server::{now_ms, AppState};
@@ -144,6 +144,43 @@ fn default_member_kind() -> PrincipalKind {
     PrincipalKind::HumanUser
 }
 
+pub(super) fn registry_error(reason: &'static str) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "code": "ENTERPRISE_HOSTED_REGISTRY_UNAVAILABLE", "reason": reason,
+        })),
+    )
+}
+
+fn require_local_registry_owner(
+    taxonomy: &str,
+    source: Option<OrganizationUnitMembershipSource>,
+) -> Result<(), (StatusCode, Json<Value>)> {
+    if taxonomy == HOSTED_TAXONOMY_ID
+        || source == Some(OrganizationUnitMembershipSource::HostedControlPlane)
+    {
+        return Err(bad_request("ENTERPRISE_HOSTED_REGISTRY_READ_ONLY"));
+    }
+    Ok(())
+}
+
+#[test]
+fn hosted_policy_registry_ownership_cannot_be_claimed_by_local_authoring() {
+    assert!(require_local_registry_owner("organization_unit", None).is_ok());
+    assert!(require_local_registry_owner(
+        "organization_unit",
+        Some(OrganizationUnitMembershipSource::Scim)
+    )
+    .is_ok());
+    assert!(require_local_registry_owner(HOSTED_TAXONOMY_ID, None).is_err());
+    assert!(require_local_registry_owner(
+        "organization_unit",
+        Some(OrganizationUnitMembershipSource::HostedControlPlane)
+    )
+    .is_err());
+}
+
 pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
     router
         .route(
@@ -176,43 +213,35 @@ pub(super) async fn list_org_units(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
     Extension(request_principal): Extension<RequestPrincipal>,
-) -> Json<EnterpriseOrgUnitsResponse> {
-    let mut org_units: Vec<_> = state
-        .enterprise
-        .org_units
-        .read()
+) -> EnterpriseResult<EnterpriseOrgUnitsResponse> {
+    let mut org_units = state
+        .enterprise_org_unit_view(&tenant_context)
         .await
-        .values()
-        .filter(|unit| organization_unit_tenant_matches(unit, &tenant_context))
-        .cloned()
-        .collect();
+        .map_err(registry_error)?
+        .units;
     org_units.sort_by(|left, right| {
         left.taxonomy_id
             .cmp(&right.taxonomy_id)
             .then_with(|| left.unit_id.cmp(&right.unit_id))
     });
 
-    Json(EnterpriseOrgUnitsResponse {
+    Ok(Json(EnterpriseOrgUnitsResponse {
         base: storage_base(tenant_context, request_principal),
         count: org_units.len(),
         org_units,
-    })
+    }))
 }
 
 pub(super) async fn list_org_unit_memberships(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
     Extension(request_principal): Extension<RequestPrincipal>,
-) -> Json<EnterpriseOrgUnitMembershipsResponse> {
-    let mut memberships: Vec<_> = state
-        .enterprise
-        .org_unit_memberships
-        .read()
+) -> EnterpriseResult<EnterpriseOrgUnitMembershipsResponse> {
+    let mut memberships = state
+        .enterprise_org_unit_view(&tenant_context)
         .await
-        .values()
-        .filter(|membership| org_unit_membership_tenant_matches(membership, &tenant_context))
-        .cloned()
-        .collect();
+        .map_err(registry_error)?
+        .memberships;
     memberships.sort_by(|left, right| {
         left.unit
             .id
@@ -221,27 +250,23 @@ pub(super) async fn list_org_unit_memberships(
             .then_with(|| left.membership_id.cmp(&right.membership_id))
     });
 
-    Json(EnterpriseOrgUnitMembershipsResponse {
+    Ok(Json(EnterpriseOrgUnitMembershipsResponse {
         base: storage_base(tenant_context, request_principal),
         count: memberships.len(),
         memberships,
-    })
+    }))
 }
 
 pub(super) async fn list_org_unit_access_grants(
     State(state): State<AppState>,
     Extension(tenant_context): Extension<TenantContext>,
     Extension(request_principal): Extension<RequestPrincipal>,
-) -> Json<EnterpriseOrgUnitAccessGrantsResponse> {
-    let mut access_grants: Vec<_> = state
-        .enterprise
-        .org_unit_access_grants
-        .read()
+) -> EnterpriseResult<EnterpriseOrgUnitAccessGrantsResponse> {
+    let mut access_grants = state
+        .enterprise_org_unit_view(&tenant_context)
         .await
-        .values()
-        .filter(|grant| org_unit_access_grant_tenant_matches(grant, &tenant_context))
-        .cloned()
-        .collect();
+        .map_err(registry_error)?
+        .access_grants;
     access_grants.sort_by(|left, right| {
         left.unit
             .id
@@ -250,11 +275,11 @@ pub(super) async fn list_org_unit_access_grants(
             .then_with(|| left.grant_id.cmp(&right.grant_id))
     });
 
-    Json(EnterpriseOrgUnitAccessGrantsResponse {
+    Ok(Json(EnterpriseOrgUnitAccessGrantsResponse {
         base: storage_base(tenant_context, request_principal),
         count: access_grants.len(),
         access_grants,
-    })
+    }))
 }
 
 pub(super) async fn list_effective_org_unit_grants(
@@ -266,12 +291,13 @@ pub(super) async fn list_effective_org_unit_grants(
     let member_id = validate_external_id("member_id", &query.member_id)?;
     let member = PrincipalRef::new(query.member_kind, member_id);
     let now = now_ms();
-    let memberships: Vec<_> = state
-        .enterprise
-        .org_unit_memberships
-        .read()
+    let view = state
+        .enterprise_org_unit_view(&tenant_context)
         .await
-        .values()
+        .map_err(registry_error)?;
+    let memberships: Vec<_> = view
+        .memberships
+        .iter()
         .filter(|membership| {
             org_unit_membership_tenant_matches(membership, &tenant_context)
                 && membership.member == member
@@ -280,12 +306,9 @@ pub(super) async fn list_effective_org_unit_grants(
         .cloned()
         .collect();
     let mut grants = Vec::new();
-    for access_grant in state
-        .enterprise
-        .org_unit_access_grants
-        .read()
-        .await
-        .values()
+    for access_grant in view
+        .access_grants
+        .iter()
         .filter(|grant| org_unit_access_grant_tenant_matches(grant, &tenant_context))
     {
         for membership in &memberships {
@@ -318,6 +341,7 @@ pub(super) async fn create_org_unit(
         .map(|value| validate_enterprise_id("taxonomy_id", value))
         .transpose()?
         .unwrap_or_else(|| "organization_unit".to_string());
+    require_local_registry_owner(&taxonomy_id, None)?;
     let display_name = input.display_name.trim().to_string();
     if display_name.is_empty() {
         return Err(bad_request("ENTERPRISE_ORG_UNIT_DISPLAY_NAME_REQUIRED"));
@@ -384,6 +408,7 @@ pub(super) async fn create_org_unit_membership(
         .map(|value| validate_enterprise_id("taxonomy_id", value))
         .transpose()?
         .unwrap_or_else(|| "organization_unit".to_string());
+    require_local_registry_owner(&taxonomy_id, Some(input.source))?;
     ensure_org_unit_for_tenant(&state, &tenant_context, &taxonomy_id, &unit_id).await?;
     let member_id = validate_external_id("member_id", &input.member_id)?;
     let membership_id = input
@@ -618,11 +643,11 @@ async fn ensure_org_unit_for_tenant(
     unit_id: &str,
 ) -> Result<(), (StatusCode, Json<Value>)> {
     if state
-        .enterprise
-        .org_units
-        .read()
+        .enterprise_org_unit_view(tenant_context)
         .await
-        .values()
+        .map_err(registry_error)?
+        .units
+        .iter()
         .any(|unit| {
             unit.taxonomy_id == taxonomy_id
                 && unit.unit_id == unit_id

--- a/crates/tandem-enterprise-server/tests/enterprise_http.rs
+++ b/crates/tandem-enterprise-server/tests/enterprise_http.rs
@@ -25,6 +25,53 @@ mod common;
 use common::{connector_body, connector_credential_ref_body, source_binding_body};
 
 #[tokio::test]
+async fn enterprise_org_unit_memberships_reject_forged_hosted_provenance() {
+    let state = test_state().await;
+    let app = build_router_with_extensions(state, &[apply_routes]);
+    let request = |path: &str, body: Value| {
+        Request::builder()
+            .method("POST")
+            .uri(path)
+            .header("content-type", "application/json")
+            .header("x-tandem-org-id", "clinic-co")
+            .header("x-tandem-workspace-id", "care-delivery")
+            .header("x-tandem-actor-id", "owner-user")
+            .body(Body::from(body.to_string()))
+            .expect("request")
+    };
+    let response = app
+        .clone()
+        .oneshot(request(
+            "/enterprise/org-units",
+            json!({
+                "unit_id": "doctors", "taxonomy_id": "clinical_role",
+                "display_name": "Doctors", "kind": "clinical_group"
+            }),
+        ))
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    for (source, expected) in [
+        ("hosted_control_plane", StatusCode::BAD_REQUEST),
+        ("direct", StatusCode::OK),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(request(
+                "/enterprise/org-unit-memberships",
+                json!({
+                    "membership_id": "membership-doctor-user", "taxonomy_id": "clinical_role",
+                    "unit_id": "doctors", "member_kind": "human_user",
+                    "member_id": "doctor.user@example.com", "source": source
+                }),
+            ))
+            .await
+            .expect("response");
+        assert_eq!(response.status(), expected);
+    }
+}
+
+#[tokio::test]
 async fn enterprise_status_returns_public_safe_summary() {
     let state = test_state().await;
     let app = build_router_with_extensions(state.clone(), &[apply_routes]);
@@ -255,7 +302,7 @@ async fn enterprise_org_unit_memberships_create_update_and_filter_by_tenant() {
                 "unit_id": "doctors",
                 "member_kind": "human_user",
                 "member_id": "doctor.user@example.com",
-                "source": "hosted_control_plane"
+                "source": "direct"
             })
             .to_string(),
         ))
@@ -400,7 +447,7 @@ async fn enterprise_org_unit_access_grants_project_effective_scoped_grants() {
                 "unit_id": "doctors",
                 "member_kind": "human_user",
                 "member_id": "doctor.user@example.com",
-                "source": "hosted_control_plane"
+                "source": "direct"
             })
             .to_string(),
         ))

--- a/crates/tandem-providers/src/dispatch_authority.rs
+++ b/crates/tandem-providers/src/dispatch_authority.rs
@@ -27,8 +27,10 @@ impl ProviderDispatchAuthority {
 
     /// Scope the guard to this future, like the registry's tenant credentials.
     /// Spawned tasks must explicitly carry their own authority scope.
-    pub async fn scope<F: Future>(self, future: F) -> F::Output {
-        DISPATCH_AUTHORITY.scope(self, future).await
+    pub fn scope<F: Future>(self, future: F) -> impl Future<Output = F::Output> {
+        // Engine prompts can have large futures. Keep them off the nested
+        // task-local wrapper's stack while preserving the same polling scope.
+        DISPATCH_AUTHORITY.scope(self, Box::pin(future))
     }
 }
 

--- a/crates/tandem-providers/src/dispatch_authority.rs
+++ b/crates/tandem-providers/src/dispatch_authority.rs
@@ -1,0 +1,40 @@
+//! Mutable request authority is checked after credential resolution and again
+//! after authentication recovery. It is never cached in a provider permit.
+use std::future::Future;
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+
+#[derive(Clone)]
+pub struct ProviderDispatchAuthority {
+    check: Arc<dyn Fn() -> BoxFuture<'static, anyhow::Result<()>> + Send + Sync>,
+}
+
+tokio::task_local! {
+    static DISPATCH_AUTHORITY: ProviderDispatchAuthority;
+}
+
+impl ProviderDispatchAuthority {
+    pub fn new<F, Fut>(check: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        Self {
+            check: Arc::new(move || Box::pin(check())),
+        }
+    }
+
+    /// Scope the guard to this future, like the registry's tenant credentials.
+    /// Spawned tasks must explicitly carry their own authority scope.
+    pub async fn scope<F: Future>(self, future: F) -> F::Output {
+        DISPATCH_AUTHORITY.scope(self, future).await
+    }
+}
+
+pub(crate) async fn revalidate() -> anyhow::Result<()> {
+    if let Ok(authority) = DISPATCH_AUTHORITY.try_with(Clone::clone) {
+        (authority.check)().await?;
+    }
+    Ok(())
+}

--- a/crates/tandem-providers/src/hosted_policy_tests.rs
+++ b/crates/tandem-providers/src/hosted_policy_tests.rs
@@ -1,0 +1,76 @@
+use super::*;
+
+#[tokio::test]
+async fn hosted_policy_revocation_during_auth_recovery_prevents_provider_retry() {
+    let registry = ProviderRegistry::new(cfg(&[], None, false));
+    let tenant = TenantContext::explicit("org-hosted", "workspace-hosted", None);
+    let attempts = Arc::new(AtomicUsize::new(0));
+    registry
+        .replace_for_test(
+            vec![Arc::new(CapturingCodexProvider {
+                attempts: attempts.clone(),
+                seen_auth: Arc::new(Mutex::new(Vec::new())),
+                fail_auth_attempts: 1,
+            })],
+            Some("openai-codex".into()),
+        )
+        .await;
+    let revoked = Arc::new(AtomicBool::new(false));
+    let recovery = ProviderAuthRecovery::new({
+        let revoked = revoked.clone();
+        move |_| {
+            let revoked = revoked.clone();
+            async move {
+                revoked.store(true, Ordering::SeqCst);
+                Ok(true)
+            }
+        }
+    });
+    let authority = ProviderDispatchAuthority::new(move || {
+        let revoked = revoked.clone();
+        async move {
+            anyhow::ensure!(!revoked.load(Ordering::SeqCst), "hosted membership revoked");
+            Ok(())
+        }
+    });
+    let error = authority
+        .scope(registry.scope_tenant_provider_auth_with_recovery(
+            tenant,
+            recovery,
+            false,
+            registry.complete_for_provider(Some("openai-codex"), "synthetic request", None),
+        ))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("revoked"));
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "revoked request must not retry after credential refresh"
+    );
+}
+
+#[tokio::test]
+async fn hosted_policy_dispatch_authority_is_isolated_between_concurrent_requests() {
+    let registry = ProviderRegistry::new(cfg(&[], None, false));
+    let attempts = Arc::new(AtomicUsize::new(0));
+    registry
+        .replace_for_test(
+            vec![Arc::new(CapturingCodexProvider {
+                attempts: attempts.clone(),
+                seen_auth: Arc::new(Mutex::new(Vec::new())),
+                fail_auth_attempts: 0,
+            })],
+            Some("openai-codex".into()),
+        )
+        .await;
+    let denied = ProviderDispatchAuthority::new(|| async { anyhow::bail!("membership revoked") });
+    let allowed = ProviderDispatchAuthority::new(|| async { Ok(()) });
+    let (denied, allowed) = tokio::join!(
+        denied.scope(registry.complete_for_provider(Some("openai-codex"), "denied", None)),
+        allowed.scope(registry.complete_for_provider(Some("openai-codex"), "allowed", None)),
+    );
+    assert!(denied.unwrap_err().to_string().contains("revoked"));
+    assert_eq!(allowed.unwrap(), "allowed");
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+}

--- a/crates/tandem-providers/src/hosted_policy_tests.rs
+++ b/crates/tandem-providers/src/hosted_policy_tests.rs
@@ -1,76 +1,80 @@
-use super::*;
+#[cfg(test)]
+mod hosted_policy_tests {
+    use super::*;
 
-#[tokio::test]
-async fn hosted_policy_revocation_during_auth_recovery_prevents_provider_retry() {
-    let registry = ProviderRegistry::new(cfg(&[], None, false));
-    let tenant = TenantContext::explicit("org-hosted", "workspace-hosted", None);
-    let attempts = Arc::new(AtomicUsize::new(0));
-    registry
-        .replace_for_test(
-            vec![Arc::new(CapturingCodexProvider {
-                attempts: attempts.clone(),
-                seen_auth: Arc::new(Mutex::new(Vec::new())),
-                fail_auth_attempts: 1,
-            })],
-            Some("openai-codex".into()),
-        )
-        .await;
-    let revoked = Arc::new(AtomicBool::new(false));
-    let recovery = ProviderAuthRecovery::new({
-        let revoked = revoked.clone();
-        move |_| {
+    #[tokio::test]
+    async fn hosted_policy_revocation_during_auth_recovery_prevents_provider_retry() {
+        let registry = ProviderRegistry::new(cfg(&[], None, false));
+        let tenant = TenantContext::explicit("org-hosted", "workspace-hosted", None);
+        let attempts = Arc::new(AtomicUsize::new(0));
+        registry
+            .replace_for_test(
+                vec![Arc::new(CapturingCodexProvider {
+                    attempts: attempts.clone(),
+                    seen_auth: Arc::new(Mutex::new(Vec::new())),
+                    fail_auth_attempts: 1,
+                })],
+                Some("openai-codex".into()),
+            )
+            .await;
+        let revoked = Arc::new(AtomicBool::new(false));
+        let recovery = ProviderAuthRecovery::new({
+            let revoked = revoked.clone();
+            move |_| {
+                let revoked = revoked.clone();
+                async move {
+                    revoked.store(true, Ordering::SeqCst);
+                    Ok(true)
+                }
+            }
+        });
+        let authority = ProviderDispatchAuthority::new(move || {
             let revoked = revoked.clone();
             async move {
-                revoked.store(true, Ordering::SeqCst);
-                Ok(true)
+                anyhow::ensure!(!revoked.load(Ordering::SeqCst), "hosted membership revoked");
+                Ok(())
             }
-        }
-    });
-    let authority = ProviderDispatchAuthority::new(move || {
-        let revoked = revoked.clone();
-        async move {
-            anyhow::ensure!(!revoked.load(Ordering::SeqCst), "hosted membership revoked");
-            Ok(())
-        }
-    });
-    let error = authority
-        .scope(registry.scope_tenant_provider_auth_with_recovery(
-            tenant,
-            recovery,
-            false,
-            registry.complete_for_provider(Some("openai-codex"), "synthetic request", None),
-        ))
-        .await
-        .unwrap_err();
-    assert!(error.to_string().contains("revoked"));
-    assert_eq!(
-        attempts.load(Ordering::SeqCst),
-        1,
-        "revoked request must not retry after credential refresh"
-    );
-}
+        });
+        let error = authority
+            .scope(registry.scope_tenant_provider_auth_with_recovery(
+                tenant,
+                recovery,
+                false,
+                registry.complete_for_provider(Some("openai-codex"), "synthetic request", None),
+            ))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("revoked"));
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "revoked request must not retry after credential refresh"
+        );
+    }
 
-#[tokio::test]
-async fn hosted_policy_dispatch_authority_is_isolated_between_concurrent_requests() {
-    let registry = ProviderRegistry::new(cfg(&[], None, false));
-    let attempts = Arc::new(AtomicUsize::new(0));
-    registry
-        .replace_for_test(
-            vec![Arc::new(CapturingCodexProvider {
-                attempts: attempts.clone(),
-                seen_auth: Arc::new(Mutex::new(Vec::new())),
-                fail_auth_attempts: 0,
-            })],
-            Some("openai-codex".into()),
-        )
-        .await;
-    let denied = ProviderDispatchAuthority::new(|| async { anyhow::bail!("membership revoked") });
-    let allowed = ProviderDispatchAuthority::new(|| async { Ok(()) });
-    let (denied, allowed) = tokio::join!(
-        denied.scope(registry.complete_for_provider(Some("openai-codex"), "denied", None)),
-        allowed.scope(registry.complete_for_provider(Some("openai-codex"), "allowed", None)),
-    );
-    assert!(denied.unwrap_err().to_string().contains("revoked"));
-    assert_eq!(allowed.unwrap(), "allowed");
-    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    #[tokio::test]
+    async fn hosted_policy_dispatch_authority_is_isolated_between_concurrent_requests() {
+        let registry = ProviderRegistry::new(cfg(&[], None, false));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        registry
+            .replace_for_test(
+                vec![Arc::new(CapturingCodexProvider {
+                    attempts: attempts.clone(),
+                    seen_auth: Arc::new(Mutex::new(Vec::new())),
+                    fail_auth_attempts: 0,
+                })],
+                Some("openai-codex".into()),
+            )
+            .await;
+        let denied =
+            ProviderDispatchAuthority::new(|| async { anyhow::bail!("membership revoked") });
+        let allowed = ProviderDispatchAuthority::new(|| async { Ok(()) });
+        let (denied, allowed) = tokio::join!(
+            denied.scope(registry.complete_for_provider(Some("openai-codex"), "denied", None)),
+            allowed.scope(registry.complete_for_provider(Some("openai-codex"), "allowed", None)),
+        );
+        assert!(denied.unwrap_err().to_string().contains("revoked"));
+        assert_eq!(allowed.unwrap(), "allowed");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
 }

--- a/crates/tandem-providers/src/lib.rs
+++ b/crates/tandem-providers/src/lib.rs
@@ -1,4 +1,6 @@
+mod dispatch_authority;
 mod guarded_dispatch;
+pub use dispatch_authority::ProviderDispatchAuthority;
 pub mod provider_auth_store;
 
 pub use provider_auth_store::*;

--- a/crates/tandem-providers/src/lib_parts/part01.rs
+++ b/crates/tandem-providers/src/lib_parts/part01.rs
@@ -1157,6 +1157,7 @@ impl ProviderRegistry {
         let auth_override = self
             .auth_override_for_provider(resolved_provider_id.as_str())
             .await;
+        dispatch_authority::revalidate().await?;
         match provider
             .complete_with_auth_override(prompt, model_id, auth_override)
             .await
@@ -1170,6 +1171,7 @@ impl ProviderRegistry {
                 let auth_override = self
                     .auth_override_for_provider(resolved_provider_id.as_str())
                     .await;
+                dispatch_authority::revalidate().await?;
                 provider
                     .complete_with_auth_override(prompt, model_id, auth_override)
                     .await
@@ -1299,6 +1301,7 @@ impl ProviderRegistry {
         let retry_messages = messages.clone();
         let retry_tools = tools.clone();
         let retry_cancel = cancel.clone();
+        dispatch_authority::revalidate().await?;
         match provider
             .stream_with_auth_override(
                 messages,
@@ -1320,6 +1323,7 @@ impl ProviderRegistry {
                 let auth_override = self
                     .auth_override_for_provider(resolved_provider_id.as_str())
                     .await;
+                dispatch_authority::revalidate().await?;
                 provider
                     .stream_with_auth_override(
                         retry_messages,

--- a/crates/tandem-providers/src/lib_parts/part04.rs
+++ b/crates/tandem-providers/src/lib_parts/part04.rs
@@ -1,9 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::*;
-    mod hosted_policy_tests {
-        include!("../hosted_policy_tests.rs");
-    }
+    include!("../hosted_policy_tests.rs");
     use futures::StreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;

--- a/crates/tandem-providers/src/lib_parts/part04.rs
+++ b/crates/tandem-providers/src/lib_parts/part04.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod tests {
     use super::*;
+    mod hosted_policy_tests {
+        include!("../hosted_policy_tests.rs");
+    }
     use futures::StreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;

--- a/crates/tandem-runtime/src/lib.rs
+++ b/crates/tandem-runtime/src/lib.rs
@@ -2,6 +2,8 @@
 
 pub mod lsp;
 pub mod mcp;
+mod mcp_dispatch_authority;
+pub use mcp_dispatch_authority::McpRequestAuthority;
 pub mod mcp_ready;
 pub mod pty;
 pub mod workspace_index;

--- a/crates/tandem-runtime/src/mcp.rs
+++ b/crates/tandem-runtime/src/mcp.rs
@@ -4,3 +4,7 @@ include!("mcp_parts/part04.rs");
 include!("mcp_parts/part03.rs");
 include!("mcp_parts/part05.rs");
 include!("mcp_parts/part06.rs");
+include!("mcp_tool_authority.rs");
+#[cfg(test)]
+#[path = "mcp_hosted_policy_tests.rs"]
+mod hosted_policy_tests;

--- a/crates/tandem-runtime/src/mcp_dispatch_authority.rs
+++ b/crates/tandem-runtime/src/mcp_dispatch_authority.rs
@@ -1,0 +1,19 @@
+//! Authority retained across connector readiness, OAuth recovery and DNS waits.
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct McpRequestAuthority {
+    check: Arc<dyn Fn() -> Result<(), String> + Send + Sync>,
+}
+
+impl McpRequestAuthority {
+    pub fn new(check: impl Fn() -> Result<(), String> + Send + Sync + 'static) -> Self {
+        Self {
+            check: Arc::new(check),
+        }
+    }
+
+    pub(crate) fn revalidate(&self) -> Result<(), String> {
+        (self.check)()
+    }
+}

--- a/crates/tandem-runtime/src/mcp_hosted_policy_tests.rs
+++ b/crates/tandem-runtime/src/mcp_hosted_policy_tests.rs
@@ -1,0 +1,161 @@
+use super::*;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+#[tokio::test]
+async fn hosted_policy_revocation_during_mcp_readiness_sends_no_tool_request() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}/mcp", listener.local_addr().unwrap());
+    let revoked = Arc::new(AtomicBool::new(false));
+    let effects = Arc::new(AtomicUsize::new(0));
+    let server_revoked = revoked.clone();
+    let server_effects = effects.clone();
+    let server = tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut bytes = Vec::new();
+            loop {
+                let mut chunk = [0u8; 4096];
+                let count = socket.read(&mut chunk).await.unwrap();
+                assert!(count > 0 && bytes.len() < 16384);
+                bytes.extend_from_slice(&chunk[..count]);
+                let text = String::from_utf8_lossy(&bytes);
+                if let Some((head, body)) = text.split_once("\r\n\r\n") {
+                    let length = head
+                        .lines()
+                        .find_map(|line| {
+                            line.to_ascii_lowercase()
+                                .strip_prefix("content-length:")
+                                .map(|value| value.trim().parse::<usize>().unwrap())
+                        })
+                        .unwrap_or(0);
+                    if body.len() >= length {
+                        break;
+                    }
+                }
+            }
+            let text = String::from_utf8(bytes).unwrap();
+            let (_, body) = text.split_once("\r\n\r\n").unwrap();
+            let request: Value = serde_json::from_str(body).unwrap();
+            let result = match request["method"].as_str().unwrap() {
+                "initialize" => json!({"protocolVersion": MCP_PROTOCOL_VERSION, "capabilities": {},
+                    "serverInfo": {"name": "synthetic", "version": "1"}}),
+                "tools/list" => {
+                    server_revoked.store(true, Ordering::SeqCst);
+                    json!({"tools": [{"name": "get_me", "description": "test", "inputSchema": {"type": "object"}}]})
+                }
+                "tools/call" => {
+                    server_effects.fetch_add(1, Ordering::SeqCst);
+                    json!({"content": []})
+                }
+                _ => json!({}),
+            };
+            let response =
+                json!({"jsonrpc": "2.0", "id": request["id"], "result": result}).to_string();
+            let response = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", response.len(), response);
+            socket.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    let file =
+        std::env::temp_dir().join(format!("mcp-hosted-policy-{}.json", uuid::Uuid::new_v4()));
+    let registry = McpRegistry::new_with_state_file(file.clone());
+    registry.allow_private_endpoints_for_tests();
+    registry
+        .add_or_update("test".into(), endpoint, HashMap::new(), true)
+        .await;
+    let authority = crate::McpRequestAuthority::new(move || {
+        if revoked.load(Ordering::SeqCst) {
+            Err("hosted membership revoked".into())
+        } else {
+            Ok(())
+        }
+    });
+    let error = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        registry.call_tool_for_tenant_with_authority(
+            "test",
+            "get_me",
+            json!({}),
+            &TenantContext::local_implicit(),
+            Some(authority),
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap_err();
+    assert!(error.contains("hosted membership revoked"), "{error}");
+    assert_eq!(effects.load(Ordering::SeqCst), 0);
+    server.abort();
+    let _ = std::fs::remove_file(file);
+}
+
+#[tokio::test]
+async fn hosted_policy_mcp_send_rechecks_connector_and_connection_changes() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}/mcp", listener.local_addr().unwrap());
+    for mutation in ["disable", "remove", "transport", "tool", "connection"] {
+        let file =
+            std::env::temp_dir().join(format!("mcp-hosted-policy-{}.json", uuid::Uuid::new_v4()));
+        let registry = McpRegistry::new_with_state_file(file.clone());
+        registry.allow_private_endpoints_for_tests();
+        registry
+            .add_or_update("test".into(), endpoint.clone(), HashMap::new(), true)
+            .await;
+        let tenant = TenantContext::local_implicit();
+        let row = registry.servers.read().await["test"].clone();
+        let connection = registry
+            .connection_for_tenant("test", &tenant)
+            .await
+            .unwrap();
+        let mut authorization = McpEndpointAuthorization::for_registry(&registry, &tenant);
+        authorization.tool_dispatch = Some(McpToolDispatchBinding {
+            registry: registry.clone(),
+            server_name: "test".into(),
+            tool_name: "get_me".into(),
+            server_policy: server_dispatch_policy(&row),
+            tenant,
+            connection_generation: Some(connection.connection_generation),
+            request_authority: None,
+        });
+        match mutation {
+            "remove" => {
+                registry.servers.write().await.remove("test");
+            }
+            "connection" => {
+                registry
+                    .connections
+                    .write()
+                    .await
+                    .remove(&connection.connection_id);
+            }
+            other => {
+                let mut servers = registry.servers.write().await;
+                let row = servers.get_mut("test").unwrap();
+                match other {
+                    "disable" => row.enabled = false,
+                    "transport" => row.transport = "https://changed.example.com/mcp".into(),
+                    "tool" => row.allowed_tools = Some(vec![]),
+                    _ => unreachable!(),
+                }
+            }
+        }
+        let error = post_json_rpc_with_session(
+            &endpoint,
+            &HashMap::new(),
+            json!({"method": "tools/call", "params": {"name": "get_me"}}),
+            None,
+            &authorization,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("before dispatch"), "{mutation}: {error}");
+        let _ = std::fs::remove_file(file);
+    }
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(20), listener.accept())
+            .await
+            .is_err(),
+        "revoked dispatches must never open a tool connection"
+    );
+}

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -1231,6 +1231,9 @@ impl McpRegistry {
                 .map(|connection| connection.connection_generation),
             request_authority,
         };
+        if !current_tenant.is_local_implicit() && dispatch_binding.connection_generation.is_none() {
+            return Err("MCP tenant connection is missing or was revoked before dispatch".into());
+        }
         // Single readiness gate (Invariant 2 of `docs/SPINE.md`): one
         // attempt, no backoff. Recheck authority after its network waits.
         let server = match self

--- a/crates/tandem-runtime/src/mcp_parts/part01.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part01.rs
@@ -1176,6 +1176,20 @@ impl McpRegistry {
         args: Value,
         current_tenant: &TenantContext,
     ) -> Result<ToolResult, String> {
+        self.call_tool_for_tenant_with_authority(server_name, tool_name, args, current_tenant, None).await
+    }
+
+    pub async fn call_tool_for_tenant_with_authority(
+        &self,
+        server_name: &str,
+        tool_name: &str,
+        args: Value,
+        current_tenant: &TenantContext,
+        request_authority: Option<crate::McpRequestAuthority>,
+    ) -> Result<ToolResult, String> {
+        if let Some(authority) = &request_authority {
+            authority.revalidate()?;
+        }
         if current_tenant.is_local_implicit()
             && self
                 .strict_tenant_enforcement
@@ -1210,8 +1224,15 @@ impl McpRegistry {
             ));
         }
 
+        let dispatch_binding = McpToolDispatchBinding {
+            registry: self.clone(), server_name: server_name.into(), tool_name: tool_name.into(),
+            server_policy: server_dispatch_policy(&server), tenant: current_tenant.clone(),
+            connection_generation: self.connection_for_tenant(server_name, current_tenant).await
+                .map(|connection| connection.connection_generation),
+            request_authority,
+        };
         // Single readiness gate (Invariant 2 of `docs/SPINE.md`): one
-        // attempt, no backoff — same shape as the previous inline check.
+        // attempt, no backoff. Recheck authority after its network waits.
         let server = match self
             .ensure_ready_for_tenant(server_name, current_tenant, EnsureReadyPolicy::default())
             .await
@@ -1288,8 +1309,9 @@ impl McpRegistry {
                 "arguments": normalized_args
             }
         });
-        let endpoint_authorization =
+        let mut endpoint_authorization =
             McpEndpointAuthorization::for_registry(self, current_tenant);
+        endpoint_authorization.tool_dispatch = Some(dispatch_binding);
         let (response, session_id) = match post_json_rpc_with_session(
             &endpoint,
             &request_headers,

--- a/crates/tandem-runtime/src/mcp_parts/part02.rs
+++ b/crates/tandem-runtime/src/mcp_parts/part02.rs
@@ -651,6 +651,7 @@ struct McpRefreshTokenResponse {
 
 #[derive(Clone)]
 struct McpEndpointAuthorization {
+    tool_dispatch: Option<McpToolDispatchBinding>,
     local_implicit: bool,
     standalone_private_endpoint_access: Arc<std::sync::atomic::AtomicBool>,
     strict_tenant_enforcement: Arc<std::sync::atomic::AtomicBool>,
@@ -661,6 +662,7 @@ struct McpEndpointAuthorization {
 impl McpEndpointAuthorization {
     fn for_registry(registry: &McpRegistry, tenant: &TenantContext) -> Self {
         Self {
+            tool_dispatch: None,
             local_implicit: tenant.is_local_implicit(),
             standalone_private_endpoint_access: registry
                 .standalone_private_endpoint_access
@@ -971,6 +973,9 @@ async fn post_json_rpc_with_session(
         }
     }
     let request = req.json(&request);
+    if let Some(binding) = &authorization.tool_dispatch {
+        binding.revalidate()?;
+    }
     target.ensure_authorized(authorization)?;
     let mut response = request
         .send()

--- a/crates/tandem-runtime/src/mcp_tool_authority.rs
+++ b/crates/tandem-runtime/src/mcp_tool_authority.rs
@@ -1,0 +1,59 @@
+#[derive(Clone)]
+struct McpToolDispatchBinding {
+    registry: McpRegistry,
+    server_name: String,
+    tool_name: String,
+    server_policy: Value,
+    tenant: TenantContext,
+    connection_generation: Option<String>,
+    request_authority: Option<crate::McpRequestAuthority>,
+}
+
+fn server_dispatch_policy(server: &McpServer) -> Value {
+    json!({
+        "transport": server.transport, "enabled": server.enabled,
+        "allowed_tools": server.allowed_tools, "auth_kind": server.auth_kind,
+        "headers": server.headers, "secret_headers": server.secret_headers,
+        "oauth": server.oauth,
+    })
+}
+
+impl McpToolDispatchBinding {
+    fn revalidate(&self) -> Result<(), String> {
+        let servers = self
+            .registry
+            .servers
+            .try_read()
+            .map_err(|_| "MCP connector authority is changing; retry required".to_string())?;
+        let connections = self
+            .registry
+            .connections
+            .try_read()
+            .map_err(|_| "MCP connection authority is changing; retry required".to_string())?;
+        let server = servers
+            .get(&self.server_name)
+            .ok_or_else(|| "MCP connector was removed before dispatch".to_string())?;
+        if !server.enabled
+            || !mcp_tool_is_allowed(server, &self.tool_name)
+            || server_dispatch_policy(server) != self.server_policy
+        {
+            return Err("MCP connector authority changed before dispatch".into());
+        }
+        // Both registries stay stable for this check, without waiting on a
+        // mutation or holding either lock across network I/O.
+        if let Some(expected) = &self.connection_generation {
+            let owner = McpPrincipalRef::from_tenant_context(&self.tenant);
+            let connection_id = mcp_connection_id(&self.server_name, &self.tenant, &owner);
+            let connection = connections.get(&connection_id);
+            if !connection.is_some_and(|connection| {
+                connection.enabled && connection.connection_generation == *expected
+            }) {
+                return Err("MCP connection was revoked or replaced before dispatch".into());
+            }
+        }
+        if let Some(authority) = &self.request_authority {
+            authority.revalidate()?;
+        }
+        Ok(())
+    }
+}

--- a/crates/tandem-server/src/action_authorization.rs
+++ b/crates/tandem-server/src/action_authorization.rs
@@ -193,6 +193,7 @@ enum AuthoritySource {
 
 #[derive(Debug, Clone)]
 pub struct AuthorizedHostEffect {
+    verified: Option<VerifiedTenantContext>,
     request_digest: String,
     tenant_context: TenantContext,
     capability: &'static str,
@@ -206,6 +207,13 @@ impl AuthorizedHostEffect {
         state: &AppState,
         request: &HostEffectRequest,
     ) -> Result<(), HostAuthorizationError> {
+        if self.source == AuthoritySource::VerifiedCapability {
+            state
+                .enterprise
+                .hosted_policy
+                .authorize(self.verified.as_ref())
+                .map_err(|_| HostAuthorizationError::PolicyRevoked)?;
+        }
         if crate::now_ms() > self.expires_at_ms {
             return Err(HostAuthorizationError::GrantExpired);
         }
@@ -250,6 +258,7 @@ pub enum HostAuthorizationError {
     AuditPersistenceFailed,
     GrantExpired,
     GrantMismatch,
+    PolicyRevoked,
 }
 
 impl HostAuthorizationError {
@@ -266,6 +275,7 @@ impl HostAuthorizationError {
             Self::AuditPersistenceFailed => "audit_persistence_failed",
             Self::GrantExpired => "authorization_grant_expired",
             Self::GrantMismatch => "authorization_grant_mismatch",
+            Self::PolicyRevoked => "hosted_policy_revoked",
         }
     }
 }
@@ -277,6 +287,17 @@ pub async fn authorize_host_effect(
     direct_loopback_request: bool,
     request: &HostEffectRequest,
 ) -> Result<AuthorizedHostEffect, HostAuthorizationError> {
+    if state.enterprise.hosted_policy.authorize(verified).is_err() {
+        audit_denial(
+            state,
+            tenant,
+            verified,
+            request,
+            HostAuthorizationError::PolicyRevoked,
+        )
+        .await;
+        return Err(HostAuthorizationError::PolicyRevoked);
+    }
     if !same_tenant(&request.resource.tenant_context, tenant) {
         audit_denial(
             state,
@@ -405,6 +426,7 @@ pub async fn authorize_host_effect(
     Ok(AuthorizedHostEffect {
         request_digest,
         tenant_context: tenant.clone(),
+        verified: verified.cloned(),
         capability,
         source,
         expires_at_ms,
@@ -460,6 +482,7 @@ pub async fn authorize_internal_host_effect(
     Ok(AuthorizedHostEffect {
         request_digest,
         tenant_context: request.resource.tenant_context.clone(),
+        verified: None,
         capability: request.action.capability(),
         source: AuthoritySource::InternalRuntime,
         expires_at_ms,

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -845,12 +845,24 @@ fn receipt_matches_tenant(
 }
 
 impl ToolPolicyHook for ServerToolPolicyHook {
+    fn revalidate_session(
+        &self,
+        verified: Option<tandem_types::VerifiedTenantContext>,
+    ) -> BoxFuture<'static, anyhow::Result<()>> {
+        let state = self.state.clone();
+        Box::pin(async move {
+            state.enterprise.hosted_policy.authorize(verified.as_ref()).map_err(anyhow::Error::msg)
+        })
+    }
+
     fn evaluate_tool(
         &self,
         ctx: ToolPolicyContext,
     ) -> BoxFuture<'static, anyhow::Result<ToolPolicyDecision>> {
         let state = self.state.clone();
         Box::pin(async move {
+            state.enterprise.hosted_policy.authorize(ctx.verified_tenant_context.as_ref())
+                .map_err(anyhow::Error::msg)?;
             let tool = normalize_tool_name(&ctx.tool);
             let mut enterprise_allow_decision = None;
             if session_allowlist_would_deny_non_automation_tool(&state, &ctx, &tool).await {

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -851,7 +851,7 @@ impl ToolPolicyHook for ServerToolPolicyHook {
     ) -> BoxFuture<'static, anyhow::Result<()>> {
         let state = self.state.clone();
         Box::pin(async move {
-            state.enterprise.hosted_policy.authorize(verified.as_ref()).map_err(anyhow::Error::msg)
+            state.enterprise.hosted_policy.authorize_execution(verified.as_ref()).map_err(anyhow::Error::msg)
         })
     }
 
@@ -861,7 +861,7 @@ impl ToolPolicyHook for ServerToolPolicyHook {
     ) -> BoxFuture<'static, anyhow::Result<ToolPolicyDecision>> {
         let state = self.state.clone();
         Box::pin(async move {
-            state.enterprise.hosted_policy.authorize(ctx.verified_tenant_context.as_ref())
+            state.enterprise.hosted_policy.authorize_execution(ctx.verified_tenant_context.as_ref())
                 .map_err(anyhow::Error::msg)?;
             let tool = normalize_tool_name(&ctx.tool);
             let mut enterprise_allow_decision = None;

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part01.rs
@@ -419,6 +419,7 @@ impl AppState {
 
     pub fn is_ready(&self) -> bool {
         self.runtime.get().is_some()
+            && self.enterprise.hosted_policy.is_ready()
             && self
                 .startup
                 .try_read()

--- a/crates/tandem-server/src/app/state/enterprise_state.rs
+++ b/crates/tandem-server/src/app/state/enterprise_state.rs
@@ -38,6 +38,8 @@ use crate::config;
 /// `Clone` and is cloned alongside `AppState`.
 #[derive(Clone)]
 pub struct EnterpriseState {
+    pub(crate) hosted_policy: Arc<crate::hosted_policy::HostedPolicyRuntime>,
+    pub(crate) hosted_policy_revision_path: PathBuf,
     pub org_units: Arc<RwLock<HashMap<String, EnterpriseOrganizationUnit>>>,
     pub org_units_path: PathBuf,
     pub org_unit_memberships: Arc<RwLock<HashMap<String, EnterpriseOrganizationUnitMembership>>>,
@@ -63,6 +65,9 @@ impl EnterpriseState {
     /// the same defaults `AppState::new_starting` previously inlined.
     pub fn new() -> Self {
         Self {
+            hosted_policy: Arc::new(crate::hosted_policy::HostedPolicyRuntime::default()),
+            hosted_policy_revision_path: config::paths::resolve_enterprise_org_units_path()
+                .with_file_name("hosted-policy-revision.json"),
             org_units: Arc::new(RwLock::new(HashMap::new())),
             org_units_path: config::paths::resolve_enterprise_org_units_path(),
             org_unit_memberships: Arc::new(RwLock::new(HashMap::new())),

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -389,6 +389,14 @@ impl ServerToolDispatchComposition {
 
 #[async_trait::async_trait]
 impl ToolDispatchPolicy for AppStateToolDispatchPolicy {
+    async fn revalidate(&self, context: &ToolDispatchContext) -> anyhow::Result<()> {
+        self.state
+            .enterprise
+            .hosted_policy
+            .authorize(context.verified_tenant_context.as_ref())
+            .map_err(anyhow::Error::msg)
+    }
+
     async fn evaluate(
         &self,
         context: ToolDispatchPolicyContext,

--- a/crates/tandem-server/src/context_assertion_security.rs
+++ b/crates/tandem-server/src/context_assertion_security.rs
@@ -31,6 +31,22 @@ pub(crate) struct RuntimeContextAssertionSecurity {
 }
 
 impl RuntimeContextAssertionSecurity {
+    #[cfg(test)]
+    pub(crate) fn from_test_metadata_keyring(raw: &str, replay_path: &Path) -> Self {
+        let keyring = parse_runtime_keyring(raw, true).unwrap();
+        let key_count = keyring.len();
+        let keyring_fingerprint = keyring_fingerprint(&keyring).unwrap();
+        let policy =
+            ContextAssertionPolicy::new("tandem-web", "tandem-runtime", 5_000, 300_000).unwrap();
+        Self {
+            verifier: ContextAssertionVerifier::new(keyring, policy).unwrap(),
+            replay_store: ContextAssertionReplayStore::persistent(replay_path).unwrap(),
+            replay_mode: ContextAssertionReplayMode::Bound,
+            key_count,
+            keyring_fingerprint,
+        }
+    }
+
     pub(crate) fn load_from_env(mode: RuntimeAuthMode) -> Result<Option<Self>, String> {
         let hosted = mode != RuntimeAuthMode::LocalSingleTenant
             || crate::config::env::hosted_control_plane_configured();

--- a/crates/tandem-server/src/context_assertion_security.rs
+++ b/crates/tandem-server/src/context_assertion_security.rs
@@ -429,7 +429,7 @@ fn read_optional_material(
     Ok(Some(value))
 }
 
-fn open_keyring_file(path: &Path, strict: bool) -> Result<File, String> {
+pub(crate) fn open_keyring_file(path: &Path, strict: bool) -> Result<File, String> {
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]

--- a/crates/tandem-server/src/governance_store.rs
+++ b/crates/tandem-server/src/governance_store.rs
@@ -25,6 +25,7 @@ pub(crate) enum GovernanceStoreFile {
     CrossTenantGrants,
     SourceBindings,
     PolicyRules,
+    HostedPolicyRevision,
 }
 
 impl GovernanceStoreFile {
@@ -39,6 +40,7 @@ impl GovernanceStoreFile {
             Self::CrossTenantGrants => "cross-tenant-grants",
             Self::SourceBindings => "source-bindings",
             Self::PolicyRules => "policy-rules",
+            Self::HostedPolicyRevision => "hosted-policy-revision",
         }
     }
 
@@ -145,6 +147,9 @@ impl<'a> GovernanceStore<'a> {
             }
             GovernanceStoreFile::SourceBindings => &self.state.enterprise.source_bindings_path,
             GovernanceStoreFile::PolicyRules => &self.state.enterprise.policy_rules_path,
+            GovernanceStoreFile::HostedPolicyRevision => {
+                &self.state.enterprise.hosted_policy_revision_path
+            }
         }
     }
 

--- a/crates/tandem-server/src/hosted_policy.rs
+++ b/crates/tandem-server/src/hosted_policy.rs
@@ -86,6 +86,14 @@ impl HostedPolicyRuntime {
         &self,
         verified: Option<&VerifiedTenantContext>,
     ) -> Result<(), &'static str> {
+        self.authorize_permission(verified, AccessPermission::HostedUse)
+    }
+
+    pub(crate) fn authorize_permission(
+        &self,
+        verified: Option<&VerifiedTenantContext>,
+        permission: AccessPermission,
+    ) -> Result<(), &'static str> {
         let Some(policy) = self.current()? else {
             return Ok(());
         };
@@ -95,14 +103,14 @@ impl HostedPolicyRuntime {
         if projection
             .evaluate_access(
                 &policy.deployment_resource(),
-                AccessPermission::HostedUse,
+                permission,
                 DataClass::Internal,
                 now,
             )
             .decision
             != AccessDecision::Allow
         {
-            return Err("hosted_use_required");
+            return Err("hosted_operation_permission_required");
         }
         Ok(())
     }

--- a/crates/tandem-server/src/hosted_policy.rs
+++ b/crates/tandem-server/src/hosted_policy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 //! Current hosted authority is one immutable snapshot. The host policy agent
 //! owns the input file; the engine never receives its control-plane credential.
 use std::collections::BTreeMap;

--- a/crates/tandem-server/src/hosted_policy.rs
+++ b/crates/tandem-server/src/hosted_policy.rs
@@ -1,0 +1,190 @@
+//! Current hosted authority is one immutable snapshot. The host policy agent
+//! owns the input file; the engine never receives its control-plane credential.
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+use anyhow::Context;
+use tandem_enterprise_contract::hosted_policy::{
+    HostedPolicyBundle, HostedPolicyRevision, ValidatedHostedPolicy, MAX_POLICY_BYTES,
+};
+use tandem_types::{RuntimeAuthMode, TenantContext, VerifiedTenantContext};
+
+use crate::governance_store::{for_state, GovernanceStoreFile};
+use crate::AppState;
+
+#[cfg(test)]
+#[path = "hosted_policy_tests.rs"]
+mod tests;
+
+#[derive(Clone)]
+struct PolicySource {
+    organization_id: String,
+    deployment_id: String,
+    path: PathBuf,
+    started_at_ms: u64,
+}
+
+#[derive(Default)]
+pub(crate) struct HostedPolicyRuntime {
+    source: RwLock<Option<PolicySource>>,
+    snapshot: RwLock<Option<Arc<ValidatedHostedPolicy>>>,
+    update: tokio::sync::Mutex<()>,
+}
+
+impl HostedPolicyRuntime {
+    pub(crate) fn authorize(
+        &self,
+        verified: Option<&VerifiedTenantContext>,
+    ) -> Result<(), &'static str> {
+        let source = self
+            .source
+            .read()
+            .map_err(|_| "hosted_policy_lock_failed")?;
+        if source.is_none() {
+            return Ok(());
+        }
+        drop(source);
+        let snapshot = self
+            .snapshot
+            .read()
+            .map_err(|_| "hosted_policy_lock_failed")?
+            .clone()
+            .ok_or("hosted_policy_not_synchronized")?;
+        snapshot.authorize_identity(
+            verified.ok_or("hosted_policy_identity_required")?,
+            crate::now_ms(),
+        )
+    }
+
+    pub(crate) fn revision(&self) -> Result<Option<HostedPolicyRevision>, &'static str> {
+        Ok(self
+            .snapshot
+            .read()
+            .map_err(|_| "hosted_policy_lock_failed")?
+            .as_ref()
+            .map(|policy| policy.revision().clone()))
+    }
+}
+
+impl AppState {
+    pub(crate) fn start_hosted_policy_sync(&self, mode: RuntimeAuthMode) -> anyhow::Result<()> {
+        let input_path = std::env::var("TANDEM_HOSTED_POLICY_FILE").ok();
+        if mode != RuntimeAuthMode::HostedSingleTenant
+            && input_path.is_none()
+            && !crate::config::env::hosted_control_plane_configured()
+        {
+            return Ok(());
+        }
+        let required = |name: &str| -> anyhow::Result<String> {
+            std::env::var(name)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| anyhow::anyhow!("hosted policy requires {name}"))
+        };
+        let source = PolicySource {
+            organization_id: required("TANDEM_HOSTED_ORGANIZATION_ID")?,
+            deployment_id: required("TANDEM_HOSTED_DEPLOYMENT_ID")?,
+            path: PathBuf::from(required("TANDEM_HOSTED_POLICY_FILE")?),
+            started_at_ms: crate::now_ms(),
+        };
+        anyhow::ensure!(
+            source.path.is_absolute(),
+            "hosted policy input path must be absolute"
+        );
+        let mut configured = self
+            .enterprise
+            .hosted_policy
+            .source
+            .write()
+            .map_err(|_| anyhow::anyhow!("hosted policy source lock failed"))?;
+        anyhow::ensure!(
+            configured.is_none(),
+            "hosted policy sync is already configured"
+        );
+        *configured = Some(source);
+        drop(configured);
+        let state = self.clone();
+        tokio::spawn(async move {
+            loop {
+                if let Err(error) = state.reload_hosted_policy().await {
+                    tracing::warn!(target: "tandem_server::hosted_policy", %error,
+                        "hosted policy synchronization failed; authority remains bounded by snapshot expiry");
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        });
+        Ok(())
+    }
+
+    pub(crate) async fn reload_hosted_policy(&self) -> anyhow::Result<()> {
+        let runtime = &self.enterprise.hosted_policy;
+        let _update = runtime.update.lock().await;
+        let source = runtime
+            .source
+            .read()
+            .map_err(|_| anyhow::anyhow!("hosted policy source lock failed"))?
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("hosted policy source is not configured"))?;
+        let bytes = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            let file = crate::context_assertion_security::open_keyring_file(&source.path, true)
+                .map_err(anyhow::Error::msg)?;
+            let mut bytes = Vec::new();
+            file.take((MAX_POLICY_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)?;
+            Ok((source, bytes))
+        })
+        .await??;
+        let (source, bytes) = bytes;
+        let bundle = HostedPolicyBundle::from_json(&bytes).map_err(anyhow::Error::msg)?;
+        anyhow::ensure!(
+            bundle.generated_at.timestamp_millis() >= source.started_at_ms as i64,
+            "hosted policy needs a fresh control-plane fetch after engine startup"
+        );
+        let store = for_state(self);
+        let previous: BTreeMap<String, HostedPolicyRevision> = store
+            .read_json(GovernanceStoreFile::HostedPolicyRevision)
+            .await?
+            .unwrap_or_default();
+        let key = format!("{}/{}", source.organization_id, source.deployment_id);
+        let policy = bundle
+            .validate(
+                &source.organization_id,
+                &source.deployment_id,
+                crate::now_ms(),
+                previous.get(&key),
+            )
+            .map_err(anyhow::Error::msg)?;
+        // Publish only after the existing encrypted, anchored store records the
+        // accepted high-water mark. A restart never loads live authority here.
+        if previous.get(&key) != Some(policy.revision()) {
+            anyhow::ensure!(
+                previous.is_empty() || previous.contains_key(&key),
+                "hosted policy persisted scope mismatch"
+            );
+            let tenant = TenantContext::explicit_user_workspace(
+                &source.organization_id,
+                &source.deployment_id,
+                Some(source.deployment_id.clone()),
+                "hosted-policy-agent",
+            );
+            let record = GovernanceStoreFile::HostedPolicyRevision.json_record(
+                key,
+                policy.revision(),
+                &tenant,
+                None,
+            )?;
+            store
+                .write_json_records(GovernanceStoreFile::HostedPolicyRevision, &[record])
+                .await
+                .context("persist hosted policy high-water mark")?;
+        }
+        *runtime
+            .snapshot
+            .write()
+            .map_err(|_| anyhow::anyhow!("hosted policy snapshot lock failed"))? =
+            Some(Arc::new(policy));
+        Ok(())
+    }
+}

--- a/crates/tandem-server/src/hosted_policy.rs
+++ b/crates/tandem-server/src/hosted_policy.rs
@@ -34,6 +34,20 @@ pub(crate) struct HostedPolicyRuntime {
 }
 
 impl HostedPolicyRuntime {
+    pub(crate) fn is_ready(&self) -> bool {
+        let Ok(source) = self.source.read() else {
+            return false;
+        };
+        if source.is_none() {
+            return true;
+        }
+        self.snapshot.read().is_ok_and(|snapshot| {
+            snapshot
+                .as_ref()
+                .is_some_and(|policy| policy.expires_at_ms() > crate::now_ms())
+        })
+    }
+
     pub(crate) fn authorize(
         &self,
         verified: Option<&VerifiedTenantContext>,

--- a/crates/tandem-server/src/hosted_policy.rs
+++ b/crates/tandem-server/src/hosted_policy.rs
@@ -9,6 +9,9 @@ use anyhow::Context;
 use tandem_enterprise_contract::hosted_policy::{
     HostedPolicyBundle, HostedPolicyRevision, ValidatedHostedPolicy, MAX_POLICY_BYTES,
 };
+use tandem_enterprise_contract::{
+    AccessDecision, AccessPermission, DataClass, OrganizationUnitMembership,
+};
 use tandem_types::{RuntimeAuthMode, TenantContext, VerifiedTenantContext};
 
 use crate::governance_store::{for_state, GovernanceStoreFile};
@@ -34,6 +37,61 @@ pub(crate) struct HostedPolicyRuntime {
 }
 
 impl HostedPolicyRuntime {
+    fn current(&self) -> Result<Option<Arc<ValidatedHostedPolicy>>, &'static str> {
+        if self
+            .source
+            .read()
+            .map_err(|_| "hosted_policy_lock_failed")?
+            .is_none()
+        {
+            return Ok(None);
+        }
+        self.snapshot
+            .read()
+            .map_err(|_| "hosted_policy_lock_failed")?
+            .clone()
+            .map(Some)
+            .ok_or("hosted_policy_not_synchronized")
+    }
+
+    pub(crate) fn project(
+        &self,
+        verified: &mut VerifiedTenantContext,
+    ) -> Result<Option<Vec<OrganizationUnitMembership>>, &'static str> {
+        let Some(policy) = self.current()? else {
+            return Ok(None);
+        };
+        let now = crate::now_ms();
+        let memberships = policy.memberships_for_identity(verified, now)?;
+        verified.strict_projection = Some(policy.project_identity(verified, now)?);
+        Ok(Some(memberships))
+    }
+
+    pub(crate) fn authorize_execution(
+        &self,
+        verified: Option<&VerifiedTenantContext>,
+    ) -> Result<(), &'static str> {
+        let Some(policy) = self.current()? else {
+            return Ok(());
+        };
+        let now = crate::now_ms();
+        let projection =
+            policy.project_identity(verified.ok_or("hosted_policy_identity_required")?, now)?;
+        if projection
+            .evaluate_access(
+                &policy.deployment_resource(),
+                AccessPermission::HostedUse,
+                DataClass::Internal,
+                now,
+            )
+            .decision
+            != AccessDecision::Allow
+        {
+            return Err("hosted_use_required");
+        }
+        Ok(())
+    }
+
     pub(crate) fn is_ready(&self) -> bool {
         let Ok(source) = self.source.read() else {
             return false;

--- a/crates/tandem-server/src/hosted_policy.rs
+++ b/crates/tandem-server/src/hosted_policy.rs
@@ -52,7 +52,7 @@ impl HostedPolicyRuntime {
         });
     }
 
-    fn current(&self) -> Result<Option<Arc<ValidatedHostedPolicy>>, &'static str> {
+    pub(crate) fn current(&self) -> Result<Option<Arc<ValidatedHostedPolicy>>, &'static str> {
         if self
             .source
             .read()

--- a/crates/tandem-server/src/hosted_policy.rs
+++ b/crates/tandem-server/src/hosted_policy.rs
@@ -37,6 +37,21 @@ pub(crate) struct HostedPolicyRuntime {
 }
 
 impl HostedPolicyRuntime {
+    #[cfg(test)]
+    pub(crate) fn configure_test_source(
+        &self,
+        organization_id: &str,
+        deployment_id: &str,
+        path: PathBuf,
+    ) {
+        *self.source.write().unwrap() = Some(PolicySource {
+            organization_id: organization_id.into(),
+            deployment_id: deployment_id.into(),
+            path,
+            started_at_ms: 0,
+        });
+    }
+
     fn current(&self) -> Result<Option<Arc<ValidatedHostedPolicy>>, &'static str> {
         if self
             .source

--- a/crates/tandem-server/src/hosted_policy_tests.rs
+++ b/crates/tandem-server/src/hosted_policy_tests.rs
@@ -1,0 +1,149 @@
+use super::*;
+use tandem_enterprise_contract::{
+    AuthorityChain, HumanActor, RequestPrincipal, TenantContextAssertionClaims,
+};
+
+fn policy_json(version: u64, generated_at_ms: u64, active: bool) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "schema_version": 1, "policy_version": version,
+        "organization_id": "org-a", "deployment_id": "dep-a",
+        "generated_at": chrono::DateTime::from_timestamp_millis(generated_at_ms as i64).unwrap(),
+        "users": [{"id": "alice", "email": null, "username": null,
+            "role": "member", "capabilities": ["hosted.use"], "is_active": active, "email_verified": true}],
+        "org_units": [], "org_unit_memberships": [], "deployment_grants": [],
+    })).unwrap()
+}
+
+fn identity(version: u64) -> VerifiedTenantContext {
+    let now = crate::now_ms();
+    let mut claims = TenantContextAssertionClaims::new_v1(
+        "tandem-web",
+        "tandem-runtime",
+        now,
+        now + 300_000,
+        "assertion-a",
+        TenantContext::explicit_user_workspace("org-a", "dep-a", Some("dep-a".into()), "alice"),
+        HumanActor::tandem_user("alice"),
+        AuthorityChain::from_request(RequestPrincipal::authenticated_user("alice", "tandem-web")),
+        vec!["hosted:role:member".into()],
+    );
+    claims.policy_version = Some(version);
+    claims.capabilities = vec!["hosted.use".into()];
+    claims.into()
+}
+
+fn write_input(path: &std::path::Path, bytes: &[u8]) {
+    std::fs::write(path, bytes).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn hosted_policy_persists_high_water_and_requires_fresh_restart_fetch() {
+    let state = crate::test_support::test_state().await;
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("policy.json");
+    let source = PolicySource {
+        organization_id: "org-a".into(),
+        deployment_id: "dep-a".into(),
+        path: path.clone(),
+        started_at_ms: 0,
+    };
+    *state.enterprise.hosted_policy.source.write().unwrap() = Some(source.clone());
+    assert!(state
+        .enterprise
+        .hosted_policy
+        .authorize(Some(&identity(4)))
+        .is_err());
+    write_input(&path, &policy_json(4, crate::now_ms(), true));
+    state.reload_hosted_policy().await.unwrap();
+    assert!(state
+        .enterprise
+        .hosted_policy
+        .authorize(Some(&identity(4)))
+        .is_ok());
+    write_input(&path, &policy_json(3, crate::now_ms(), true));
+    assert!(state
+        .reload_hosted_policy()
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("rollback"));
+    assert_eq!(
+        state
+            .enterprise
+            .hosted_policy
+            .revision()
+            .unwrap()
+            .unwrap()
+            .version,
+        4
+    );
+    write_input(&path, &policy_json(4, crate::now_ms(), false));
+    assert!(state
+        .reload_hosted_policy()
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("conflict"));
+    write_input(&path, &policy_json(5, crate::now_ms(), false));
+    state.reload_hosted_policy().await.unwrap();
+    assert!(state
+        .enterprise
+        .hosted_policy
+        .authorize(Some(&identity(4)))
+        .is_err());
+    assert!(state
+        .enterprise
+        .hosted_policy
+        .authorize(Some(&identity(5)))
+        .is_err());
+
+    // Simulate a fresh process with the same persisted store and input file.
+    *state.enterprise.hosted_policy.snapshot.write().unwrap() = None;
+    let boot = crate::now_ms() + 1;
+    *state.enterprise.hosted_policy.source.write().unwrap() = Some(PolicySource {
+        started_at_ms: boot,
+        ..source
+    });
+    assert!(state
+        .reload_hosted_policy()
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("after engine startup"));
+    assert!(state
+        .enterprise
+        .hosted_policy
+        .authorize(Some(&identity(5)))
+        .is_err());
+    write_input(&path, &policy_json(6, boot, true));
+    state.reload_hosted_policy().await.unwrap();
+    assert!(state
+        .enterprise
+        .hosted_policy
+        .authorize(Some(&identity(6)))
+        .is_ok());
+}
+
+#[test]
+fn snapshot_expiry_is_checked_at_effect_time_without_polling() {
+    let runtime = HostedPolicyRuntime::default();
+    *runtime.source.write().unwrap() = Some(PolicySource {
+        organization_id: "org-a".into(),
+        deployment_id: "dep-a".into(),
+        path: "/unused/policy.json".into(),
+        started_at_ms: 0,
+    });
+    let now = crate::now_ms();
+    let policy = HostedPolicyBundle::from_json(&policy_json(4, now - 120_000, true))
+        .unwrap()
+        .validate("org-a", "dep-a", now - 120_000, None)
+        .unwrap();
+    *runtime.snapshot.write().unwrap() = Some(Arc::new(policy));
+    assert!(runtime.authorize(Some(&identity(4))).is_err());
+    assert!(runtime.authorize(None).is_err());
+}

--- a/crates/tandem-server/src/hosted_policy_tests.rs
+++ b/crates/tandem-server/src/hosted_policy_tests.rs
@@ -87,6 +87,129 @@ fn write_input(path: &std::path::Path, bytes: &[u8]) {
 }
 
 #[tokio::test]
+async fn hosted_policy_registry_view_replaces_human_memberships_without_persisting_imports() {
+    use tandem_enterprise_contract::{
+        hosted_policy::{hosted_unit_principal, HOSTED_TAXONOMY_ID},
+        OrganizationUnit, OrganizationUnitAccessGrant, OrganizationUnitKind,
+        OrganizationUnitMembership, OrganizationUnitMembershipSource, PrincipalKind, PrincipalRef,
+        ResourceKind, ResourceRef,
+    };
+    let state = crate::test_support::test_state().await;
+    let tenant = identity(4).tenant_context;
+    let now = crate::now_ms();
+    let local = OrganizationUnit::active(
+        "local",
+        tenant.clone(),
+        "Local",
+        OrganizationUnitKind::Team,
+        PrincipalRef::human_user("operator"),
+        now,
+    );
+    state
+        .enterprise
+        .org_units
+        .write()
+        .await
+        .insert("local".into(), local.clone());
+    for (id, member) in [
+        ("old-human", PrincipalRef::human_user("alice")),
+        (
+            "service",
+            PrincipalRef::new(PrincipalKind::ServiceAccount, "automation"),
+        ),
+    ] {
+        state.enterprise.org_unit_memberships.write().await.insert(
+            id.into(),
+            OrganizationUnitMembership::active(
+                id,
+                tenant.clone(),
+                local.principal_ref(),
+                member,
+                OrganizationUnitMembershipSource::Direct,
+                now,
+            ),
+        );
+    }
+    let native_grant = OrganizationUnitAccessGrant::active(
+        "data",
+        tenant.clone(),
+        hosted_unit_principal("eng"),
+        ResourceRef::new("org-a", "dep-a", ResourceKind::Document, "engineering"),
+        now,
+    )
+    .with_permissions(vec![AccessPermission::Read]);
+    state
+        .enterprise
+        .org_unit_access_grants
+        .write()
+        .await
+        .insert("data".into(), native_grant.clone());
+    assert_eq!(
+        state
+            .enterprise_org_unit_view(&tenant)
+            .await
+            .unwrap()
+            .memberships
+            .len(),
+        2
+    );
+    *state.enterprise.hosted_policy.source.write().unwrap() = Some(PolicySource {
+        organization_id: "org-a".into(),
+        deployment_id: "dep-a".into(),
+        path: PathBuf::from("unused"),
+        started_at_ms: 0,
+    });
+    assert!(state.enterprise_org_unit_view(&tenant).await.is_err());
+    let mut input = HostedPolicyBundle::from_json(&policy_json(4, now, true)).unwrap();
+    input.org_units = serde_json::from_value(serde_json::json!([
+        {"id":"eng", "slug":"eng", "display_name":"Engineering", "kind":"department", "state":"active"}])).unwrap();
+    input.org_unit_memberships =
+        serde_json::from_value(serde_json::json!([{"unit_id":"eng", "user_id":"alice"}])).unwrap();
+    *state.enterprise.hosted_policy.snapshot.write().unwrap() = Some(Arc::new(
+        input.clone().validate("org-a", "dep-a", now, None).unwrap(),
+    ));
+    let view = state.enterprise_org_unit_view(&tenant).await.unwrap();
+    assert_eq!(view.hosted_policy_revision.unwrap().version, 4);
+    assert_eq!(view.units.len(), 2);
+    assert_eq!(view.memberships.len(), 2);
+    assert!(!view
+        .memberships
+        .iter()
+        .any(|row| row.membership_id == "old-human"));
+    let hosted_member = view
+        .memberships
+        .iter()
+        .find(|row| row.source == OrganizationUnitMembershipSource::HostedControlPlane)
+        .unwrap();
+    assert!(view.access_grants[0]
+        .to_scoped_grant_for_membership(hosted_member, now)
+        .is_some());
+    input.policy_version = 5;
+    input.org_unit_memberships.clear();
+    *state.enterprise.hosted_policy.snapshot.write().unwrap() = Some(Arc::new(
+        input.validate("org-a", "dep-a", now, None).unwrap(),
+    ));
+    let removed = state.enterprise_org_unit_view(&tenant).await.unwrap();
+    assert_eq!(removed.hosted_policy_revision.unwrap().version, 5);
+    assert_eq!(removed.memberships.len(), 1);
+    assert_eq!(removed.memberships[0].membership_id, "service");
+    assert_eq!(removed.access_grants, vec![native_grant]);
+    assert_eq!(state.enterprise.org_units.read().await.len(), 1);
+    assert_eq!(state.enterprise.org_unit_memberships.read().await.len(), 2);
+    let other =
+        TenantContext::explicit_user_workspace("other", "dep-a", Some("dep-a".into()), "alice");
+    assert!(state.enterprise_org_unit_view(&other).await.is_err());
+    state.enterprise.org_units.write().await.insert(
+        "conflict".into(),
+        local.with_taxonomy_id(HOSTED_TAXONOMY_ID),
+    );
+    assert!(matches!(
+        state.enterprise_org_unit_view(&tenant).await,
+        Err("hosted_registry_ownership_conflict")
+    ));
+}
+
+#[tokio::test]
 async fn hosted_policy_persists_high_water_and_requires_fresh_restart_fetch() {
     let state = crate::test_support::test_state().await;
     let temp = tempfile::tempdir().unwrap();

--- a/crates/tandem-server/src/hosted_policy_tests.rs
+++ b/crates/tandem-server/src/hosted_policy_tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use super::*;
 use tandem_enterprise_contract::{
     AuthorityChain, HumanActor, RequestPrincipal, TenantContextAssertionClaims,

--- a/crates/tandem-server/src/hosted_policy_tests.rs
+++ b/crates/tandem-server/src/hosted_policy_tests.rs
@@ -146,4 +146,47 @@ fn snapshot_expiry_is_checked_at_effect_time_without_polling() {
     *runtime.snapshot.write().unwrap() = Some(Arc::new(policy));
     assert!(runtime.authorize(Some(&identity(4))).is_err());
     assert!(runtime.authorize(None).is_err());
+    assert!(!runtime.is_ready());
+}
+
+#[tokio::test]
+async fn hosted_policy_public_health_reports_unavailable_until_a_fresh_snapshot() {
+    use axum::{
+        body::{to_bytes, Body},
+        http::Request,
+    };
+    use tower::ServiceExt;
+    let state = crate::test_support::test_state().await;
+    let app = crate::build_router_with_extensions(state.clone(), &[]);
+    *state.enterprise.hosted_policy.source.write().unwrap() = Some(PolicySource {
+        organization_id: "org-a".into(),
+        deployment_id: "dep-a".into(),
+        path: "/unused/policy.json".into(),
+        started_at_ms: 0,
+    });
+    for fresh in [false, true, false] {
+        if fresh {
+            let now = crate::now_ms();
+            let policy = HostedPolicyBundle::from_json(&policy_json(4, now, true))
+                .unwrap()
+                .validate("org-a", "dep-a", now, None)
+                .unwrap();
+            *state.enterprise.hosted_policy.snapshot.write().unwrap() = Some(Arc::new(policy));
+        } else {
+            *state.enterprise.hosted_policy.snapshot.write().unwrap() = None;
+        }
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/global/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(response.into_body(), 1024).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value, serde_json::json!({"healthy": fresh, "ready": fresh}));
+    }
 }

--- a/crates/tandem-server/src/hosted_policy_tests.rs
+++ b/crates/tandem-server/src/hosted_policy_tests.rs
@@ -4,6 +4,166 @@ use tandem_enterprise_contract::{
 };
 
 #[tokio::test]
+#[serial_test::serial(data_boundary_env)]
+async fn hosted_policy_direct_provider_rechecks_after_real_approval() {
+    use crate::http::session_run_retry::{
+        provider_auth_test_support::install_capturing_codex_provider,
+        scope_provider_auth_for_tenant, PromptExecutionSurface,
+    };
+    use crate::provider_egress::{prepare_chat_messages, ServerProviderEgressKind};
+    struct Restore(Vec<(&'static str, Option<std::ffi::OsString>)>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            for (name, value) in self.0.drain(..) {
+                if let Some(value) = value {
+                    std::env::set_var(name, value);
+                } else {
+                    std::env::remove_var(name);
+                }
+            }
+        }
+    }
+    let values = [
+        ("TANDEM_DATA_BOUNDARY_MODE", "enforce"),
+        ("TANDEM_DATA_BOUNDARY_STRICT", "1"),
+        (
+            "TANDEM_DATA_BOUNDARY_PROVIDER_CLASSES",
+            "openai-codex=approved_external",
+        ),
+        ("TANDEM_DATA_BOUNDARY_APPROVAL_CLASSES", "customer_data"),
+    ];
+    let _restore = Restore(
+        values
+            .iter()
+            .map(|(name, _)| (*name, std::env::var_os(name)))
+            .collect(),
+    );
+    for (name, value) in values {
+        std::env::set_var(name, value);
+    }
+    for revoked in [false, true] {
+        let state = crate::test_support::test_state().await;
+        let verified = identity(4);
+        let tenant = verified.tenant_context.clone();
+        let now = crate::now_ms();
+        let policy = HostedPolicyBundle::from_json(&policy_json(4, now, true)).unwrap();
+        *state.enterprise.hosted_policy.source.write().unwrap() = Some(PolicySource {
+            organization_id: "org-a".into(),
+            deployment_id: "dep-a".into(),
+            path: PathBuf::from("unused"),
+            started_at_ms: 0,
+        });
+        *state.enterprise.hosted_policy.snapshot.write().unwrap() = Some(Arc::new(
+            policy.validate("org-a", "dep-a", now, None).unwrap(),
+        ));
+        let sends = install_capturing_codex_provider(
+            &state,
+            "synthetic output",
+            &[(&tenant, "synthetic-access-token")],
+        )
+        .await;
+        let mut events = state.event_bus.subscribe();
+        let permissions = state.runtime.wait().permissions.clone();
+        let reply_state = state.clone();
+        let reply_tenant = tenant.clone();
+        let responder = tokio::spawn(async move {
+            tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+                loop {
+                    let event = events.recv().await.unwrap();
+                    if event.event_type != "permission.asked" {
+                        continue;
+                    }
+                    if revoked {
+                        let changed =
+                            HostedPolicyBundle::from_json(&policy_json(5, crate::now_ms(), false))
+                                .unwrap();
+                        *reply_state
+                            .enterprise
+                            .hosted_policy
+                            .snapshot
+                            .write()
+                            .unwrap() = Some(Arc::new(
+                            changed
+                                .validate("org-a", "dep-a", crate::now_ms(), None)
+                                .unwrap(),
+                        ));
+                    }
+                    assert!(permissions
+                        .reply_with_provenance_for_tenant(
+                            &reply_tenant,
+                            Some("session-direct"),
+                            event.properties["requestID"].as_str().unwrap(),
+                            "allow",
+                            Some("independent-reviewer".into()),
+                            Some("hosted-policy-test".into())
+                        )
+                        .await
+                        .unwrap()
+                        .is_some());
+                    break;
+                }
+            })
+            .await
+            .unwrap();
+        });
+        let dispatch = async {
+            let messages = [tandem_providers::ChatMessage {
+                role: "user".into(),
+                content: "ordinary mission content".into(),
+                attachments: vec![],
+            }];
+            let prepared = prepare_chat_messages(
+                &state,
+                Some(&tenant),
+                Some(&verified),
+                Some("run-direct"),
+                "session-direct",
+                "operation-direct",
+                "server.mission_builder",
+                ServerProviderEgressKind::MissionBuilder,
+                "openai-codex",
+                Some("codex-test"),
+                &messages,
+            )
+            .await
+            .map_err(anyhow::Error::msg)?;
+            state
+                .providers
+                .stream_with_egress_permit(
+                    &prepared.permit,
+                    Some("openai-codex"),
+                    Some("codex-test"),
+                    prepared.messages,
+                    tandem_types::ToolMode::None,
+                    None,
+                    tandem_types::SamplingParams::default(),
+                    tokio_util::sync::CancellationToken::new(),
+                )
+                .await
+                .map(|_| ())
+        };
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            scope_provider_auth_for_tenant(
+                &state,
+                &tenant,
+                Some(&verified),
+                PromptExecutionSurface::MissionBuilder,
+                Some("session-direct"),
+                Some("run-direct"),
+                Some("openai-codex"),
+                dispatch,
+            ),
+        )
+        .await
+        .unwrap();
+        responder.await.unwrap();
+        assert_eq!(result.is_ok(), !revoked, "{result:?}");
+        assert_eq!(sends.lock().unwrap().len(), usize::from(!revoked));
+    }
+}
+
+#[tokio::test]
 async fn hosted_policy_execution_requires_current_use_grant_and_replaces_projection() {
     let state = crate::test_support::test_state().await;
     assert!(state

--- a/crates/tandem-server/src/hosted_policy_tests.rs
+++ b/crates/tandem-server/src/hosted_policy_tests.rs
@@ -3,6 +3,51 @@ use tandem_enterprise_contract::{
     AuthorityChain, HumanActor, RequestPrincipal, TenantContextAssertionClaims,
 };
 
+#[tokio::test]
+async fn hosted_policy_execution_requires_current_use_grant_and_replaces_projection() {
+    let state = crate::test_support::test_state().await;
+    assert!(state
+        .enterprise
+        .hosted_policy
+        .authorize_execution(None)
+        .is_ok());
+    *state.enterprise.hosted_policy.source.write().unwrap() = Some(PolicySource {
+        organization_id: "org-a".into(),
+        deployment_id: "dep-a".into(),
+        path: PathBuf::from("unused"),
+        started_at_ms: 0,
+    });
+    let runtime = &state.enterprise.hosted_policy;
+    assert!(runtime.authorize_execution(Some(&identity(4))).is_err());
+    let now = crate::now_ms();
+    let policy = HostedPolicyBundle::from_json(&policy_json(4, now, true))
+        .unwrap()
+        .validate("org-a", "dep-a", now, None)
+        .unwrap();
+    *runtime.snapshot.write().unwrap() = Some(Arc::new(policy));
+    let mut verified = identity(4);
+    assert!(runtime.project(&mut verified).unwrap().unwrap().is_empty());
+    assert!(verified.strict_projection.is_some());
+    assert!(runtime.authorize_execution(Some(&verified)).is_ok());
+    let mut changed = HostedPolicyBundle::from_json(&policy_json(5, now, true)).unwrap();
+    changed.users[0].role = "viewer".into();
+    changed.users[0].capabilities = vec!["hosted.view".into()];
+    *runtime.snapshot.write().unwrap() = Some(Arc::new(
+        changed.validate("org-a", "dep-a", now, None).unwrap(),
+    ));
+    assert!(runtime.authorize_execution(Some(&verified)).is_err());
+    verified.policy_version = Some(5);
+    verified.roles = vec!["hosted:role:viewer".into()];
+    verified.capabilities = vec!["hosted.view".into()];
+    assert!(runtime.authorize(Some(&verified)).is_ok());
+    assert!(runtime.authorize_execution(Some(&verified)).is_err());
+    runtime.project(&mut verified).unwrap();
+    assert!(!verified
+        .strict_projection
+        .unwrap()
+        .has_permission(AccessPermission::HostedUse));
+}
+
 fn policy_json(version: u64, generated_at_ms: u64, active: bool) -> Vec<u8> {
     serde_json::to_vec(&serde_json::json!({
         "schema_version": 1, "policy_version": version,

--- a/crates/tandem-server/src/hosted_registry.rs
+++ b/crates/tandem-server/src/hosted_registry.rs
@@ -1,0 +1,88 @@
+//! Read-through view over local authoring and one immutable hosted revision.
+use crate::AppState;
+use tandem_enterprise_contract::{
+    hosted_policy::{HostedPolicyRevision, HOSTED_TAXONOMY_ID},
+    OrganizationUnit, OrganizationUnitAccessGrant, OrganizationUnitMembership,
+    OrganizationUnitMembershipSource, PrincipalKind, TenantContext,
+};
+
+pub struct EnterpriseOrgUnitView {
+    pub units: Vec<OrganizationUnit>,
+    pub memberships: Vec<OrganizationUnitMembership>,
+    pub access_grants: Vec<OrganizationUnitAccessGrant>,
+    pub hosted_policy_revision: Option<HostedPolicyRevision>,
+}
+
+fn same_scope(a: &TenantContext, b: &TenantContext) -> bool {
+    a.org_id == b.org_id && a.workspace_id == b.workspace_id && a.deployment_id == b.deployment_id
+}
+
+impl AppState {
+    pub async fn enterprise_org_unit_view(
+        &self,
+        tenant: &TenantContext,
+    ) -> Result<EnterpriseOrgUnitView, &'static str> {
+        let policy = self.enterprise.hosted_policy.current()?;
+        let mut units: Vec<_> = self
+            .enterprise
+            .org_units
+            .read()
+            .await
+            .values()
+            .filter(|row| same_scope(&row.tenant_context, tenant))
+            .cloned()
+            .collect();
+        let mut memberships: Vec<_> = self
+            .enterprise
+            .org_unit_memberships
+            .read()
+            .await
+            .values()
+            .filter(|row| same_scope(&row.tenant_context, tenant))
+            .cloned()
+            .collect();
+        let mut access_grants: Vec<_> = self
+            .enterprise
+            .org_unit_access_grants
+            .read()
+            .await
+            .values()
+            .filter(|row| same_scope(&row.tenant_context, tenant))
+            .cloned()
+            .collect();
+        let hosted_policy_revision = if let Some(policy) = policy {
+            if tenant.org_id != policy.bundle().organization_id
+                || tenant.workspace_id != policy.bundle().deployment_id
+                || tenant.deployment_id.as_deref() != Some(policy.bundle().deployment_id.as_str())
+            {
+                return Err("hosted_policy_scope_mismatch");
+            }
+            if units
+                .iter()
+                .any(|unit| unit.taxonomy_id == HOSTED_TAXONOMY_ID)
+            {
+                return Err("hosted_registry_ownership_conflict");
+            }
+            let projected = policy.registry_projection(crate::now_ms())?;
+            units.extend(projected.units);
+            // Hosted human memberships have a single owner. Native service and
+            // automation memberships retain their independently authored state.
+            memberships.retain(|row| {
+                row.member.kind != PrincipalKind::HumanUser
+                    && row.source != OrganizationUnitMembershipSource::HostedControlPlane
+                    && !row.unit.id.starts_with(&format!("{HOSTED_TAXONOMY_ID}/"))
+            });
+            memberships.extend(projected.memberships);
+            access_grants.extend(projected.access_grants);
+            Some(policy.revision().clone())
+        } else {
+            None
+        };
+        Ok(EnterpriseOrgUnitView {
+            units,
+            memberships,
+            access_grants,
+            hosted_policy_revision,
+        })
+    }
+}

--- a/crates/tandem-server/src/hosted_registry.rs
+++ b/crates/tandem-server/src/hosted_registry.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 //! Read-through view over local authoring and one immutable hosted revision.
 use crate::AppState;
 use tandem_enterprise_contract::{

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -81,6 +81,7 @@ mod goals_api;
 mod goals_projection;
 pub(crate) mod governance;
 pub(crate) mod host_authority;
+mod hosted_route_authority;
 pub(crate) mod incident_monitor;
 mod marketplace;
 pub(crate) mod mcp;

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -502,6 +502,7 @@ pub async fn serve_with_route_extensions(
             anyhow::anyhow!("context assertion security startup validation failed: {error}")
         })?;
     let memory_context_policy = apply_strict_tenant_enforcement_defaults()?;
+    state.start_hosted_policy_sync(runtime_auth_mode)?;
     if memory_context_policy.strict_required {
         if let Some(runtime) = state.runtime.get() {
             runtime.mcp.set_strict_tenant_enforcement(true);

--- a/crates/tandem-server/src/http/hosted_route_authority.rs
+++ b/crates/tandem-server/src/http/hosted_route_authority.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 //! Hosted operation grants are an additional gate. The handler must still
 //! authorize the individual automation/run, owner, governance and data scope.
 use axum::extract::{MatchedPath, Request};

--- a/crates/tandem-server/src/http/hosted_route_authority.rs
+++ b/crates/tandem-server/src/http/hosted_route_authority.rs
@@ -1,0 +1,53 @@
+//! Hosted operation grants are an additional gate. The handler must still
+//! authorize the individual automation/run, owner, governance and data scope.
+use axum::extract::{MatchedPath, Request};
+use tandem_types::AccessPermission;
+
+pub(super) fn required_permission(request: &Request) -> Option<AccessPermission> {
+    let path = request.extensions().get::<MatchedPath>()?.as_str();
+    let method = request.method().as_str();
+    let read = matches!(method, "GET" | "HEAD");
+    use AccessPermission::*;
+    match (method, path) {
+        (
+            _,
+            "/automations/v2"
+            | "/automations/v2/{id}"
+            | "/automations/v2/events"
+            | "/automations/v2/runs"
+            | "/automations/v2/{id}/runs"
+            | "/automations/v2/runs/{run_id}"
+            | "/automations/v2/{id}/handoffs"
+            | "/automations/v2/graduation/summary"
+            | "/automations/v2/runs/{run_id}/tasks/{node_id}/reset_preview",
+        ) if read => Some(HostedAutomationRead),
+        ("POST", "/automations/v2/{id}/share") => Some(HostedAutomationShare),
+        (
+            "POST",
+            "/automations/v2/{id}/run_now"
+            | "/automations/v2/{id}/pause"
+            | "/automations/v2/{id}/resume"
+            | "/automations/v2/runs/{run_id}/pause"
+            | "/automations/v2/runs/{run_id}/resume"
+            | "/automations/v2/runs/{run_id}/cancel"
+            | "/automations/v2/runs/{run_id}/recover"
+            | "/automations/v2/runs/{run_id}/repair"
+            | "/automations/v2/runs/{run_id}/tasks/{node_id}/retry"
+            | "/automations/v2/runs/{run_id}/tasks/{node_id}/continue"
+            | "/automations/v2/runs/{run_id}/tasks/{node_id}/requeue"
+            | "/automations/v2/runs/{run_id}/backlog/tasks/{task_id}/claim"
+            | "/automations/v2/runs/{run_id}/backlog/tasks/{task_id}/requeue",
+        ) => Some(HostedAutomationExecute),
+        ("POST", "/automations/v2")
+        | ("PATCH" | "DELETE", "/automations/v2/{id}")
+        | ("PATCH", "/automations/v2/runs/{run_id}/tasks/{node_id}/disposition") => {
+            Some(HostedAutomationWrite)
+        }
+        // Gate decisions keep their independent reviewer and governance checks.
+        ("POST", "/automations/v2/runs/{run_id}/gate") => Some(HostedAutomationExecute),
+        (_, "/workflows/runs" | "/workflows/runs/{id}" | "/workflows/events") if read => {
+            Some(HostedWorkflowRead)
+        }
+        _ => None,
+    }
+}

--- a/crates/tandem-server/src/http/mcp_run_as.rs
+++ b/crates/tandem-server/src/http/mcp_run_as.rs
@@ -102,9 +102,7 @@ pub(crate) async fn call_mcp_tool_for_tenant_with_audit(
         tool_name,
         args,
         tenant_context,
-        verified_context
-            .as_ref()
-            .and_then(|context| context.strict_projection.as_ref()),
+        verified_context.as_ref(),
     )
     .await
 }
@@ -123,7 +121,7 @@ pub(crate) async fn call_mcp_tool_for_tenant_with_verified_context(
         tool_name,
         args,
         tenant_context,
-        verified_context.and_then(|context| context.strict_projection.as_ref()),
+        verified_context,
     )
     .await
 }
@@ -134,8 +132,14 @@ async fn call_mcp_tool_for_tenant_with_trusted_context(
     tool_name: &str,
     args: Value,
     tenant_context: &TenantContext,
-    strict_context: Option<&StrictTenantContext>,
+    verified_context: Option<&VerifiedTenantContext>,
 ) -> Result<ToolResult, String> {
+    let strict_context = verified_context.and_then(|context| context.strict_projection.as_ref());
+    let authority = tandem_runtime::McpRequestAuthority::new({
+        let policy = state.enterprise.hosted_policy.clone();
+        let verified = verified_context.cloned();
+        move || policy.authorize(verified.as_ref()).map_err(str::to_owned)
+    });
     let phase_authority = extract_mcp_phase_tool_authority(&args);
     let run_as = resolve_mcp_run_as(state, server_name, tool_name, args, tenant_context).await?;
     let context_preflight = enforce_mcp_context_assertion_preflight(
@@ -156,11 +160,12 @@ async fn call_mcp_tool_for_tenant_with_trusted_context(
     .await?;
     let result = state
         .mcp
-        .call_tool_for_tenant(
+        .call_tool_for_tenant_with_authority(
             server_name,
             tool_name,
             run_as.args.clone(),
             &run_as.effective_tenant_context,
+            Some(authority),
         )
         .await;
     if result

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -1780,6 +1780,7 @@ fn resource_kind_scope_label(kind: ResourceKind) -> &'static str {
         ResourceKind::SourceObject => "source_object",
         ResourceKind::IngestionJob => "ingestion_job",
         ResourceKind::ExternalIntegrationAccount => "external_integration_account",
+        ResourceKind::HostedDeployment => "hosted_deployment",
     }
 }
 

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -203,6 +203,15 @@ async fn attach_enterprise_request_context_for_mode(
         return Ok(false);
     }
 
+    if let Err(reason) = state
+        .enterprise
+        .hosted_policy
+        .authorize(resolved.verified_tenant_context.as_ref())
+    {
+        tracing::warn!(target: "tandem_server::hosted_policy", reason, "hosted request authority denied");
+        append_authorization_denial_audit_event(state, &resolved).await?;
+        return Ok(false);
+    }
     if let Some(mut verified_tenant_context) = resolved.verified_tenant_context {
         enrich_verified_context_with_org_unit_grants(state, &mut verified_tenant_context).await;
         super::cross_tenant_grants::enrich_verified_context_with_inbound_cross_tenant_grants(

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -1863,7 +1863,7 @@ mod tests;
 mod hosted_policy_tests;
 
 #[cfg(test)]
-#[path = "middleware_hosted_signed_tests.rs"]
+#[path = "tests/middleware_hosted_signed_tests.rs"]
 mod hosted_signed_tests;
 
 #[cfg(test)]

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -224,6 +224,17 @@ async fn attach_enterprise_request_context_for_mode(
     } else {
         None
     };
+    if let Some(permission) = super::hosted_route_authority::required_permission(request) {
+        if let Err(reason) = state
+            .enterprise
+            .hosted_policy
+            .authorize_permission(resolved.verified_tenant_context.as_ref(), permission)
+        {
+            tracing::warn!(target: "tandem_server::hosted_policy", reason, "hosted operation denied");
+            append_authorization_denial_audit_event(state, &resolved).await?;
+            return Ok(false);
+        }
+    }
     if let Some(mut verified_tenant_context) = resolved.verified_tenant_context {
         enrich_verified_context_with_org_unit_grants(
             state,

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -1852,6 +1852,10 @@ mod tests;
 mod hosted_policy_tests;
 
 #[cfg(test)]
+#[path = "middleware_hosted_signed_tests.rs"]
+mod hosted_signed_tests;
+
+#[cfg(test)]
 mod slack_events_bypass_tests {
     use super::is_public_slack_events_path;
 

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -1847,6 +1847,10 @@ fn extract_request_token(headers: &HeaderMap) -> Option<String> {
 mod tests;
 
 #[cfg(test)]
+#[path = "middleware_hosted_policy_tests.rs"]
+mod hosted_policy_tests;
+
+#[cfg(test)]
 mod slack_events_bypass_tests {
     use super::is_public_slack_events_path;
 

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -173,7 +173,7 @@ async fn attach_enterprise_request_context_for_mode(
 ) -> Result<bool, String> {
     let headers = request.headers();
     let assertion_security = state.context_assertion_security_snapshot().ok();
-    let resolved = match resolve_enterprise_request_context_for_mode_with_cached_security(
+    let mut resolved = match resolve_enterprise_request_context_for_mode_with_cached_security(
         headers,
         mode,
         state.trust_test_tenant_headers.load(Ordering::Relaxed),
@@ -212,8 +212,25 @@ async fn attach_enterprise_request_context_for_mode(
         append_authorization_denial_audit_event(state, &resolved).await?;
         return Ok(false);
     }
+    let hosted_memberships = if let Some(verified) = resolved.verified_tenant_context.as_mut() {
+        match state.enterprise.hosted_policy.project(verified) {
+            Ok(memberships) => memberships,
+            Err(reason) => {
+                tracing::warn!(target: "tandem_server::hosted_policy", reason, "hosted projection denied");
+                append_authorization_denial_audit_event(state, &resolved).await?;
+                return Ok(false);
+            }
+        }
+    } else {
+        None
+    };
     if let Some(mut verified_tenant_context) = resolved.verified_tenant_context {
-        enrich_verified_context_with_org_unit_grants(state, &mut verified_tenant_context).await;
+        enrich_verified_context_with_org_unit_grants(
+            state,
+            &mut verified_tenant_context,
+            hosted_memberships,
+        )
+        .await;
         super::cross_tenant_grants::enrich_verified_context_with_inbound_cross_tenant_grants(
             state,
             &mut verified_tenant_context,
@@ -251,18 +268,23 @@ fn denial_audit_failure_response(error: &str) -> Response {
 async fn enrich_verified_context_with_org_unit_grants(
     state: &AppState,
     verified: &mut VerifiedTenantContext,
+    hosted_memberships: Option<Vec<OrganizationUnitMembership>>,
 ) {
     if verified.strict_projection.is_none() {
         return;
     }
-    let memberships = state
-        .enterprise
-        .org_unit_memberships
-        .read()
-        .await
-        .values()
-        .cloned()
-        .collect::<Vec<_>>();
+    let memberships = if let Some(memberships) = hosted_memberships {
+        memberships
+    } else {
+        state
+            .enterprise
+            .org_unit_memberships
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>()
+    };
     let access_grants = state
         .enterprise
         .org_unit_access_grants

--- a/crates/tandem-server/src/http/middleware_hosted_policy_tests.rs
+++ b/crates/tandem-server/src/http/middleware_hosted_policy_tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 use super::*;
 use tandem_enterprise_contract::hosted_policy::HostedPolicyBundle;
 use tandem_types::{AccessDecision, AuthorityChain, HumanActor};

--- a/crates/tandem-server/src/http/middleware_hosted_policy_tests.rs
+++ b/crates/tandem-server/src/http/middleware_hosted_policy_tests.rs
@@ -1,0 +1,94 @@
+use super::*;
+use tandem_enterprise_contract::hosted_policy::HostedPolicyBundle;
+use tandem_types::{AccessDecision, AuthorityChain, HumanActor};
+
+#[tokio::test]
+async fn hosted_policy_removed_membership_cannot_reappear_from_local_registry() {
+    let state = crate::test_support::test_state().await;
+    let now = crate::now_ms();
+    let mut input = HostedPolicyBundle::from_json(serde_json::json!({
+        "schema_version": 1, "policy_version": 1, "organization_id": "org-a", "deployment_id": "dep-a",
+        "generated_at": chrono::DateTime::from_timestamp_millis(now as i64).unwrap(),
+        "users": [{"id": "alice", "email": null, "username": null, "role": "member",
+            "capabilities": ["hosted.use"], "is_active": true, "email_verified": true}],
+        "org_units": [{"id": "eng", "slug": "eng", "display_name": "Engineering", "kind": "department", "state": "active"}],
+        "org_unit_memberships": [{"unit_id": "eng", "user_id": "alice"}], "deployment_grants": []
+    }).to_string().as_bytes()).unwrap();
+    let policy = input.clone().validate("org-a", "dep-a", now, None).unwrap();
+    let tenant =
+        TenantContext::explicit_user_workspace("org-a", "dep-a", Some("dep-a".into()), "alice");
+    let mut claims = TenantContextAssertionClaims::new_v1(
+        "tandem-web",
+        "tandem-runtime",
+        now,
+        now + 300_000,
+        "assertion-a",
+        tenant.clone(),
+        HumanActor::tandem_user("alice"),
+        AuthorityChain::from_request(RequestPrincipal::authenticated_user("alice", "tandem-web")),
+        vec!["hosted:role:member".into()],
+    );
+    claims.policy_version = Some(1);
+    claims.org_units = vec!["eng".into()];
+    claims.capabilities = vec!["hosted.use".into()];
+    let mut verified: VerifiedTenantContext = claims.into();
+    let memberships = policy.memberships_for_identity(&verified, now).unwrap();
+    state
+        .enterprise
+        .org_unit_memberships
+        .write()
+        .await
+        .insert("retained-membership".into(), memberships[0].clone());
+    let document = ResourceRef::new(
+        "org-a",
+        "dep-a",
+        ResourceKind::Document,
+        "engineering-document",
+    );
+    state
+        .enterprise
+        .org_unit_access_grants
+        .write()
+        .await
+        .insert(
+            "grant-eng".into(),
+            OrganizationUnitAccessGrant::active(
+                "grant-eng",
+                tenant,
+                PrincipalRef::organization_unit("eng"),
+                document.clone(),
+                now,
+            )
+            .with_permissions(vec![AccessPermission::Read])
+            .with_data_classes(vec![DataClass::Internal]),
+        );
+    verified.strict_projection = Some(policy.project_identity(&verified, now).unwrap());
+    enrich_verified_context_with_org_unit_grants(&state, &mut verified, Some(memberships)).await;
+    let access = |verified: &VerifiedTenantContext| {
+        verified
+            .strict_projection
+            .as_ref()
+            .unwrap()
+            .evaluate_access(&document, AccessPermission::Read, DataClass::Internal, now)
+            .decision
+    };
+    assert_eq!(access(&verified), AccessDecision::Allow);
+
+    input.policy_version = 2;
+    input.org_unit_memberships.clear();
+    let removed = input
+        .validate("org-a", "dep-a", now, Some(policy.revision()))
+        .unwrap();
+    verified.policy_version = Some(2);
+    verified.org_units.clear();
+    verified.strict_projection = Some(removed.project_identity(&verified, now).unwrap());
+    let removed_memberships = removed.memberships_for_identity(&verified, now).unwrap();
+    enrich_verified_context_with_org_unit_grants(&state, &mut verified, Some(removed_memberships))
+        .await;
+    assert_ne!(access(&verified), AccessDecision::Allow);
+    assert_eq!(state.enterprise.org_unit_memberships.read().await.len(), 1);
+
+    // Unconfigured local policy enrichment preserves its existing behavior.
+    enrich_verified_context_with_org_unit_grants(&state, &mut verified, None).await;
+    assert_eq!(access(&verified), AccessDecision::Allow);
+}

--- a/crates/tandem-server/src/http/middleware_hosted_policy_tests.rs
+++ b/crates/tandem-server/src/http/middleware_hosted_policy_tests.rs
@@ -55,7 +55,7 @@ async fn hosted_policy_removed_membership_cannot_reappear_from_local_registry() 
             OrganizationUnitAccessGrant::active(
                 "grant-eng",
                 tenant,
-                PrincipalRef::organization_unit("eng"),
+                tandem_enterprise_contract::hosted_policy::hosted_unit_principal("eng"),
                 document.clone(),
                 now,
             )

--- a/crates/tandem-server/src/http/middleware_hosted_signed_tests.rs
+++ b/crates/tandem-server/src/http/middleware_hosted_signed_tests.rs
@@ -1,0 +1,164 @@
+//! Signed HTTP ingress with the actual key verifier, durable replay store and
+//! file-backed policy reload. Uses disposable state; no environment overrides.
+use super::*;
+use axum::{
+    body::{to_bytes, Body},
+    routing::get,
+    Extension, Router,
+};
+use serde_json::Value;
+use tandem_types::{AuthorityChain, HumanActor};
+use tower::ServiceExt;
+
+fn claims(actor: &str, role: &str, version: u64, now: u64) -> TenantContextAssertionClaims {
+    let mut claims = TenantContextAssertionClaims::new_v1(
+        "tandem-web",
+        "tandem-runtime",
+        now,
+        now + 60_000,
+        format!("assertion-{actor}-{version}-{role}"),
+        TenantContext::explicit_user_workspace("org-a", "dep-a", Some("dep-a".into()), actor),
+        HumanActor::tandem_user(actor),
+        AuthorityChain::from_request(RequestPrincipal::authenticated_user(actor, "tandem-web")),
+        vec![format!("hosted:role:{role}")],
+    );
+    claims.policy_version = Some(version);
+    claims.capabilities = tandem_enterprise_contract::hosted_policy::role_capabilities(role)
+        .iter()
+        .map(|cap| cap.to_string())
+        .collect();
+    claims
+}
+
+fn write_policy(path: &std::path::Path, version: u64, alice_role: Option<&str>, now: u64) {
+    let users: Vec<_> = [("alice", alice_role), ("bob", Some("member"))]
+        .into_iter()
+        .filter_map(|(id, role)| {
+            role.map(|role| json!({
+            "id": id, "email": null, "username": null, "role": role,
+            "capabilities": tandem_enterprise_contract::hosted_policy::role_capabilities(role),
+            "is_active": true, "email_verified": true,
+        }))
+        })
+        .collect();
+    std::fs::write(path, serde_json::to_vec(&json!({
+        "schema_version": 1, "policy_version": version, "organization_id": "org-a", "deployment_id": "dep-a",
+        "generated_at": chrono::DateTime::from_timestamp_millis(now as i64).unwrap(), "users": users,
+        "org_units": [], "org_unit_memberships": [], "deployment_grants": []
+    })).unwrap()).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+}
+
+async fn probe(Extension(verified): Extension<VerifiedTenantContext>) -> Json<Value> {
+    let strict = verified.strict_projection.unwrap();
+    Json(
+        json!({"hosted_admin": strict.has_permission(AccessPermission::HostedAdmin),
+        "generic_admin": strict.has_permission(AccessPermission::Admin),
+        "hosted_use": strict.has_permission(AccessPermission::HostedUse)}),
+    )
+}
+
+async fn ingress(State(state): State<AppState>, mut request: Request, next: Next) -> Response {
+    match attach_enterprise_request_context_for_mode(
+        &state,
+        &mut request,
+        RuntimeAuthMode::HostedSingleTenant,
+    )
+    .await
+    {
+        Ok(true) => next.run(request).await,
+        Ok(false) => StatusCode::FORBIDDEN.into_response(),
+        Err(error) => panic!("required test denial receipt failed: {error}"),
+    }
+}
+
+async fn request(app: &Router, assertion: &str) -> Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .uri("/probe")
+                .header("x-tandem-context-assertion", assertion)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn hosted_policy_signed_http_downgrade_removal_and_unaffected_user_refresh() {
+    let state = crate::test_support::test_state().await;
+    let temp = tempfile::tempdir().unwrap();
+    let key = ed25519_dalek::SigningKey::from_bytes(&[39; 32]);
+    let raw = json!({"key-a": {"purpose": "context_assertion",
+        "public_key": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key.verifying_key().to_bytes()),
+        "organization_id": "org-a", "deployment_id": "dep-a", "allowed_audiences": ["tandem-runtime"], "status": "active"}}).to_string();
+    let security = crate::context_assertion_security::RuntimeContextAssertionSecurity::from_test_metadata_keyring(&raw, &temp.path().join("replay.json"));
+    *state.context_assertion_security.write().unwrap() = Some(std::sync::Arc::new(security));
+    let path = temp.path().join("policy.json");
+    state
+        .enterprise
+        .hosted_policy
+        .configure_test_source("org-a", "dep-a", path.clone());
+    let app = Router::new()
+        .route("/probe", get(probe))
+        .layer(axum::middleware::from_fn_with_state(state.clone(), ingress));
+    let now = crate::now_ms();
+    let sign = |actor, role, version| {
+        super::tests::sign_test_context_assertion(&key, "key-a", claims(actor, role, version, now))
+    };
+    let alice = sign("alice", "admin", 1);
+    assert_eq!(request(&app, &alice).await.status(), StatusCode::FORBIDDEN);
+    write_policy(&path, 1, Some("admin"), now);
+    state.reload_hosted_policy().await.unwrap();
+    let response = request(&app, &alice).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let value: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), 4096).await.unwrap()).unwrap();
+    assert_eq!(
+        value,
+        json!({"hosted_admin": true, "generic_admin": false, "hosted_use": true})
+    );
+    let bob = sign("bob", "member", 1);
+    assert_eq!(request(&app, &bob).await.status(), StatusCode::OK);
+
+    write_policy(&path, 2, Some("viewer"), now);
+    state.reload_hosted_policy().await.unwrap();
+    assert_eq!(request(&app, &alice).await.status(), StatusCode::FORBIDDEN);
+    assert_eq!(request(&app, &bob).await.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        request(&app, &sign("bob", "member", 2)).await.status(),
+        StatusCode::OK
+    );
+    let viewer = request(&app, &sign("alice", "viewer", 2)).await;
+    assert_eq!(viewer.status(), StatusCode::OK);
+    let value: Value =
+        serde_json::from_slice(&to_bytes(viewer.into_body(), 4096).await.unwrap()).unwrap();
+    assert_eq!(
+        value,
+        json!({"hosted_admin": false, "generic_admin": false, "hosted_use": false})
+    );
+
+    write_policy(&path, 3, None, now);
+    state.reload_hosted_policy().await.unwrap();
+    assert_eq!(
+        request(&app, &sign("alice", "viewer", 3)).await.status(),
+        StatusCode::FORBIDDEN
+    );
+    assert_eq!(
+        request(&app, &sign("bob", "member", 3)).await.status(),
+        StatusCode::OK
+    );
+    let wrong_key = ed25519_dalek::SigningKey::from_bytes(&[40; 32]);
+    let forged = super::tests::sign_test_context_assertion(
+        &wrong_key,
+        "key-a",
+        claims("bob", "member", 3, now),
+    );
+    assert_eq!(request(&app, &forged).await.status(), StatusCode::FORBIDDEN);
+    assert!(temp.path().join("replay.json").is_file());
+}

--- a/crates/tandem-server/src/http/middleware_hosted_signed_tests.rs
+++ b/crates/tandem-server/src/http/middleware_hosted_signed_tests.rs
@@ -89,6 +89,61 @@ async fn request(app: &Router, assertion: &str) -> Response {
         .unwrap()
 }
 
+fn private_automation(owner: &str) -> crate::AutomationV2Spec {
+    let mut automation = crate::AutomationV2Spec {
+        automation_id: format!("private-{owner}"),
+        name: format!("Private {owner} automation"),
+        description: None,
+        status: crate::AutomationV2Status::Paused,
+        schedule: crate::AutomationV2Schedule {
+            schedule_type: crate::AutomationV2ScheduleType::Manual,
+            cron_expression: None,
+            interval_seconds: None,
+            timezone: "UTC".into(),
+            misfire_policy: crate::RoutineMisfirePolicy::RunOnce,
+        },
+        knowledge: tandem_orchestrator::KnowledgeBinding::default(),
+        agents: Vec::new(),
+        flow: crate::AutomationFlowSpec { nodes: Vec::new() },
+        execution: crate::AutomationExecutionPolicy::default(),
+        output_targets: Vec::new(),
+        created_at_ms: crate::now_ms(),
+        updated_at_ms: crate::now_ms(),
+        creator_id: owner.into(),
+        workspace_root: None,
+        metadata: Some(
+            json!({"resource_access": {"visibility": "private", "owner_principal": {"kind": "human_user", "id": owner}}}),
+        ),
+        next_fire_at_ms: None,
+        last_fired_at_ms: None,
+        scope_policy: None,
+        watch_conditions: Vec::new(),
+        handoff_config: None,
+    };
+    automation.set_tenant_context(&TenantContext::explicit_user_workspace(
+        "org-a",
+        "dep-a",
+        Some("dep-a".into()),
+        owner,
+    ));
+    automation
+}
+
+async fn automation_request(app: &Router, assertion: &str, method: &str, path: &str) -> Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(path)
+                .header("x-tandem-context-assertion", assertion)
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
 #[tokio::test]
 async fn hosted_policy_signed_http_downgrade_removal_and_unaffected_user_refresh() {
     let state = crate::test_support::test_state().await;
@@ -104,9 +159,10 @@ async fn hosted_policy_signed_http_downgrade_removal_and_unaffected_user_refresh
         .enterprise
         .hosted_policy
         .configure_test_source("org-a", "dep-a", path.clone());
-    let app = Router::new()
+    let app = super::super::routes_routines_automations::apply(Router::new())
         .route("/probe", get(probe))
-        .layer(axum::middleware::from_fn_with_state(state.clone(), ingress));
+        .layer(axum::middleware::from_fn_with_state(state.clone(), ingress))
+        .with_state(state.clone());
     let now = crate::now_ms();
     let sign = |actor, role, version| {
         super::tests::sign_test_context_assertion(&key, "key-a", claims(actor, role, version, now))
@@ -161,4 +217,69 @@ async fn hosted_policy_signed_http_downgrade_removal_and_unaffected_user_refresh
     );
     assert_eq!(request(&app, &forged).await.status(), StatusCode::FORBIDDEN);
     assert!(temp.path().join("replay.json").is_file());
+
+    for owner in ["alice", "bob"] {
+        state
+            .put_automation_v2(private_automation(owner))
+            .await
+            .unwrap();
+    }
+    write_policy(&path, 4, Some("viewer"), now);
+    state.reload_hosted_policy().await.unwrap();
+    assert_eq!(
+        automation_request(&app, &sign("alice", "viewer", 4), "GET", "/automations/v2")
+            .await
+            .status(),
+        StatusCode::FORBIDDEN
+    );
+
+    // Explicit operation grants unlock only the corresponding surface. The
+    // existing per-resource ownership check must still hide Bob's private row.
+    write_policy(&path, 5, Some("viewer"), now);
+    let mut policy: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    policy["deployment_grants"] = json!([{"id": "grant-alice", "deployment_id": "dep-a",
+        "principal_kind": "member", "principal_id": "alice", "resource_kind": "deployment", "resource_id": "dep-a",
+        "permissions": ["automation.read", "automation.write"]}]);
+    std::fs::write(&path, serde_json::to_vec(&policy).unwrap()).unwrap();
+    state.reload_hosted_policy().await.unwrap();
+    let fresh = sign("alice", "viewer", 5);
+    let response = automation_request(&app, &fresh, "GET", "/automations/v2").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let value: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), 65536).await.unwrap()).unwrap();
+    assert_eq!(value["count"], 1);
+    assert_eq!(value["automations"][0]["automation_id"], "private-alice");
+    assert_eq!(
+        automation_request(&app, &fresh, "GET", "/automations/v2/private-bob")
+            .await
+            .status(),
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        automation_request(&app, &fresh, "DELETE", "/automations/v2/private-bob")
+            .await
+            .status(),
+        StatusCode::FORBIDDEN
+    );
+    for action in ["run_now", "share"] {
+        assert_eq!(
+            automation_request(
+                &app,
+                &fresh,
+                "POST",
+                &format!("/automations/v2/private-alice/{action}")
+            )
+            .await
+            .status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+    assert_eq!(
+        automation_request(&app, &fresh, "DELETE", "/automations/v2/private-alice")
+            .await
+            .status(),
+        StatusCode::OK
+    );
+    assert!(state.get_automation_v2("private-alice").await.is_none());
+    assert!(state.get_automation_v2("private-bob").await.is_some());
 }

--- a/crates/tandem-server/src/http/middleware_tests.rs
+++ b/crates/tandem-server/src/http/middleware_tests.rs
@@ -1175,7 +1175,7 @@ fn test_claims(issued_at_ms: u64, expires_at_ms: u64) -> TenantContextAssertionC
     )
 }
 
-fn sign_test_context_assertion(
+pub(super) fn sign_test_context_assertion(
     signing_key: &ed25519_dalek::SigningKey,
     kid: &str,
     claims: TenantContextAssertionClaims,

--- a/crates/tandem-server/src/http/mission_builder_host.rs
+++ b/crates/tandem-server/src/http/mission_builder_host.rs
@@ -349,6 +349,7 @@ async fn invoke_mission_builder_provider(
     let builder_future = crate::http::session_run_retry::scope_provider_auth_for_tenant(
         state,
         tenant_context,
+        verified_tenant_context,
         crate::http::session_run_retry::PromptExecutionSurface::MissionBuilder,
         Some(session_id),
         Some(run_id),

--- a/crates/tandem-server/src/http/session_kb_grounding.rs
+++ b/crates/tandem-server/src/http/session_kb_grounding.rs
@@ -1162,6 +1162,7 @@ async fn synthesize_strict_kb_answer(
     let stream = match crate::http::session_run_retry::scope_provider_auth_for_tenant(
         state,
         tenant_context,
+        verified_tenant_context,
         crate::http::session_run_retry::PromptExecutionSurface::KnowledgeBase,
         Some(session_id),
         Some(run_id),
@@ -1279,6 +1280,7 @@ async fn retry_strict_kb_non_streaming_synthesis(
     crate::http::session_run_retry::scope_provider_auth_for_tenant(
         state,
         tenant_context,
+        verified_tenant_context,
         crate::http::session_run_retry::PromptExecutionSurface::KnowledgeBase,
         Some(session_id),
         Some(run_id),

--- a/crates/tandem-server/src/http/session_run_retry.rs
+++ b/crates/tandem-server/src/http/session_run_retry.rs
@@ -11,8 +11,8 @@
 
 use serde_json::json;
 use tandem_data_boundary::SensitiveDataClass;
-use tandem_providers::ProviderAuthRecovery;
-use tandem_types::{SendMessageRequest, TenantContext};
+use tandem_providers::{ProviderAuthRecovery, ProviderDispatchAuthority};
+use tandem_types::{SendMessageRequest, TenantContext, VerifiedTenantContext};
 
 use super::sessions::publish_tenant_event;
 use crate::http::AppState;
@@ -197,6 +197,7 @@ fn recovery_for_execution(
 pub(crate) async fn scope_provider_auth_for_tenant<F>(
     state: &AppState,
     tenant_context: &TenantContext,
+    verified_tenant_context: Option<&VerifiedTenantContext>,
     surface: PromptExecutionSurface,
     session_id: Option<&str>,
     run_id: Option<&str>,
@@ -240,6 +241,17 @@ where
     }
 
     let recovery = recovery_for_execution(state, tenant_context, surface, session_id, run_id);
+    let policy = state.enterprise.hosted_policy.clone();
+    let verified = verified_tenant_context.cloned();
+    let authority = ProviderDispatchAuthority::new(move || {
+        let policy = policy.clone();
+        let verified = verified.clone();
+        async move {
+            policy
+                .authorize_execution(verified.as_ref())
+                .map_err(anyhow::Error::msg)
+        }
+    });
     let allow_private_provider_endpoints =
         crate::http::host_authority::standalone_local_runtime_posture(state, tenant_context);
     state
@@ -248,7 +260,7 @@ where
             tenant_context.clone(),
             recovery,
             allow_private_provider_endpoints,
-            future,
+            authority.scope(future),
         )
         .await
 }
@@ -265,11 +277,8 @@ pub(crate) async fn run_prompt_with_auth_recovery(
     correlation_id: Option<String>,
     tenant_context: &TenantContext,
 ) -> anyhow::Result<()> {
-    let session_model = state
-        .storage
-        .get_session(session_id)
-        .await
-        .and_then(|session| session.model);
+    let session = state.storage.get_session(session_id).await;
+    let session_model = session.as_ref().and_then(|session| session.model.as_ref());
     let provider_id_hint = req
         .model
         .as_ref()
@@ -291,6 +300,9 @@ pub(crate) async fn run_prompt_with_auth_recovery(
     scope_provider_auth_for_tenant(
         state,
         tenant_context,
+        session
+            .as_ref()
+            .and_then(|session| session.verified_tenant_context.as_ref()),
         surface,
         Some(session_id),
         Some(run_id),

--- a/crates/tandem-server/src/http/skills_memory_parts/part04.rs
+++ b/crates/tandem-server/src/http/skills_memory_parts/part04.rs
@@ -1746,6 +1746,7 @@ pub(super) async fn context_generate_layers(
     crate::http::session_run_retry::scope_provider_auth_for_tenant(
         &state,
         &tenant_context,
+        verified_tenant_context.as_deref(),
         crate::http::session_run_retry::PromptExecutionSurface::KnowledgeBase,
         Some(&layer_session_id),
         Some(&layer_run_id),
@@ -1827,6 +1828,7 @@ pub(super) async fn context_distill(
     let report = crate::http::session_run_retry::scope_provider_auth_for_tenant(
         &state,
         &tenant_context,
+        verified_tenant_context.as_deref(),
         crate::http::session_run_retry::PromptExecutionSurface::KnowledgeBase,
         Some(&input.session_id),
         Some(&provider_auth_run_id),

--- a/crates/tandem-server/src/http/tests/middleware_hosted_signed_tests.rs
+++ b/crates/tandem-server/src/http/tests/middleware_hosted_signed_tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
 //! Signed HTTP ingress with the actual key verifier, durable replay store and
 //! file-backed policy reload. Uses disposable state; no environment overrides.
 use super::*;

--- a/crates/tandem-server/src/http/workflow_planner_transport.rs
+++ b/crates/tandem-server/src/http/workflow_planner_transport.rs
@@ -353,9 +353,13 @@ pub(crate) async fn invoke_planner_provider(
         )
     };
 
+    let dispatch_session = state.storage.get_session(session_id).await;
     let planner_future = crate::http::session_run_retry::scope_provider_auth_for_tenant(
         state,
         tenant_context,
+        dispatch_session
+            .as_ref()
+            .and_then(|session| session.verified_tenant_context.as_ref()),
         crate::http::session_run_retry::PromptExecutionSurface::Planner,
         Some(session_id),
         Some(run_id),

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -80,6 +80,8 @@ pub mod failures;
 pub mod goal_capability_learning;
 pub(crate) mod governance_store;
 pub(crate) mod hosted_policy;
+mod hosted_registry;
+pub use hosted_registry::EnterpriseOrgUnitView;
 pub mod http;
 pub mod incident_monitor;
 pub mod incident_monitor_github;

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -79,6 +79,7 @@ pub mod eval_support;
 pub mod failures;
 pub mod goal_capability_learning;
 pub(crate) mod governance_store;
+pub(crate) mod hosted_policy;
 pub mod http;
 pub mod incident_monitor;
 pub mod incident_monitor_github;

--- a/crates/tandem-tools/src/tool_dispatcher.rs
+++ b/crates/tandem-tools/src/tool_dispatcher.rs
@@ -214,6 +214,12 @@ impl std::error::Error for ToolDispatchBlocked {}
 
 #[async_trait]
 pub trait ToolDispatchPolicy: Send + Sync {
+    /// Recheck mutable authority after receipts/approvals, immediately before
+    /// dispatch. Implementations must not create another approval request.
+    async fn revalidate(&self, _context: &ToolDispatchContext) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn evaluate(
         &self,
         context: ToolDispatchPolicyContext,
@@ -706,7 +712,9 @@ impl GovernedToolDispatcher {
         })
         .await?;
 
-        let result = if canonical_tool.as_deref() == Some("batch") || name == "batch" {
+        let result = if let Err(error) = context.policy.revalidate(&context).await {
+            Err(error.context("tool authority revoked before dispatch"))
+        } else if canonical_tool.as_deref() == Some("batch") || name == "batch" {
             self.execute_governed_batch(args, context.clone(), cancel, progress)
                 .await
         } else {

--- a/docs/PRIVATE_IDENTITY_FOUNDATION.md
+++ b/docs/PRIVATE_IDENTITY_FOUNDATION.md
@@ -117,3 +117,41 @@ passed. This environment result is not a passing remote-host deployment gate.
 TAN-824's pure solution planner receives the verified context from this trusted
 host boundary. Planning never provisions accounts; apply must reauthorize the
 current user and recheck memberships, grants and bindings before every mutation.
+
+## Hosted policy synchronization
+
+The opt-in runtime security v2 profile consumes the existing control plane's
+authenticated policy bundle. One complete, validated snapshot owns hosted human
+memberships and deployment-operation grants. The engine rejects mismatched
+organization/deployment scope, rollback, conflicting content at the same
+revision, and snapshots at least 120 seconds old. The timestamp check permits
+at most five seconds of future clock skew. Failed fetches do not extend trust.
+Every process restart requires a fetch generated after startup; the durable
+high-water record prevents rollback but cannot restore live authority itself.
+
+An accepted revision invalidates assertions from older revisions, including
+those belonging to unaffected users; those users must obtain fresh assertions.
+Current authority is checked at HTTP ingress and again at governed execution
+boundaries after approval, provider credential recovery and MCP readiness waits.
+This bounds future dispatch; it cannot undo an external effect already sent.
+
+Hosted permissions use a distinct deployment resource and typed operations.
+For example, `hosted.use` permits runtime execution without granting generic
+document Read or Admin. Automation operations additionally retain their existing
+resource-owner/audience checks. Administrative routes require their existing
+independent authorization until individually integrated.
+
+The existing enterprise registry APIs expose imported units under the reserved
+`hosted-control-plane` taxonomy. Their principal IDs are
+`hosted-control-plane/{unit_id}`. Imported rows are ephemeral, and local API
+writes cannot claim that namespace or membership source. Local data grants can
+target these units, but apply only through current hosted memberships. Retained
+local human memberships cannot restore removed hosted authority. The readiness
+view uses one hosted revision and does not count deployment-operation grants as
+proof of governed data access.
+
+Focused tests live in the contract's `hosted_policy` module and the server,
+core, provider and MCP hosted-policy tests. Cross-repository process acceptance
+uses the source-pinned enterprise engine and copied authenticated policy agent
+in `tandem-agents`. Release-image verification, clean-host encrypted recovery
+and full two-user/two-department governed-memory acceptance remain required.

--- a/docs/SECURITY_ROUTE_POLICY_INVENTORY.json
+++ b/docs/SECURITY_ROUTE_POLICY_INVENTORY.json
@@ -4414,7 +4414,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:161"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:198"
       ]
     },
     {
@@ -4427,7 +4427,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:161"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:198"
       ]
     },
     {
@@ -4440,7 +4440,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:161"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:198"
       ]
     },
     {
@@ -4453,7 +4453,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:169"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:206"
       ]
     },
     {
@@ -4466,7 +4466,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:165"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:202"
       ]
     },
     {
@@ -4479,7 +4479,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:165"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:202"
       ]
     },
     {
@@ -4492,7 +4492,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:153"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:190"
       ]
     },
     {
@@ -4505,7 +4505,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:153"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:190"
       ]
     },
     {
@@ -4518,7 +4518,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:153"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:190"
       ]
     },
     {
@@ -4531,7 +4531,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:157"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:194"
       ]
     },
     {
@@ -4544,7 +4544,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:149"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:186"
       ]
     },
     {
@@ -4557,7 +4557,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:149"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:186"
       ]
     },
     {
@@ -4570,7 +4570,7 @@
       "resolver": "deployment_or_enterprise_state",
       "policy_origin": "admin.deployment",
       "sources": [
-        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:149"
+        "crates/tandem-enterprise-server/src/http/routes_enterprise_org_units.rs:186"
       ]
     },
     {


### PR DESCRIPTION
## What changed?

Accept an authenticated hosted-policy snapshot with explicit scope, monotonic revision and bounded freshness; project it through existing enterprise registries and strict authorization. Revalidate current identity/HostedUse after approval, provider recovery and MCP readiness, including direct mission-builder/planner/KB provider paths. Keep hosted operation permissions separate from generic data access/Admin and preserve native resource-owner checks.

## Why?

A valid signed assertion alone did not establish current membership or grants. Removed or downgraded users could retain authority while work waited. New revisions invalidate old assertions; unaffected users regain access with fresh assertions. Restart requires a new fetch, and the existing durable governance store preserves only the rollback high-water mark.

## How to test

- `cargo test -p tandem-enterprise-contract hosted_policy --lib`
- `cargo test -p tandem-server hosted_policy --lib`
- `cargo test -p tandem-core hosted_policy --lib`
- `cargo test -p tandem-server session_run_retry --lib`, plus `workflow_planner_transport` and `mission_builder_host`
- `cargo test -p tandem-enterprise-server hosted_policy --lib`; provider/MCP suites and formatting in CI.
- Deterministic approval/revocation, signed HTTP, registry ownership and actual MCP network-effect fixtures added.

Current candidate e5e1d334 passed all workflows, including [focused policy checks](https://github.com/frumu-ai/tandem/actions/runs/33993631500), [Engine CI](https://github.com/frumu-ai/tandem/actions/runs/33993631322) (5142 passed, 7 intentional skips), [PostgreSQL/backend/frontend CI](https://github.com/frumu-ai/tandem/actions/runs/33993631511), and [Security Assurance/release composition](https://github.com/frumu-ai/tandem/actions/runs/33993631494). ACME, evaluation, enforcement drift, Rust security and solution contract workflows also passed. [Actual non-root process integration](https://github.com/frumu-ai/tandem-agents/actions/runs/33994289523) passed at agents04f03f4 against this exact engine. Web907e0cf consumes that tested bundle and passed its integration suite. Required independent review is complete and findings are addressed.

## UX / Screenshots (if UI)

No UI change. Existing public health response shape is preserved; readiness includes current policy.

## Security considerations

- [x] No secrets added; acceptance uses synthetic identities and disposable services.
- [x] Permission and filesystem changes reviewed. One independent review found the direct-provider omission; the shared-boundary fix and regression are included.

Relates to TAN-834/TAN-840/TAN-836; does not complete any whole issue. Compatible release images, signing/recovery lifecycle, full governed-memory privacy and durable solution installation remain acceptance work. No automatic merge.