### PR TITLE
TAN-842: make setup doctor fail on unavailable or unready engines

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -89,3 +89,8 @@ e64795105ba26d08348f26d8cbcc0d6d615976da:guide/src/content/docs/engine-authentic
 # for a loopback-only fake engine. The current test uses a short test placeholder.
 # Keep all-history scanning enabled; other commits and findings remain blocking.
 6689c1dc3c6a3332fedde925ff2deac33ad0e9aa:packages/tandem-control-panel/tests/hosted-session-integration.test.mjs:tandem-token-assignment:77
+
+# Reviewed 2026-09-05: exact historical doctor fixture placeholder, never a
+# credential. The test asserts it is absent from diagnostics and never sends it.
+# Current fixture uses a short placeholder. No rule/path-wide exclusion.
+92cc0f75ab9c01bb0d8f5c01271519b10b20b5cc:packages/tandem-control-panel/tests/doctor-readiness.test.mjs:tandem-token-assignment:29

--- a/packages/tandem-control-panel/README.md
+++ b/packages/tandem-control-panel/README.md
@@ -73,6 +73,21 @@ tandem panel doctor
 tandem panel open
 ```
 
+`tandem panel doctor --json` checks the installed panel/engine packages and the
+engine's current public health response. Its exit status is nonzero when the
+engine is unreachable, returns an invalid/error response, or reports either
+`ready` or `healthy` as false. Each check includes a stable code and a suggested
+next action. Doctor reads configuration without initializing state or changing
+credentials; use `init` explicitly when setup is missing.
+
+The result has `scope: "runtime-health"`. `ok` covers these basic checks only:
+it does not prove authenticated identity, current policy, functional model or
+storage access, backup recovery, or Company Brain activation. Those unperformed
+checks are represented by `authenticated: null`, `policyCurrent: null` and
+`solutionReady: false`. Every invocation fetches health again; no earlier green
+result is reused. Optional transcription/connector services are outside this
+basic health check and do not disable text-only diagnosis.
+
 ## Run Foreground
 
 ```bash

--- a/packages/tandem-control-panel/lib/setup/doctor.js
+++ b/packages/tandem-control-panel/lib/setup/doctor.js
@@ -5,6 +5,45 @@ import { ensureBootstrapEnv } from "./env.js";
 import { isLoopbackHost } from "./common.js";
 const require = createRequire(import.meta.url);
 
+function diagnosticUrl(value) {
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:"].includes(url.protocol)) return "invalid";
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return "invalid";
+  }
+}
+
+async function probeEngine(engineUrl) {
+  let running = false;
+  try {
+    const url = new URL(engineUrl);
+    if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+      return { running, engineHealth: null, code: "engine_url_invalid" };
+    }
+    const res = await fetch(`${url.toString().replace(/\/$/, "")}/global/health`, {
+      signal: AbortSignal.timeout(1500),
+      redirect: "error",
+    });
+    running = true;
+    if (!res.ok) return { running, engineHealth: null, code: "engine_health_http_error" };
+    const body = await res.json();
+    if (!body || typeof body.ready !== "boolean" || typeof body.healthy !== "boolean") {
+      return { running, engineHealth: null, code: "engine_health_invalid" };
+    }
+    // Keep only the public booleans, never arbitrary response/error content.
+    const engineHealth = { ready: body.ready, healthy: body.healthy };
+    return { running, engineHealth, code: body.ready && body.healthy ? "engine_ready" : "engine_not_ready" };
+  } catch {
+    return { running, engineHealth: null, code: running ? "engine_health_invalid" : "engine_unreachable" };
+  }
+}
+
 async function runDoctor(options = {}) {
   const bootstrap = await ensureBootstrapEnv({
     envPath: options.envFile,
@@ -13,6 +52,7 @@ async function runDoctor(options = {}) {
     cwd: options.cwd,
     allowAmbientStateEnv: options.allowAmbientStateEnv,
     allowCwdEnvMerge: options.allowCwdEnvMerge,
+    readOnly: true,
   });
   const distExists = existsSync(new URL("../../dist", import.meta.url));
   let engineResolvable = false;
@@ -20,13 +60,17 @@ async function runDoctor(options = {}) {
     require.resolve("@frumu/tandem/bin/tandem-engine.js");
     engineResolvable = true;
   } catch {}
-  let engineHealth = null;
-  try {
-    const res = await fetch(`${bootstrap.engineUrl}/global/health`, {
-      signal: AbortSignal.timeout(1500),
-    });
-    if (res.ok) engineHealth = await res.json();
-  } catch {}
+  const probe = await probeEngine(bootstrap.engineUrl);
+  const { engineHealth, running } = probe;
+  const runtimeReady = probe.code === "engine_ready";
+  const checks = [
+    { id: "panel_bundle", status: distExists ? "passed" : "failed", code: distExists ? "panel_installed" : "panel_bundle_missing",
+      remediation: distExists ? null : "Install or build the control panel distribution." },
+    { id: "engine_package", status: engineResolvable ? "passed" : "failed", code: engineResolvable ? "engine_installed" : "engine_package_missing",
+      remediation: engineResolvable ? null : "Install the supported engine package." },
+    { id: "engine_readiness", status: runtimeReady ? "passed" : "failed", code: probe.code,
+      remediation: runtimeReady ? null : "Check the configured engine URL and service, then inspect its readiness diagnostics and run doctor again." },
+  ];
   let serviceManager = "none";
   if (process.platform === "linux") {
     serviceManager = "systemd";
@@ -34,12 +78,22 @@ async function runDoctor(options = {}) {
     serviceManager = "launchd";
   }
   const result = {
-    ok: Boolean(distExists && engineResolvable),
+    scope: "runtime-health",
+    ok: checks.every((check) => check.status === "passed"),
+    installed: Boolean(distExists && engineResolvable),
+    running,
+    runtimeReady,
+    authenticated: null,
+    policyCurrent: null,
+    solutionReady: false,
+    solutionReadinessCode: "authenticated_solution_checks_not_run",
+    checkedAt: new Date().toISOString(),
+    checks,
     envFile: bootstrap.envPath,
     panelHost: bootstrap.panelHost,
     panelPort: bootstrap.panelPort,
-    panelPublicUrl: bootstrap.env.TANDEM_CONTROL_PANEL_PUBLIC_URL || "",
-    engineUrl: bootstrap.engineUrl,
+    panelPublicUrl: bootstrap.env.TANDEM_CONTROL_PANEL_PUBLIC_URL ? diagnosticUrl(bootstrap.env.TANDEM_CONTROL_PANEL_PUBLIC_URL) : "",
+    engineUrl: diagnosticUrl(bootstrap.engineUrl),
     distExists,
     engineResolvable,
     serviceManager,
@@ -66,6 +120,11 @@ function printDoctor(result, json = false) {
   console.log(
     `[Tandem Setup] Engine health:${result.engineHealth ? ` ready=${result.engineHealth.ready === true}` : " unavailable"}`
   );
+  for (const check of result.checks || []) {
+    console.log(`[Tandem Setup] ${check.id}: ${check.status} (${check.code})`);
+    if (check.remediation) console.log(`[Tandem Setup] Action: ${check.remediation}`);
+  }
+  console.log("[Tandem Setup] Solution readiness: unverified; authenticated identity, policy, storage, provider and recovery checks are still required.");
   for (const warning of result.warnings || []) {
     console.log(`[Tandem Setup] Warning:     ${warning}`);
   }

--- a/packages/tandem-control-panel/lib/setup/env.js
+++ b/packages/tandem-control-panel/lib/setup/env.js
@@ -128,11 +128,11 @@ async function ensureBootstrapEnv(options = {}) {
   const defaults = { ...bootstrapDefaults(paths), ...example };
   const merged = { ...defaults, ...cwdEnv, ...existing };
 
-  if (
+  if (!options.readOnly && (
     overwrite ||
     !merged.TANDEM_CONTROL_PANEL_ENGINE_TOKEN ||
     merged.TANDEM_CONTROL_PANEL_ENGINE_TOKEN === "tk_change_me"
-  ) {
+  )) {
     merged.TANDEM_CONTROL_PANEL_ENGINE_TOKEN = `tk_${randomBytes(16).toString("hex")}`;
   }
 
@@ -163,11 +163,13 @@ async function ensureBootstrapEnv(options = {}) {
     if (!preferredOrder.includes(key)) ordered.push([key, value]);
   }
 
-  await mkdir(dirname(envPath), { recursive: true });
-  await mkdir(paths.logsDir, { recursive: true });
-  await mkdir(paths.engineStateDir, { recursive: true });
-  await mkdir(paths.controlPanelStateDir, { recursive: true });
-  writeFileSync(envPath, serializeEnv(ordered), "utf8");
+  if (!options.readOnly) {
+    await mkdir(dirname(envPath), { recursive: true });
+    await mkdir(paths.logsDir, { recursive: true });
+    await mkdir(paths.engineStateDir, { recursive: true });
+    await mkdir(paths.controlPanelStateDir, { recursive: true });
+    writeFileSync(envPath, serializeEnv(ordered), "utf8");
+  }
 
   return {
     envPath,

--- a/packages/tandem-control-panel/tests/doctor-readiness.test.mjs
+++ b/packages/tandem-control-panel/tests/doctor-readiness.test.mjs
@@ -26,7 +26,7 @@ async function installedPanel() {
   }
   const { runDoctor } = await import(pathToFileURL(join(panel, "lib/setup/doctor.js")));
   const envFile = join(root, "panel.env");
-  const source = "TANDEM_CONTROL_PANEL_ENGINE_TOKEN=synthetic-private-token\nTANDEM_ENGINE_URL=";
+  const source = "TANDEM_CONTROL_PANEL_ENGINE_TOKEN=doctor-fixture\nTANDEM_ENGINE_URL=";
   const env = { HOME: root, XDG_CONFIG_HOME: root, XDG_DATA_HOME: root };
   const cli = () => new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [join(panel, "bin/cli.js"), "doctor", "--json", "--env-file", envFile], {
@@ -45,7 +45,7 @@ async function installedPanel() {
     const result = await runDoctor({ cwd: root, envFile, env, allowAmbientStateEnv: false, allowCwdEnvMerge: false });
     assert.equal(await readFile(envFile, "utf8"), before, "doctor must not rewrite credentials/configuration");
     assert.equal(result.installed, true);
-    assert.ok(!JSON.stringify(result).includes("synthetic-private-token"));
+    assert.ok(!JSON.stringify(result).includes("doctor-fixture"));
     assert.deepEqual((await readdir(root)).sort(), ["panel", "panel.env"], "doctor must not initialize state");
     return result;
   } };

--- a/packages/tandem-control-panel/tests/doctor-readiness.test.mjs
+++ b/packages/tandem-control-panel/tests/doctor-readiness.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { copyFile, mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+import { runDoctor } from "../lib/setup/doctor.js";
+
+async function installedPanel() {
+  const root = await mkdtemp(join(tmpdir(), "tandem-doctor-installed-"));
+  const panel = join(root, "panel");
+  await mkdir(join(panel, "lib/setup"), { recursive: true });
+  await mkdir(join(panel, "dist"));
+  // Isolated installed package: test actual resolution without changing the checkout.
+  const engine = join(panel, "node_modules/@frumu/tandem/bin");
+  await mkdir(engine, { recursive: true });
+  await writeFile(join(engine, "tandem-engine.js"), "throw new Error('doctor must not start the engine');\n");
+  await writeFile(join(panel, "package.json"), '{"type":"module"}');
+  await mkdir(join(panel, "bin"));
+  await mkdir(join(panel, "lib/setup/services"));
+  await copyFile(new URL("../bin/cli.js", import.meta.url), join(panel, "bin/cli.js"));
+  for (const name of ["doctor", "env", "paths", "common", "bootstrap", "services/systemd", "services/launchd", "services/common"]) {
+    await copyFile(new URL(`../lib/setup/${name}.js`, import.meta.url), join(panel, `lib/setup/${name}.js`));
+  }
+  const { runDoctor } = await import(pathToFileURL(join(panel, "lib/setup/doctor.js")));
+  const envFile = join(root, "panel.env");
+  const source = "TANDEM_CONTROL_PANEL_ENGINE_TOKEN=synthetic-private-token\nTANDEM_ENGINE_URL=";
+  const env = { HOME: root, XDG_CONFIG_HOME: root, XDG_DATA_HOME: root };
+  const cli = () => new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [join(panel, "bin/cli.js"), "doctor", "--json", "--env-file", envFile], {
+      cwd: root, env: { ...env, PATH: process.env.PATH, ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "", error = "";
+    child.stdout.on("data", (chunk) => { output += chunk; });
+    child.stderr.on("data", (chunk) => { error += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, output, error }));
+  });
+  return { root, envFile, cli, run: async (url) => {
+    await writeFile(envFile, source + url + "\n");
+    const before = await readFile(envFile, "utf8");
+    const result = await runDoctor({ cwd: root, envFile, env, allowAmbientStateEnv: false, allowCwdEnvMerge: false });
+    assert.equal(await readFile(envFile, "utf8"), before, "doctor must not rewrite credentials/configuration");
+    assert.equal(result.installed, true);
+    assert.ok(!JSON.stringify(result).includes("synthetic-private-token"));
+    assert.deepEqual((await readdir(root)).sort(), ["panel", "panel.env"], "doctor must not initialize state");
+    return result;
+  } };
+}
+
+test("installed packages cannot hide stopped, unready, invalid or recovered engine state", async (t) => {
+  const panel = await installedPanel();
+  let response = { ready: false, healthy: false };
+  let status = 200;
+  const seen = [];
+  const server = createServer((request, reply) => {
+    seen.push({ path: request.url, authorization: request.headers.authorization });
+    reply.writeHead(status, { "content-type": "application/json" });
+    reply.end(typeof response === "string" ? response : JSON.stringify(response));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => server.close());
+  const url = `http://127.0.0.1:${server.address().port}`;
+  for (const body of [{ ready: false, healthy: true }, { ready: true, healthy: false }, {}, null,
+                       { ready: "true", healthy: true }, "not json synthetic-private-response"]) {
+    response = body;
+    const result = await panel.run(url);
+    assert.equal(result.ok, false);
+    assert.equal(result.running, true);
+    assert.equal(result.runtimeReady, false);
+    assert.equal(result.solutionReady, false);
+    assert.ok(!JSON.stringify(result).includes("synthetic-private-response"));
+  }
+  status = 503;
+  response = { ready: true, healthy: true };
+  assert.equal((await panel.run(url)).checks[2].code, "engine_health_http_error");
+  status = 200;
+  response = { ready: true, healthy: true, private: "synthetic-private-response" };
+  const recovered = await panel.run(url);
+  assert.equal(recovered.ok, true);
+  assert.equal(recovered.runtimeReady, true);
+  assert.equal(recovered.solutionReady, false, "public liveness cannot establish authenticated solution readiness");
+  assert.equal(recovered.authenticated, null);
+  assert.equal(recovered.policyCurrent, null);
+  assert.deepEqual(recovered.engineHealth, { ready: true, healthy: true });
+  const recoveredCli = await panel.cli();
+  assert.equal(recoveredCli.code, 0, recoveredCli.error);
+  assert.equal(JSON.parse(recoveredCli.output).solutionReady, false);
+  assert.ok(seen.every((request) => request.path === "/global/health" && request.authorization === undefined));
+  await new Promise((resolve) => server.close(resolve));
+  const stopped = await panel.run(url);
+  assert.equal(stopped.ok, false, "previous green result must not survive loss of the engine");
+  assert.equal(stopped.running, false);
+  assert.equal(stopped.checks[2].code, "engine_unreachable");
+  const stoppedCli = await panel.cli();
+  assert.equal(stoppedCli.code, 1, stoppedCli.error);
+  assert.equal(JSON.parse(stoppedCli.output).ok, false);
+});
+
+test("diagnostics reject credential-bearing URLs without sending or printing them", async () => {
+  const panel = await installedPanel();
+  const result = await panel.run("https://private-user:private-password@example.invalid?token=private-query");
+  assert.equal(result.ok, false);
+  assert.equal(result.checks[2].code, "engine_url_invalid");
+  assert.equal(result.engineUrl, "https://example.invalid");
+  for (const secret of ["private-user", "private-password", "private-query"]) {
+    assert.ok(!JSON.stringify(result).includes(secret));
+  }
+});
+
+test("doctor does not initialize a missing configuration or generate new credentials", async () => {
+  const root = await mkdtemp(join(tmpdir(), "tandem-doctor-missing-"));
+  const env = { HOME: root, XDG_CONFIG_HOME: root, XDG_DATA_HOME: root };
+  await runDoctor({ cwd: root, envFile: join(root, "missing.env"), env,
+    allowAmbientStateEnv: false, allowCwdEnvMerge: false });
+  assert.deepEqual(await readdir(root), []);
+});


### PR DESCRIPTION
## What changed?

Setup doctor now requires installed packages and a current valid public engine response with ready/healthy true for its basic-health success status. Structured check codes and remediation distinguish installation from HTTP availability and runtime readiness. The JSON explicitly labels its runtime-health scope and leaves authenticated identity/current policy unverified and solutionReady false.

## Why?

An installed panel and engine package previously made doctor exit successfully even if the engine was stopped. Doctor also rewrote the bootstrap environment during inspection. It now uses the existing environment resolver in read-only mode, without generating replacement credentials or initializing state. Public responses are reduced to health booleans; credential-bearing URLs are rejected and sanitized in diagnostics.

## How to test

Five doctor tests passed locally, including an isolated installed-package fixture with real HTTP responses and actual CLI child processes: stopped/unready/error/malformed engine, recovery followed by another outage, configuration preservation, missing setup and secret-free output. Two existing bootstrap-write tests also passed. Three existing platform path assertions fail identically on Windows in the unchanged baseline and candidate. Linux CI33998124249 at 6c307029 passed every required job, including panel and PostgreSQL storage; the prior92cc panel run recorded 164 contract tests and 184 browser/accessibility tests. Current Gitleaks passed after classifying the exact historical synthetic doctor placeholder. Current Security Assurance33998124348 also passed every job, including Linux Enterprise Release Composition and both container checks. No customer environment or engine was contacted.

## Remaining work

This is the initial TAN-842 health-reporting repair. It does not implement authenticated solution readiness, selected storage/provider probes, backup/restore verification, support export or durable installer resume. Those remain required; whole issue stays open. No automatic merge.