### PR TITLE
TAN-827: bind scoped customer configuration to existing solution planning

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -89,3 +89,8 @@ e64795105ba26d08348f26d8cbcc0d6d615976da:guide/src/content/docs/engine-authentic
 # for a loopback-only fake engine. The current test uses a short test placeholder.
 # Keep all-history scanning enabled; other commits and findings remain blocking.
 6689c1dc3c6a3332fedde925ff2deac33ad0e9aa:packages/tandem-control-panel/tests/hosted-session-integration.test.mjs:tandem-token-assignment:77
+
+# Reviewed 2026-09-05: exact historical doctor fixture placeholder, never a
+# credential. The test asserts it is absent from diagnostics and never sends it.
+# Current fixture uses a short placeholder. No rule/path-wide exclusion.
+92cc0f75ab9c01bb0d8f5c01271519b10b20b5cc:packages/tandem-control-panel/tests/doctor-readiness.test.mjs:tandem-token-assignment:29

--- a/crates/tandem-solutions/fixtures/company-brain-text/customer-a.yaml
+++ b/crates/tandem-solutions/fixtures/company-brain-text/customer-a.yaml
@@ -1,0 +1,29 @@
+schema_version: "1"
+scope:
+  org_id: org-a
+  workspace_id: workspace-a
+  deployment_id: deployment-a
+  instance_id: company-brain
+profile_ref: profile-ref:synthetic-company-a
+timezone: Europe/Budapest
+locale: en
+models:
+  economy: local.fixture
+secret_refs: {}
+data_refs:
+  notes: data-ref:synthetic-notes-a
+memory_spaces:
+  private:
+    kind: private_user
+    subject_id: owner-a
+  shared:
+    kind: tenant_shared
+  projects:
+    kind: project
+    project_id: project-a
+constraints:
+  allowed_providers: [local]
+  allow_network_egress: false
+  max_tokens_per_run: 2048
+  max_concurrent_runs: 1
+  max_daily_cost_microusd: 0

--- a/crates/tandem-solutions/fixtures/company-brain-text/customer-b.yaml
+++ b/crates/tandem-solutions/fixtures/company-brain-text/customer-b.yaml
@@ -1,0 +1,30 @@
+schema_version: "1"
+scope:
+  org_id: org-b
+  workspace_id: workspace-b
+  deployment_id: deployment-b
+  instance_id: company-brain
+profile_ref: profile-ref:synthetic-company-b
+timezone: America/New_York
+locale: fr
+models:
+  economy: local.fixture
+preferences:
+  reply-language: fr
+data_refs:
+  notes: data-ref:synthetic-notes-b
+memory_spaces:
+  private:
+    kind: private_user
+    subject_id: owner-b
+  shared:
+    kind: tenant_shared
+  projects:
+    kind: project
+    project_id: project-b
+constraints:
+  allowed_providers: [local]
+  allow_network_egress: false
+  max_tokens_per_run: 1024
+  max_concurrent_runs: 1
+  max_daily_cost_microusd: 0

--- a/crates/tandem-solutions/src/customer_config.rs
+++ b/crates/tandem-solutions/src/customer_config.rs
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+use crate::validate::{digest, identifier};
+use crate::*;
+use std::collections::{BTreeMap, BTreeSet};
+use tandem_enterprise_contract::VerifiedTenantContext;
+
+/// All approved sets and the selected installation come from the trusted host
+/// for this caller. Never deserialize these inputs from the customer document.
+pub struct CustomerConfigInput<'a> {
+    pub verified_context: &'a VerifiedTenantContext,
+    pub selected_scope: &'a CustomerScope,
+    pub now_ms: u64,
+    pub current_revision: Option<&'a str>,
+    pub expected_revision: Option<&'a str>,
+    pub host_policy: &'a Constraints,
+    pub approved_references: &'a BTreeSet<String>,
+    pub approved_connectors: &'a BTreeMap<String, ConnectorBinding>,
+    pub approved_subjects: &'a BTreeSet<String>,
+    pub approved_org_units: &'a BTreeSet<String>,
+    pub approved_projects: &'a BTreeSet<String>,
+}
+
+fn invalid(path: &str) -> SolutionError {
+    SolutionError::new(
+        "invalid_customer_config",
+        path,
+        "Invalid customer configuration field",
+    )
+}
+
+fn reference(value: &str, prefix: &str, path: &str) -> Result<(), SolutionError> {
+    let suffix = value.strip_prefix(prefix).ok_or_else(|| invalid(path))?;
+    identifier(suffix, path)
+}
+
+pub fn parse_customer_config(input: &str) -> Result<CustomerConfig, SolutionError> {
+    if input.len() > MAX_BLUEPRINT_BYTES {
+        return Err(SolutionError::new(
+            "size_limit",
+            "$",
+            "Customer configuration exceeds 1 MiB",
+        ));
+    }
+    // As with blueprints, reject duplicate YAML/JSON keys before typed maps.
+    let value: serde_yaml::Value = serde_yaml::from_str(input).map_err(|_| invalid("$"))?;
+    let config: CustomerConfig = serde_yaml::from_value(value).map_err(|_| invalid("$"))?;
+    validate_customer_config(&config)?;
+    Ok(config)
+}
+
+pub fn validate_customer_config(config: &CustomerConfig) -> Result<(), SolutionError> {
+    if config.schema_version != SCHEMA_VERSION {
+        return Err(SolutionError::new(
+            "unsupported_schema",
+            "schema_version",
+            "Expected string version 1",
+        ));
+    }
+    for (path, value) in [
+        ("scope.org_id", &config.scope.org_id),
+        ("scope.workspace_id", &config.scope.workspace_id),
+        ("scope.deployment_id", &config.scope.deployment_id),
+        ("scope.instance_id", &config.scope.instance_id),
+    ] {
+        identifier(value, path)?;
+    }
+    reference(&config.profile_ref, "profile-ref:", "profile_ref")?;
+    if config.timezone.is_empty()
+        || config.timezone.len() > 80
+        || config.timezone.contains("..")
+        || !config
+            .timezone
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"/_+-".contains(&b))
+    {
+        return Err(invalid("timezone"));
+    }
+    if config.locale.is_empty()
+        || config.locale.len() > 35
+        || !config
+            .locale
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-')
+    {
+        return Err(invalid("locale"));
+    }
+    if [
+        config.optional_components.len(),
+        config.preferences.len(),
+        config.connectors.len(),
+        config.models.len(),
+        config.secret_refs.len(),
+        config.data_refs.len(),
+        config.memory_spaces.len(),
+    ]
+    .into_iter()
+    .any(|length| length > MAX_COMPONENTS)
+    {
+        return Err(SolutionError::new(
+            "size_limit",
+            "$",
+            "Customer collections exceed 256 entries",
+        ));
+    }
+    for (path, references, prefix) in [
+        ("secret_refs", &config.secret_refs, "secret-ref:"),
+        ("data_refs", &config.data_refs, "data-ref:"),
+    ] {
+        for (slot, value) in references {
+            identifier(slot, path)?;
+            reference(value, prefix, path)?;
+        }
+    }
+    for (slot, space) in &config.memory_spaces {
+        identifier(slot, "memory_spaces")?;
+        match space {
+            CustomerMemorySpace::PrivateUser { subject_id } => {
+                identifier(subject_id, "memory_spaces.subject_id")?
+            }
+            CustomerMemorySpace::DepartmentShared { org_unit_id } => {
+                identifier(org_unit_id, "memory_spaces.org_unit_id")?
+            }
+            CustomerMemorySpace::Project { project_id } => {
+                identifier(project_id, "memory_spaces.project_id")?
+            }
+            CustomerMemorySpace::TenantShared => (),
+        }
+    }
+    Ok(())
+}
+
+pub fn customer_config_revision(config: &CustomerConfig) -> Result<String, SolutionError> {
+    validate_customer_config(config)?;
+    Ok(sha256(&canonical_json(config)?))
+}
+
+/// Produces inputs for the existing resolver, never an activation receipt.
+/// The eventual apply transaction must repeat the revision/authority checks
+/// atomically with persistence; this pure check does not lock a database.
+pub fn prepare_customer_config(
+    blueprint: &SolutionBlueprint,
+    config: &CustomerConfig,
+    input: CustomerConfigInput<'_>,
+) -> Result<PreparedCustomerConfig, SolutionError> {
+    validate_blueprint(blueprint)?;
+    let revision = customer_config_revision(config)?;
+    let authority = crate::resolve::authority_binding(input.verified_context, input.now_ms)?;
+    if config.scope != *input.selected_scope
+        || config.scope.org_id != authority.org_id
+        || config.scope.workspace_id != authority.workspace_id
+        || config.scope.deployment_id != authority.deployment_id
+    {
+        return Err(SolutionError::new(
+            "customer_scope_mismatch",
+            "scope",
+            "Select the authorized organization and installation",
+        ));
+    }
+    for value in [input.current_revision, input.expected_revision]
+        .into_iter()
+        .flatten()
+    {
+        digest(value, "expected_revision")?;
+    }
+    if input.current_revision != input.expected_revision {
+        return Err(SolutionError::new(
+            "customer_revision_conflict",
+            "expected_revision",
+            "Configuration changed; preview the current revision",
+        ));
+    }
+    for value in std::iter::once(&config.profile_ref)
+        .chain(config.secret_refs.values())
+        .chain(config.data_refs.values())
+    {
+        if !input.approved_references.contains(value) {
+            return Err(SolutionError::new(
+                "customer_reference_denied",
+                "references",
+                "Host must approve each reference for this scope and caller",
+            ));
+        }
+    }
+    for (capability, binding) in &config.connectors {
+        if input.approved_connectors.get(capability) != Some(binding) {
+            return Err(SolutionError::new(
+                "customer_connector_denied",
+                "connectors",
+                "CapabilityResolver must approve the current account generation",
+            ));
+        }
+    }
+    if !config
+        .memory_spaces
+        .keys()
+        .eq(blueprint.memory_spaces.keys())
+    {
+        return Err(SolutionError::new(
+            "customer_memory_binding_denied",
+            "memory_spaces",
+            "Bind every declared memory space exactly once",
+        ));
+    }
+    for (slot, space) in &config.memory_spaces {
+        let (kind, approved) = match space {
+            CustomerMemorySpace::PrivateUser { subject_id } => (
+                MemorySpace::PrivateUser,
+                input.approved_subjects.contains(subject_id),
+            ),
+            CustomerMemorySpace::DepartmentShared { org_unit_id } => (
+                MemorySpace::DepartmentShared,
+                input.approved_org_units.contains(org_unit_id),
+            ),
+            CustomerMemorySpace::Project { project_id } => (
+                MemorySpace::Project,
+                input.approved_projects.contains(project_id),
+            ),
+            CustomerMemorySpace::TenantShared => (MemorySpace::TenantShared, true),
+        };
+        if blueprint.memory_spaces.get(slot) != Some(&kind) || !approved {
+            return Err(SolutionError::new(
+                "customer_memory_binding_denied",
+                "memory_spaces",
+                "Bind a declared space to an existing authorized subject, department or project",
+            ));
+        }
+    }
+    Ok(PreparedCustomerConfig {
+        request: InstallRequest {
+            instance_id: config.scope.instance_id.clone(),
+            customer_config_revision: revision,
+            optional_components: config.optional_components.clone(),
+            preferences: config.preferences.clone(),
+            connectors: config.connectors.clone(),
+            models: config.models.clone(),
+        },
+        deployment_policy: crate::resolve::intersect_constraints(
+            &config.constraints,
+            input.host_policy,
+        ),
+    })
+}
+
+/// A shareable skeleton, not a deployable export. Derive it from the blueprint
+/// alone so even customer identifiers hidden in preference/reference keys or
+/// values cannot escape. Customer-owned backup uses CustomerConfig separately.
+pub fn customer_config_template(
+    blueprint: &SolutionBlueprint,
+) -> Result<CustomerConfigTemplate, SolutionError> {
+    validate_blueprint(blueprint)?;
+    Ok(CustomerConfigTemplate {
+        schema_version: SCHEMA_VERSION.into(),
+        template_kind: "customer-config-template".into(),
+        solution: blueprint.solution.clone(),
+        optional_components: blueprint
+            .components
+            .iter()
+            .filter(|(_, c)| !c.required)
+            .map(|(id, _)| id.clone())
+            .collect(),
+        model_slots: blueprint
+            .components
+            .values()
+            .flat_map(|c| c.model_classes.iter().cloned())
+            .collect(),
+        connector_slots: blueprint
+            .components
+            .values()
+            .flat_map(|c| {
+                c.required_capabilities
+                    .iter()
+                    .chain(&c.optional_capabilities)
+                    .cloned()
+            })
+            .collect(),
+        requires_customer_configuration: true,
+    })
+}
+
+pub fn customer_config_changes(
+    previous_blueprint: &SolutionBlueprint,
+    next_blueprint: &SolutionBlueprint,
+    previous: &CustomerConfig,
+    next: &CustomerConfig,
+) -> Result<CustomerConfigChanges, SolutionError> {
+    validate_customer_config(previous)?;
+    validate_customer_config(next)?;
+    let groups = [
+        ("scope", previous.scope != next.scope),
+        ("profile_ref", previous.profile_ref != next.profile_ref),
+        ("timezone", previous.timezone != next.timezone),
+        ("locale", previous.locale != next.locale),
+        (
+            "optional_components",
+            previous.optional_components != next.optional_components,
+        ),
+        ("preferences", previous.preferences != next.preferences),
+        ("connectors", previous.connectors != next.connectors),
+        ("models", previous.models != next.models),
+        ("secret_refs", previous.secret_refs != next.secret_refs),
+        ("data_refs", previous.data_refs != next.data_refs),
+        (
+            "memory_spaces",
+            previous.memory_spaces != next.memory_spaces,
+        ),
+        ("constraints", previous.constraints != next.constraints),
+    ];
+    Ok(CustomerConfigChanges {
+        upstream_changed: blueprint_hash(previous_blueprint)? != blueprint_hash(next_blueprint)?,
+        customer_fields: groups
+            .into_iter()
+            .filter(|(_, changed)| *changed)
+            .map(|(name, _)| name.to_string())
+            .collect(),
+    })
+}

--- a/crates/tandem-solutions/src/customer_contract.rs
+++ b/crates/tandem-solutions/src/customer_contract.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+use crate::*;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Customer-owned document, never reusable pack content or an authority grant.
+/// Human names, aliases and imported content stay in the referenced profile/data
+/// stores. This document contains no credential values or connection settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CustomerConfig {
+    pub schema_version: String,
+    pub scope: CustomerScope,
+    pub profile_ref: String,
+    pub timezone: String,
+    pub locale: String,
+    #[serde(default)]
+    pub optional_components: BTreeSet<String>,
+    #[serde(default)]
+    pub preferences: BTreeMap<String, PreferenceValue>,
+    #[serde(default)]
+    pub connectors: BTreeMap<String, ConnectorBinding>,
+    #[serde(default)]
+    pub models: BTreeMap<String, String>,
+    #[serde(default)]
+    pub secret_refs: BTreeMap<String, String>,
+    #[serde(default)]
+    pub data_refs: BTreeMap<String, String>,
+    #[serde(default)]
+    pub memory_spaces: BTreeMap<String, CustomerMemorySpace>,
+    pub constraints: Constraints,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CustomerScope {
+    pub org_id: String,
+    pub workspace_id: String,
+    pub deployment_id: String,
+    pub instance_id: String,
+}
+
+/// Declarations bind existing authorized resources; they do not create users,
+/// memberships, knowledge grants, or team/curated backing stores.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum CustomerMemorySpace {
+    PrivateUser { subject_id: String },
+    DepartmentShared { org_unit_id: String },
+    TenantShared,
+    Project { project_id: String },
+}
+
+pub struct PreparedCustomerConfig {
+    pub request: InstallRequest,
+    /// Pass this narrowed policy to the existing resolver. It intersects again
+    /// with the blueprint. Never substitute customer policy for host policy.
+    pub deployment_policy: Constraints,
+}
+
+/// Public template derives only from the reusable blueprint. No customer
+/// values, IDs, reference names, hashes, bindings or override values are copied.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CustomerConfigTemplate {
+    pub schema_version: String,
+    pub template_kind: String,
+    pub solution: SolutionIdentity,
+    pub optional_components: BTreeSet<String>,
+    pub model_slots: BTreeSet<String>,
+    pub connector_slots: BTreeSet<String>,
+    pub requires_customer_configuration: bool,
+}
+
+/// A value-free review summary. It is not permission to apply either change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CustomerConfigChanges {
+    pub upstream_changed: bool,
+    pub customer_fields: BTreeSet<String>,
+}

--- a/crates/tandem-solutions/src/lib.rs
+++ b/crates/tandem-solutions/src/lib.rs
@@ -4,10 +4,14 @@
 //! Pure solution planning. This crate does not provision identities, download
 //! packs, grant permissions, or mutate a running Tandem installation.
 mod contract;
+mod customer_config;
+mod customer_contract;
 mod resolve;
 mod validate;
 
 pub use contract::*;
+pub use customer_config::*;
+pub use customer_contract::*;
 pub use resolve::{resolve, ResolutionInput};
 pub use validate::{blueprint_hash, parse_blueprint, validate_blueprint};
 

--- a/crates/tandem-solutions/src/resolve.rs
+++ b/crates/tandem-solutions/src/resolve.rs
@@ -277,7 +277,7 @@ pub fn resolve(
     })
 }
 
-fn intersect_constraints(blueprint: &Constraints, policy: &Constraints) -> Constraints {
+pub(crate) fn intersect_constraints(blueprint: &Constraints, policy: &Constraints) -> Constraints {
     Constraints {
         allowed_providers: blueprint
             .allowed_providers
@@ -311,7 +311,7 @@ fn nonsecret_reference(value: &str, path: &str) -> Result<(), SolutionError> {
     Ok(())
 }
 
-fn authority_binding(
+pub(crate) fn authority_binding(
     context: &VerifiedTenantContext,
     now_ms: u64,
 ) -> Result<AuthorityBinding, SolutionError> {

--- a/crates/tandem-solutions/tests/customer_configuration.rs
+++ b/crates/tandem-solutions/tests/customer_configuration.rs
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+use std::collections::{BTreeMap, BTreeSet};
+use tandem_enterprise_contract::{
+    AuthorityChain, HumanActor, RequestPrincipal, TenantContext, TenantContextAssertionClaims,
+    VerifiedTenantContext,
+};
+use tandem_solutions::*;
+
+const A: &str = include_str!("../fixtures/company-brain-text/customer-a.yaml");
+const B: &str = include_str!("../fixtures/company-brain-text/customer-b.yaml");
+
+struct Fixture {
+    blueprint: SolutionBlueprint,
+    config: CustomerConfig,
+    context: VerifiedTenantContext,
+    refs: BTreeSet<String>,
+    subjects: BTreeSet<String>,
+    projects: BTreeSet<String>,
+    units: BTreeSet<String>,
+    connectors: BTreeMap<String, ConnectorBinding>,
+}
+
+impl Fixture {
+    fn new(document: &str, customer: &str) -> Self {
+        let actor = format!("owner-{customer}");
+        Self {
+            blueprint: parse_blueprint(include_str!(
+                "../fixtures/company-brain-text/solution.json"
+            ))
+            .unwrap(),
+            config: parse_customer_config(document).unwrap(),
+            context: TenantContextAssertionClaims::new_v1(
+                "issuer",
+                "runtime",
+                1000,
+                2000,
+                "synthetic-assertion",
+                TenantContext::explicit_user_workspace(
+                    format!("org-{customer}"),
+                    format!("workspace-{customer}"),
+                    Some(format!("deployment-{customer}")),
+                    &actor,
+                ),
+                HumanActor::tandem_user(&actor),
+                AuthorityChain::from_request(RequestPrincipal::authenticated_user(
+                    &actor, "fixture",
+                )),
+                vec!["workspace:user".into()],
+            )
+            .into(),
+            refs: [
+                format!("profile-ref:synthetic-company-{customer}"),
+                format!("data-ref:synthetic-notes-{customer}"),
+            ]
+            .into(),
+            subjects: [actor].into(),
+            projects: [format!("project-{customer}")].into(),
+            units: BTreeSet::new(),
+            connectors: BTreeMap::new(),
+        }
+    }
+    fn prepare(
+        &self,
+        current: Option<&str>,
+        expected: Option<&str>,
+    ) -> Result<PreparedCustomerConfig, SolutionError> {
+        prepare_customer_config(
+            &self.blueprint,
+            &self.config,
+            CustomerConfigInput {
+                verified_context: &self.context,
+                selected_scope: &self.config.scope,
+                now_ms: 1500,
+                current_revision: current,
+                expected_revision: expected,
+                host_policy: &self.blueprint.constraints,
+                approved_references: &self.refs,
+                approved_subjects: &self.subjects,
+                approved_org_units: &self.units,
+                approved_projects: &self.projects,
+                approved_connectors: &self.connectors,
+            },
+        )
+    }
+    fn plan(&self) -> ResolvedPlan {
+        let prepared = self.prepare(None, None).unwrap();
+        let models = serde_json::from_str(include_str!(
+            "../fixtures/company-brain-text/host-models.json"
+        ))
+        .unwrap();
+        let artifacts = BTreeMap::from([(
+            "central-brain".into(),
+            include_bytes!("../fixtures/company-brain-text/agents/central-brain.json").to_vec(),
+        )]);
+        resolve(
+            &self.blueprint,
+            ResolutionInput {
+                request: &prepared.request,
+                verified_context: &self.context,
+                now_ms: 1500,
+                engine_version: "0.7.2",
+                deployment_policy: &prepared.deployment_policy,
+                available_deployment_requirements: &self.blueprint.deployment_requirements,
+                approved_models: &models,
+                artifacts: &artifacts,
+            },
+        )
+        .unwrap()
+    }
+}
+
+#[test]
+fn two_customers_resolve_one_artifact_with_distinct_scopes_and_bounded_overrides() {
+    let a = Fixture::new(A, "a");
+    let b = Fixture::new(B, "b");
+    let (pa, pb) = (a.plan(), b.plan());
+    assert_eq!(pa.blueprint_sha256, pb.blueprint_sha256);
+    assert_eq!(
+        pa.components["central-brain"].artifact,
+        pb.components["central-brain"].artifact
+    );
+    assert_ne!(
+        pa.components["central-brain"].resource_id,
+        pb.components["central-brain"].resource_id
+    );
+    assert_ne!(pa.customer_config_revision, pb.customer_config_revision);
+    assert_eq!(pa.constraints.max_tokens_per_run, 2048);
+    assert_eq!(pb.constraints.max_tokens_per_run, 1024);
+    assert!(!pa.constraints.allow_network_egress);
+    assert!(pa.connectors.is_empty());
+    assert!(pb.connectors.is_empty());
+    assert_eq!(
+        pb.preferences["reply-language"],
+        PreferenceValue::Choice("fr".into())
+    );
+}
+
+#[test]
+fn parser_rejects_credentials_duplicate_keys_authority_claims_and_unsupported_stores() {
+    for input in [
+        format!("{A}\nroles: [admin]\n"),
+        format!("{A}\nschema_version: '1'\n"),
+        A.replace(
+            "secret_refs: {}",
+            "secret_refs: {mail: 'raw-password-value'}",
+        ),
+        A.replace("kind: private_user", "kind: team"),
+        A.replace(
+            "profile-ref:synthetic-company-a",
+            "https://user:password@example.invalid",
+        ),
+    ] {
+        assert!(parse_customer_config(&input).is_err());
+    }
+}
+
+#[test]
+fn current_identity_selection_approved_references_and_revisions_are_required() {
+    let mut f = Fixture::new(A, "a");
+    let revision = customer_config_revision(&f.config).unwrap();
+    assert!(f.prepare(Some(&revision), Some(&revision)).is_ok());
+    assert_eq!(
+        f.prepare(Some(&revision), None).err().unwrap().code,
+        "customer_revision_conflict"
+    );
+    f.config.scope.org_id = "org-b".into();
+    assert_eq!(
+        f.prepare(None, None).err().unwrap().code,
+        "customer_scope_mismatch"
+    );
+    f.config.scope.org_id = "org-a".into();
+    f.config
+        .data_refs
+        .insert("notes".into(), "data-ref:synthetic-notes-b".into());
+    assert_eq!(
+        f.prepare(None, None).err().unwrap().code,
+        "customer_reference_denied"
+    );
+    f.config.data_refs.clear();
+    f.config.memory_spaces.insert(
+        "private".into(),
+        CustomerMemorySpace::PrivateUser {
+            subject_id: "owner-b".into(),
+        },
+    );
+    assert_eq!(
+        f.prepare(None, None).err().unwrap().code,
+        "customer_memory_binding_denied"
+    );
+    f.config.memory_spaces.remove("private");
+    assert_eq!(
+        f.prepare(None, None).err().unwrap().code,
+        "customer_memory_binding_denied"
+    );
+}
+
+#[test]
+fn sanitized_template_contains_no_customer_values_and_cannot_be_imported_as_deployable_config() {
+    let a = Fixture::new(A, "a");
+    let b = Fixture::new(B, "b");
+    let exported = canonical_json(&customer_config_template(&a.blueprint).unwrap()).unwrap();
+    assert_eq!(
+        exported,
+        canonical_json(&customer_config_template(&b.blueprint).unwrap()).unwrap()
+    );
+    let text = String::from_utf8(exported).unwrap();
+    for value in [
+        "org-a",
+        "workspace-a",
+        "owner-a",
+        "synthetic-company",
+        "synthetic-notes",
+        "Europe/Budapest",
+        "local.fixture",
+    ] {
+        assert!(!text.contains(value));
+    }
+    assert!(parse_customer_config(&text).is_err());
+    // Customer-owned recovery serialization preserves references, never values.
+    let backup = String::from_utf8(canonical_json(&a.config).unwrap()).unwrap();
+    assert_eq!(parse_customer_config(&backup).unwrap(), a.config);
+}
+
+#[test]
+fn customer_constraints_cannot_raise_host_ceilings_or_enable_egress() {
+    let mut f = Fixture::new(A, "a");
+    f.config.constraints.allow_network_egress = true;
+    f.config.constraints.max_tokens_per_run = u64::MAX;
+    f.config
+        .constraints
+        .allowed_providers
+        .insert("external".into());
+    let plan = f.plan();
+    assert!(!plan.constraints.allow_network_egress);
+    assert_eq!(plan.constraints.max_tokens_per_run, 4096);
+    assert_eq!(plan.constraints.allowed_providers, ["local".into()].into());
+}
+
+#[test]
+fn selected_install_expiry_and_connector_generation_cannot_come_from_config() {
+    let mut f = Fixture::new(A, "a");
+    let selected = f.config.scope.clone();
+    f.config.scope.instance_id = "another-install".into();
+    let error = prepare_customer_config(
+        &f.blueprint,
+        &f.config,
+        CustomerConfigInput {
+            verified_context: &f.context,
+            selected_scope: &selected,
+            now_ms: 1500,
+            current_revision: None,
+            expected_revision: None,
+            host_policy: &f.blueprint.constraints,
+            approved_references: &f.refs,
+            approved_subjects: &f.subjects,
+            approved_org_units: &f.units,
+            approved_projects: &f.projects,
+            approved_connectors: &f.connectors,
+        },
+    )
+    .err()
+    .unwrap();
+    assert_eq!(error.code, "customer_scope_mismatch");
+    f.config.scope = selected;
+    f.config.connectors.insert(
+        "mail.read".into(),
+        ConnectorBinding {
+            connection_id: "another-account".into(),
+            generation: "stale".into(),
+        },
+    );
+    assert_eq!(
+        f.prepare(None, None).err().unwrap().code,
+        "customer_connector_denied"
+    );
+    f.config.connectors.clear();
+    f.context.expires_at_ms = 1400;
+    assert_eq!(
+        f.prepare(None, None).err().unwrap().code,
+        "verified_identity_required"
+    );
+}
+
+#[test]
+fn review_diff_separates_upstream_changes_without_printing_customer_identifiers() {
+    let a = Fixture::new(A, "a");
+    let mut b = Fixture::new(B, "b");
+    let changes =
+        customer_config_changes(&a.blueprint, &b.blueprint, &a.config, &b.config).unwrap();
+    assert!(!changes.upstream_changed);
+    assert!(changes.customer_fields.contains("scope"));
+    assert!(changes.customer_fields.contains("preferences"));
+    assert!(!String::from_utf8(canonical_json(&changes).unwrap())
+        .unwrap()
+        .contains("org-a"));
+    b.blueprint.solution.version = "0.1.1".into();
+    assert!(
+        customer_config_changes(&a.blueprint, &b.blueprint, &a.config, &a.config)
+            .unwrap()
+            .upstream_changed
+    );
+}

--- a/specs/solutions/README.md
+++ b/specs/solutions/README.md
@@ -5,6 +5,10 @@ contract. It parses JSON/YAML, rejects invalid input, verifies selected artifact
 digests, and produces the same resolved plan for every caller. It has no network,
 filesystem, credential lookup, account provisioning or installation side effects.
 
+The separate [customer configuration contract](customer-configuration.md)
+prepares scoped customer inputs, reference checks and sanitized template exports
+for this same resolver. Runtime installation and persistence remain separate.
+
 This is the foundation for the installer, **not a working Company Brain
 installation yet**. The fixture is an offline planning example; it neither logs
 in a user nor runs a model. Keep TAN-824 open until the runtime adapter and the

--- a/specs/solutions/customer-configuration.md
+++ b/specs/solutions/customer-configuration.md
@@ -1,0 +1,84 @@
+# Customer configuration contract (TAN-827)
+
+The existing `tandem-solutions` planner now accepts a separate versioned customer
+document through `parse_customer_config` and `prepare_customer_config`. Pass the
+prepared `InstallRequest` and narrowed `deployment_policy` to the existing
+`resolve` function. This remains pure planning; it does not install resources,
+create identities, grant data access or persist configuration.
+
+`fixtures/company-brain-text/customer-a.yaml` and `customer-b.yaml` bind the same
+text-only blueprint to two synthetic organizations. Contract tests resolve both
+through the actual planner and check distinct tenant-qualified resource IDs,
+configuration revisions and preferences with identical artifact digests.
+
+## Customer-owned input
+
+Schema version is the string `"1"`. Unknown fields, duplicate YAML/JSON keys,
+unsupported memory kinds, oversized documents and malformed references are
+rejected. Scope explicitly selects organization, workspace, deployment and
+installation. The trusted host must independently select that installation and
+supply a current verified context; matching client-provided IDs are not proof
+of authorization.
+
+Human company names, aliases and imported content belong in separately owned
+profile/data stores. This initial contract references them with `profile-ref:`
+and `data-ref:` identifiers. Credentials use `secret-ref:` identifiers. No raw
+credential, connection URL, role, membership or provider-configuration fields
+exist. A syntactically valid reference is still untrusted: the host must supply
+the exact approved references for the current scope and caller. Likewise,
+CapabilityResolver must approve each connector account and generation, and the
+existing resolver requires host-approved model binding metadata.
+
+Timezone and locale receive bounded syntax checks here. The runtime adapter must
+validate them against its supported timezone/locale registry before activation.
+This slice does not add profile/data stores, credential lookup or an HTTP import
+endpoint. Never log this customer-owned document as public diagnostic output.
+
+## Composition and revisions
+
+All customer-owned fields participate in the canonical SHA-256 revision, including
+references and memory labels. The caller supplies current and expected revisions;
+`None`/`None` is an explicit new installation. A mismatch blocks preparation.
+The future apply adapter must repeat authorization and compare-and-swap this
+revision within its persistence transaction. A pure comparison is not atomic
+installation evidence or a durable retry receipt.
+
+Optional selections, preferences and model/connector bindings reuse the existing
+planner's validation. Customer policy intersects with trusted host policy, then
+with blueprint ceilings; it cannot enable forbidden egress, add a provider or
+raise token, concurrency or spending limits. A customer configuration revision
+is not itself a verified policy revision.
+
+Every blueprint memory space requires a matching declaration. Private subjects,
+departments and projects must already be approved by the trusted host for this
+caller. These declarations are not grants. The runtime adapter must use governed
+`memory_records` and its verified owner/department/tenant labels; project
+partitions do not confer access. Unsupported team/curated stores are rejected.
+Actual write/recall and membership-change evidence is tracked separately in
+agents PR64; this pure planner test does not establish runtime privacy.
+
+`customer_config_changes` reports upstream blueprint changes separately from
+changed customer field groups. It emits no old/new values, identifiers or
+secret-reference names. Review and authorization remain necessary at apply.
+
+## Export boundaries
+
+There are two distinct artifacts:
+
+- Customer-owned JSON/YAML serialization preserves scoped identifiers and
+  references for authorized backup/import. It contains no resolved secret values
+  and must stay within that customer's storage and access controls.
+- `customer_config_template(blueprint)` produces a shareable skeleton containing
+  only reusable blueprint identity and declared configuration slots. It accepts
+  no customer document, so customer names, source IDs, reference names, hashes,
+  bindings and override values cannot be copied accidentally. The result requires
+  new customer configuration and cannot be imported as a deployable document.
+
+The blueprint itself must come from the reusable pack's existing trust/content
+review. This API does not sanitize arbitrary customer content embedded in a
+blueprint. Pack export and installer adapters must select the shareable skeleton
+instead of serializing a customer document or resolved plan.
+
+Remaining TAN-827 acceptance includes those runtime/export adapters, scoped
+profile/data storage, transactional concurrent updates, effective lifecycle
+checks, browser import/export and the real two-customer installation drill.


### PR DESCRIPTION
The solution planner currently accepts an opaque customer configuration hash without a customer document contract. Add a versioned customer-owned document and preparation step that checks verified organization/workspace/deployment, explicit installation selection, expected revisions and host-approved references, subjects, departments, projects and connector generations. Reuse the existing resolver, canonical revision hashing, bounded preferences, model registry and policy intersection. Configuration does not manufacture identities or data grants.

Provide two synthetic text-only customer fixtures for the same blueprint/artifact. A separate shareable template derives only from the reusable blueprint and copies no customer identifiers, reference names or override values; it cannot be imported as a deployable document. A value-free change summary separates upstream blueprint changes from customer field changes.

Seven focused tests cover same-artifact/different-tenant resolution, unsafe schema and references, scope/installation spoofing, stale revisions, account generation and expired identity, private subject bindings, sanitized template/customer-owned round-trip and policy ceilings. Rustfmt and diff checks passed locally. Solution Contract CI33998646395 at 955a3e2f passed all 7 new tests, all 19 existing solution tests and clippy: https://github.com/frumu-ai/tandem/actions/runs/33998646395. At current head3d1186b6, Solution Contract33999433164 and every required main CI33999433142 job passed, including PostgreSQL storage and panel checks. Cross-platform engine checks passed. Workspace job101396085884 was interrupted by runner shutdown (exit143) during compilation; same-candidate retry101397983249 PASSED all5121 tests with7 skips. Security33999433170 passed every job, including Linux Enterprise Release Composition and engine/panel container checks. The only source difference from955a is an exact historical synthetic doctor-fixture Gitleaks fingerprint used by the all-history scan, without a rule/path exclusion.

This is a pure contract slice. Runtime import/export adapters, scoped profile/data stores, atomic persistence/installer receipts, supported locale/timezone lookup, browser acceptance and actual two-customer installation remain open. Real governed-memory acceptance is tracked separately in agents #64 and is not yet passing. Keep TAN-827 open. Do not merge automatically.