### PR TITLE
TAN-827: persist customer configuration with scoped atomic versions

### DIFF
--- a/.github/workflows/solution-contract.yml
+++ b/.github/workflows/solution-contract.yml
@@ -78,5 +78,7 @@ jobs:
           components: clippy
       - name: Verify protected customer configuration on both backends
         run: cargo test -p tandem-server --locked --features storage-postgres customer_config_ --lib -- --test-threads=1
+      - name: Verify protected configuration survives backend round trip
+        run: cargo test -p tandem-server --locked --features storage-postgres stateful_runtime::orchestration_store::transfer --lib -- --test-threads=1
       - name: Lint the PostgreSQL and SQLite store adapter
         run: cargo clippy -p tandem-server --locked --features storage-postgres --lib -- -D warnings

--- a/.github/workflows/solution-contract.yml
+++ b/.github/workflows/solution-contract.yml
@@ -49,3 +49,34 @@ jobs:
 
       - name: Lint solution contract and fixture
         run: cargo clippy -p tandem-solutions --all-targets --locked -- -D warnings
+
+  customer-state:
+    name: Customer configuration storage
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: tandem
+          POSTGRES_DB: tandem
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d tandem"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      TANDEM_TEST_POSTGRES_URL: postgres://postgres:tandem@localhost:5432/tandem
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: ./.github/actions/setup-rust-ci
+        with:
+          cache-profile: customer-config-storage
+          toolchain: 1.98.0
+          components: clippy
+      - name: Verify protected customer configuration on both backends
+        run: cargo test -p tandem-server --locked --features storage-postgres customer_config_ --lib -- --test-threads=1
+      - name: Lint the PostgreSQL and SQLite store adapter
+        run: cargo clippy -p tandem-server --locked --features storage-postgres --lib -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8456,6 +8456,7 @@ dependencies = [
  "tandem-providers",
  "tandem-runtime",
  "tandem-skills",
+ "tandem-solutions",
  "tandem-tools",
  "tandem-types",
  "tandem-wire",

--- a/crates/tandem-server/Cargo.toml
+++ b/crates/tandem-server/Cargo.toml
@@ -73,6 +73,7 @@ tandem-tools = { path = "../tandem-tools", version = "0.7.2" }
 tandem-automation = { path = "../tandem-automation", version = "0.7.2" }
 tandem-incident-monitor = { path = "../tandem-incident-monitor", version = "0.7.2" }
 tandem-skills = { path = "../tandem-skills", version = "0.7.2" }
+tandem-solutions = { path = "../tandem-solutions", version = "0.7.2" }
 tandem-memory = { path = "../tandem-memory", version = "0.7.2" }
 tandem-orchestrator = { path = "../tandem-orchestrator", version = "0.7.2" }
 tandem-enterprise-contract = { path = "../tandem-enterprise-contract", version = "0.7.2" }

--- a/crates/tandem-server/src/stateful_runtime/backend/postgres.rs
+++ b/crates/tandem-server/src/stateful_runtime/backend/postgres.rs
@@ -541,17 +541,25 @@ fn ensure_schema_exists(pool: &Pool, schema: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// PostgreSQL rendering of stateful schema v5. Fresh deployments start at the
-/// current version directly — the SQLite v1→v5 migration chain is historical
-/// and never existed on PostgreSQL.
+/// PostgreSQL starts with the v5 baseline, then applies current additive
+/// migrations. The historical SQLite v1-v5 chain never existed on PostgreSQL.
 pub(crate) fn initialize_schema(connection: &mut Connection) -> anyhow::Result<()> {
     use super::{Executor as _, ExecutorRaw as _};
     connection.execute_batch(POSTGRES_SCHEMA_V5)?;
-    let version: i64 = connection.query_row(
+    let mut version: i64 = connection.query_row(
         "SELECT schema_version FROM schema_metadata LIMIT 1",
         [],
         |row| row.get(0),
     )?;
+    if version == 5 {
+        let transaction =
+            connection.transaction_with_behavior(super::TransactionBehavior::Immediate)?;
+        transaction.execute_batch(
+            crate::stateful_runtime::orchestration_store::customer_configs::SCHEMA_V6,
+        )?;
+        transaction.commit()?;
+        version = 6;
+    }
     if version != crate::stateful_runtime::orchestration_store::SCHEMA_VERSION {
         bail!(
             "unsupported orchestration store schema version {version}; expected {}",

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -14,6 +14,7 @@ use tandem_automation::{
     WorkflowHandoffStatus,
 };
 
+pub(crate) mod customer_configs;
 mod definitions;
 mod engine_lock;
 mod goal_control;
@@ -24,6 +25,7 @@ mod runtime_records;
 mod transfer;
 mod transition;
 
+pub use customer_configs::{CustomerConfigVersion, StoredCustomerConfig, CUSTOMER_CONFIG_CONFLICT};
 pub use definitions::{DRAFT_CONCURRENCY_CONFLICT, ORCHESTRATION_DRAFT_VERSION};
 pub use engine_lock::{read_engine_lock_owner, EngineLockOwner, StatefulEngineLock};
 pub use goal_control::{GoalCancellationResult, GoalControlOutcome};
@@ -40,7 +42,7 @@ pub use transition::{
     WorkflowCompletionResult,
 };
 
-pub(crate) const SCHEMA_VERSION: i64 = 5;
+pub(crate) const SCHEMA_VERSION: i64 = 6;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrchestrationStorePaths {
@@ -1203,6 +1205,10 @@ fn initialize_schema(connection: &mut rusqlite::Connection) -> anyhow::Result<()
         migrate_schema_v4_to_v5(connection)?;
         version = 5;
     }
+    if version == 5 {
+        customer_configs::migrate_sqlite(connection)?;
+        version = 6;
+    }
     if version != SCHEMA_VERSION {
         bail!(
             "unsupported orchestration store schema version {version}; expected {SCHEMA_VERSION}"
@@ -1552,3 +1558,7 @@ mod encryption_tests;
 #[cfg(test)]
 #[path = "orchestration_store/hardening_tests.rs"]
 mod hardening_tests;
+
+#[cfg(test)]
+#[path = "orchestration_store/customer_config_tests.rs"]
+mod customer_config_tests;

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/backend_conformance_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/backend_conformance_tests.rs
@@ -30,7 +30,7 @@ use crate::stateful_runtime::{
 
 /// Runs `test` once per available backend. The backend name is passed for
 /// assertion messages so a Postgres-only failure is immediately attributable.
-fn for_each_backend(test: impl Fn(&str, &OrchestrationStateStore)) {
+pub(super) fn for_each_backend(test: impl Fn(&str, &OrchestrationStateStore)) {
     #[cfg(feature = "storage-sqlite")]
     {
         let directory = tempfile::tempdir().unwrap();

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/customer_config_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/customer_config_tests.rs
@@ -116,6 +116,54 @@ fn reopened(store: &OrchestrationStateStore) -> OrchestrationStateStore {
     reopened
 }
 
+#[cfg(feature = "storage-postgres")]
+pub(super) fn seed_protected_config_for_transfer(
+    store: &OrchestrationStateStore,
+) -> StoredCustomerConfig {
+    futures::executor::block_on(crate::encrypted_file_store::with_test_crypto_provider(
+        tandem_memory::MemoryCryptoProvider::local_key([0x5a; 32]),
+        None,
+        async {
+            let fixture = Fixture::new("a");
+            let stored = fixture.save(store, &fixture.config, None).unwrap();
+            store
+                .with_connection(|connection| {
+                    let payload: String = connection.query_row(
+                        "SELECT record_json FROM solution_customer_configs WHERE org_id='org-a'",
+                        [],
+                        |row| row.get(0),
+                    )?;
+                    assert!(crate::encrypted_file_store::is_encrypted_payload(&payload));
+                    assert!(!payload.contains(&fixture.config.profile_ref));
+                    Ok(())
+                })
+                .unwrap();
+            stored
+        },
+    ))
+}
+
+#[cfg(feature = "storage-postgres")]
+pub(super) fn assert_protected_config_after_transfer(
+    store: &OrchestrationStateStore,
+    expected: &StoredCustomerConfig,
+) {
+    futures::executor::block_on(crate::encrypted_file_store::with_test_crypto_provider(
+        tandem_memory::MemoryCryptoProvider::local_key([0x5a; 32]),
+        None,
+        async {
+            assert_eq!(&Fixture::new("a").read(store), expected);
+            store.with_connection(|connection| {
+                    let versions: i64 = connection.query_row(
+                        "SELECT COUNT(*) FROM solution_customer_config_versions WHERE org_id='org-a'",
+                        [], |row| row.get(0))?;
+                    assert_eq!(versions, 1);
+                    Ok(())
+                }).unwrap();
+        },
+    ));
+}
+
 #[test]
 #[serial]
 fn customer_config_two_scopes_persist_without_exporting_customer_data() {
@@ -228,10 +276,29 @@ fn customer_config_failed_version_append_rolls_back_current_document() {
     });
 }
 
-#[tokio::test]
+#[test]
 #[serial]
-async fn customer_config_protected_payload_rejects_tenant_substitution() {
-    crate::encrypted_file_store::with_test_crypto_provider(
+fn customer_config_noop_still_checks_current_host_bindings() {
+    for_each_backend(|backend, store| {
+        let mut fixture = Fixture::new("a");
+        let first = fixture.save(store, &fixture.config, None).unwrap();
+        fixture.refs.clear();
+        assert!(
+            fixture
+                .save(store, &fixture.config, Some(&first.version))
+                .is_err(),
+            "{backend}: unchanged content cannot reuse revoked reference approval"
+        );
+        assert_eq!(fixture.read(&reopened(store)), first);
+    });
+}
+
+#[test]
+#[serial]
+fn customer_config_protected_payload_rejects_tenant_substitution() {
+    // Poll the task-local crypto scope without entering Tokio: the synchronous
+    // PostgreSQL client owns its own runtime while these store calls execute.
+    futures::executor::block_on(crate::encrypted_file_store::with_test_crypto_provider(
         tandem_memory::MemoryCryptoProvider::local_key([0x5a; 32]),
         None,
         async {
@@ -262,8 +329,7 @@ async fn customer_config_protected_payload_rejects_tenant_substitution() {
                     .is_err());
             });
         },
-    )
-    .await;
+    ));
 }
 
 #[test]

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/customer_config_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/customer_config_tests.rs
@@ -1,0 +1,303 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serial_test::serial;
+use tandem_enterprise_contract::{
+    AuthorityChain, HumanActor, RequestPrincipal, TenantContext, TenantContextAssertionClaims,
+    VerifiedTenantContext,
+};
+use tandem_solutions::*;
+
+use super::backend_conformance_tests::for_each_backend;
+use super::{CustomerConfigVersion, OrchestrationStateStore, StoredCustomerConfig};
+use crate::stateful_runtime::backend::{params, Executor, ExecutorRaw};
+
+struct Fixture {
+    blueprint: SolutionBlueprint,
+    config: CustomerConfig,
+    context: VerifiedTenantContext,
+    refs: BTreeSet<String>,
+    subjects: BTreeSet<String>,
+    projects: BTreeSet<String>,
+    units: BTreeSet<String>,
+    connectors: BTreeMap<String, ConnectorBinding>,
+}
+
+impl Fixture {
+    fn new(customer: &str) -> Self {
+        let document = match customer {
+            "a" => include_str!(
+                "../../../../tandem-solutions/fixtures/company-brain-text/customer-a.yaml"
+            ),
+            "b" => include_str!(
+                "../../../../tandem-solutions/fixtures/company-brain-text/customer-b.yaml"
+            ),
+            _ => panic!("unknown synthetic customer"),
+        };
+        let actor = format!("owner-{customer}");
+        let mut config = parse_customer_config(document).unwrap();
+        config.scope.instance_id = "same-installation-name".into();
+        Self {
+            blueprint: parse_blueprint(include_str!(
+                "../../../../tandem-solutions/fixtures/company-brain-text/solution.json"
+            ))
+            .unwrap(),
+            config,
+            context: TenantContextAssertionClaims::new_v1(
+                "issuer",
+                "runtime",
+                1000,
+                2000,
+                "synthetic-assertion",
+                TenantContext::explicit_user_workspace(
+                    format!("org-{customer}"),
+                    format!("workspace-{customer}"),
+                    Some(format!("deployment-{customer}")),
+                    &actor,
+                ),
+                HumanActor::tandem_user(&actor),
+                AuthorityChain::from_request(RequestPrincipal::authenticated_user(
+                    &actor, "fixture",
+                )),
+                vec!["workspace:user".into()],
+            )
+            .into(),
+            refs: [
+                format!("profile-ref:synthetic-company-{customer}"),
+                format!("data-ref:synthetic-notes-{customer}"),
+            ]
+            .into(),
+            subjects: [actor].into(),
+            projects: [format!("project-{customer}")].into(),
+            units: BTreeSet::new(),
+            connectors: BTreeMap::new(),
+        }
+    }
+
+    fn save(
+        &self,
+        store: &OrchestrationStateStore,
+        config: &CustomerConfig,
+        expected: Option<&CustomerConfigVersion>,
+    ) -> anyhow::Result<StoredCustomerConfig> {
+        store.save_customer_configuration(
+            &self.blueprint,
+            config,
+            CustomerConfigInput {
+                verified_context: &self.context,
+                selected_scope: &self.config.scope,
+                now_ms: 1500,
+                current_revision: None,
+                expected_revision: expected.map(|value| value.sha256.as_str()),
+                host_policy: &self.blueprint.constraints,
+                approved_references: &self.refs,
+                approved_subjects: &self.subjects,
+                approved_org_units: &self.units,
+                approved_projects: &self.projects,
+                approved_connectors: &self.connectors,
+            },
+            expected,
+        )
+    }
+
+    fn read(&self, store: &OrchestrationStateStore) -> StoredCustomerConfig {
+        store
+            .customer_configuration(&self.context, &self.config.scope, 1500)
+            .unwrap()
+            .unwrap()
+    }
+}
+
+fn reopened(store: &OrchestrationStateStore) -> OrchestrationStateStore {
+    let reopened = store.clone();
+    reopened.initialize().unwrap();
+    reopened
+}
+
+#[test]
+#[serial]
+fn customer_config_two_scopes_persist_without_exporting_customer_data() {
+    for_each_backend(|backend, store| {
+        let a = Fixture::new("a");
+        let b = Fixture::new("b");
+        let sa = a.save(store, &a.config, None).unwrap();
+        let sb = b.save(store, &b.config, None).unwrap();
+        assert_eq!(sa.version.generation, 1, "{backend}");
+        assert_eq!(sa.blueprint_sha256, sb.blueprint_sha256);
+        assert_ne!(sa.version.sha256, sb.version.sha256);
+        let reopened = reopened(store);
+        assert_eq!(a.read(&reopened), sa);
+        assert_eq!(b.read(&reopened), sb);
+        assert!(store
+            .customer_configuration(&a.context, &b.config.scope, 1500)
+            .is_err());
+        assert!(store
+            .customer_configuration(&a.context, &a.config.scope, 2001)
+            .is_err());
+        let mut spoofed = a.config.clone();
+        spoofed.scope = b.config.scope.clone();
+        assert!(a.save(store, &spoofed, Some(&sa.version)).is_err());
+        let export =
+            serde_json::to_string(&customer_config_template(&a.blueprint).unwrap()).unwrap();
+        for sensitive in [
+            &a.config.scope.org_id,
+            &b.config.scope.org_id,
+            &a.config.profile_ref,
+            &b.config.profile_ref,
+            &a.config.scope.instance_id,
+        ] {
+            assert!(!export.contains(sensitive));
+        }
+        assert_eq!(a.read(store), sa);
+        assert_eq!(b.read(store), sb);
+    });
+}
+
+#[test]
+#[serial]
+fn customer_config_concurrent_edits_and_aba_reject_stale_versions() {
+    for_each_backend(|backend, store| {
+        let fixture = Fixture::new("a");
+        let first = fixture.save(store, &fixture.config, None).unwrap();
+        let mut left = fixture.config.clone();
+        left.locale = "en-GB".into();
+        let mut right = fixture.config.clone();
+        right.locale = "fr-FR".into();
+        let outcomes = std::thread::scope(|threads| {
+            let l = threads.spawn(|| fixture.save(store, &left, Some(&first.version)));
+            let r = threads.spawn(|| fixture.save(store, &right, Some(&first.version)));
+            [l.join().unwrap(), r.join().unwrap()]
+        });
+        assert_eq!(
+            outcomes.iter().filter(|result| result.is_ok()).count(),
+            1,
+            "{backend}"
+        );
+        let second = fixture.read(store);
+        assert_eq!(second.version.generation, 2);
+        let third = fixture
+            .save(store, &fixture.config, Some(&second.version))
+            .unwrap();
+        assert_eq!(third.version.sha256, first.version.sha256);
+        assert_eq!(third.version.generation, 3);
+        assert!(fixture.save(store, &right, Some(&first.version)).is_err());
+        assert_eq!(
+            fixture
+                .save(store, &fixture.config, Some(&third.version))
+                .unwrap(),
+            third
+        );
+        assert_eq!(fixture.read(&reopened(store)), third);
+    });
+}
+
+#[test]
+#[serial]
+fn customer_config_failed_version_append_rolls_back_current_document() {
+    for_each_backend(|backend, store| {
+        let fixture = Fixture::new("a");
+        let first = fixture.save(store, &fixture.config, None).unwrap();
+        let scope = &fixture.config.scope;
+        // A duplicate immutable version forces the second insert to fail after
+        // the current document update. Neither backend may commit that update.
+        store
+            .with_connection(|connection| {
+                connection.execute(
+                    "INSERT INTO solution_customer_config_versions
+                (org_id,workspace_id,deployment_id,instance_id,generation,revision,record_json)
+                VALUES (?1,?2,?3,?4,2,'synthetic-conflict','synthetic-conflict')",
+                    params![
+                        scope.org_id,
+                        scope.workspace_id,
+                        scope.deployment_id,
+                        scope.instance_id
+                    ],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let mut next = fixture.config.clone();
+        next.locale = "fr-FR".into();
+        assert!(
+            fixture.save(store, &next, Some(&first.version)).is_err(),
+            "{backend}"
+        );
+        assert_eq!(fixture.read(&reopened(store)), first);
+    });
+}
+
+#[tokio::test]
+#[serial]
+async fn customer_config_protected_payload_rejects_tenant_substitution() {
+    crate::encrypted_file_store::with_test_crypto_provider(
+        tandem_memory::MemoryCryptoProvider::local_key([0x5a; 32]),
+        None,
+        async {
+            for_each_backend(|_, store| {
+                let a = Fixture::new("a");
+                let b = Fixture::new("b");
+                a.save(store, &a.config, None).unwrap();
+                b.save(store, &b.config, None).unwrap();
+                store
+                    .with_connection(|connection| {
+                        let payload: String = connection.query_row(
+                            "SELECT record_json FROM solution_customer_configs WHERE org_id=?1",
+                            params![a.config.scope.org_id],
+                            |row| row.get(0),
+                        )?;
+                        assert!(crate::encrypted_file_store::is_encrypted_payload(&payload));
+                        assert!(!payload.contains(&a.config.profile_ref));
+                        connection.execute(
+                            "UPDATE solution_customer_configs SET record_json=?1 WHERE org_id=?2",
+                            params![payload, b.config.scope.org_id],
+                        )?;
+                        Ok(())
+                    })
+                    .unwrap();
+                assert_eq!(a.read(&reopened(store)).config, a.config);
+                assert!(store
+                    .customer_configuration(&b.context, &b.config.scope, 1500)
+                    .is_err());
+            });
+        },
+    )
+    .await;
+}
+
+#[test]
+#[serial]
+fn customer_config_schema_upgrade_keeps_existing_runtime_records() {
+    for_each_backend(|_, store| {
+        store.with_connection(|connection| {
+            connection.execute_batch("DROP TABLE solution_customer_config_versions;
+                DROP TABLE solution_customer_configs;
+                UPDATE schema_metadata SET schema_version=5;
+                INSERT INTO orchestration_tool_requests
+                (org_id,workspace_id,deployment_key,operation,idempotency_key,request_digest,created_at_ms)
+                VALUES ('synthetic-org','workspace','deployment','fixture','request','digest',1);")?;
+            Ok(())
+        }).unwrap();
+        let migrated = reopened(store);
+        let fixture = Fixture::new("a");
+        fixture.save(&migrated, &fixture.config, None).unwrap();
+        reopened(&migrated)
+            .with_connection(|connection| {
+                let count: i64 = connection.query_row(
+                    "SELECT COUNT(*) FROM orchestration_tool_requests WHERE org_id='synthetic-org'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(count, 1);
+                let version: i64 = connection.query_row(
+                    "SELECT schema_version FROM schema_metadata",
+                    [],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(version, super::SCHEMA_VERSION);
+                Ok(())
+            })
+            .unwrap();
+    });
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/customer_configs.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/customer_configs.rs
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+//! Customer-owned configuration persistence, separate from install/activation.
+//! Callers must authorize the selected installation and load current host-owned
+//! bindings before calling this store. A document never supplies authority.
+
+use anyhow::{bail, ensure};
+use serde::{Deserialize, Serialize};
+use tandem_enterprise_contract::VerifiedTenantContext;
+use tandem_solutions::{
+    blueprint_hash, customer_config_revision, prepare_customer_config,
+    validate_customer_config_scope, CustomerConfig, CustomerConfigInput, CustomerScope,
+    SolutionBlueprint,
+};
+use tandem_types::TenantContext;
+
+use super::{protected_records, OrchestrationStateStore};
+use crate::stateful_runtime::backend::{params, Executor, OptionalExtension, TransactionBehavior};
+
+pub const CUSTOMER_CONFIG_CONFLICT: &str = "customer configuration changed concurrently";
+const RECORD_KIND: &str = "solution-customer-config";
+
+/// Generation prevents an A -> B -> A edit from accepting an old A preview.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CustomerConfigVersion {
+    pub generation: u64,
+    pub sha256: String,
+}
+
+/// Sensitive customer state. Never return this as a reusable pack export.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StoredCustomerConfig {
+    pub config: CustomerConfig,
+    pub version: CustomerConfigVersion,
+    pub blueprint_sha256: String,
+    pub updated_by: String,
+    pub updated_at_ms: u64,
+}
+
+fn record_id(scope: &CustomerScope, generation: u64) -> String {
+    format!("{}:{generation}", scope.instance_id)
+}
+
+fn load(
+    executor: &impl Executor,
+    tenant: &TenantContext,
+    scope: &CustomerScope,
+) -> anyhow::Result<Option<StoredCustomerConfig>> {
+    let row = executor
+        .query_row(
+            "SELECT generation, revision, record_json FROM solution_customer_configs
+         WHERE org_id=?1 AND workspace_id=?2 AND deployment_id=?3 AND instance_id=?4",
+            params![
+                scope.org_id,
+                scope.workspace_id,
+                scope.deployment_id,
+                scope.instance_id
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, u64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((generation, revision, payload)) = row else {
+        return Ok(None);
+    };
+    let stored: StoredCustomerConfig =
+        protected_records::decode(tenant, RECORD_KIND, &record_id(scope, generation), &payload)?;
+    ensure!(
+        stored.config.scope == *scope
+            && stored.version.generation == generation
+            && stored.version.sha256 == revision
+            && customer_config_revision(&stored.config)? == revision,
+        "customer configuration persisted binding mismatch"
+    );
+    Ok(Some(stored))
+}
+
+impl OrchestrationStateStore {
+    /// Read only after the service authorizes this installation for this caller.
+    /// Scope and verified-identity freshness are also checked at the store seam.
+    pub fn customer_configuration(
+        &self,
+        context: &VerifiedTenantContext,
+        selected_scope: &CustomerScope,
+        now_ms: u64,
+    ) -> anyhow::Result<Option<StoredCustomerConfig>> {
+        validate_customer_config_scope(context, selected_scope, now_ms)?;
+        self.with_connection(|connection| load(connection, &context.tenant_context, selected_scope))
+    }
+
+    /// Atomically validate the current revision, write the protected document
+    /// and append its immutable version. This does not install any component.
+    /// `input.current_revision` is replaced by authoritative database state.
+    pub fn save_customer_configuration(
+        &self,
+        blueprint: &SolutionBlueprint,
+        config: &CustomerConfig,
+        input: CustomerConfigInput<'_>,
+        expected: Option<&CustomerConfigVersion>,
+    ) -> anyhow::Result<StoredCustomerConfig> {
+        ensure!(
+            serde_json::to_vec(config)?.len() <= tandem_solutions::MAX_BLUEPRINT_BYTES,
+            "customer configuration exceeds the document size limit"
+        );
+        ensure!(
+            input.expected_revision == expected.map(|version| version.sha256.as_str()),
+            "customer configuration expected version mismatch"
+        );
+        validate_customer_config_scope(input.verified_context, input.selected_scope, input.now_ms)?;
+        self.with_connection(|connection| {
+            let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let tenant = &input.verified_context.tenant_context;
+            let scope = input.selected_scope;
+            let current = load(&transaction, tenant, scope)?;
+            if current.as_ref().map(|stored| &stored.version) != expected {
+                bail!(CUSTOMER_CONFIG_CONFLICT);
+            }
+            let prepared = prepare_customer_config(blueprint, config, CustomerConfigInput {
+                current_revision: current.as_ref().map(|stored| stored.version.sha256.as_str()),
+                ..input
+            })?;
+            let blueprint_sha256 = blueprint_hash(blueprint)?;
+            if let Some(stored) = current.as_ref().filter(|stored|
+                stored.version.sha256 == prepared.request.customer_config_revision
+                && stored.blueprint_sha256 == blueprint_sha256) {
+                transaction.commit()?;
+                return Ok(stored.clone());
+            }
+            let generation = current.as_ref().map_or(0, |stored| stored.version.generation)
+                .checked_add(1).filter(|value| *value <= i64::MAX as u64)
+                .ok_or_else(|| anyhow::anyhow!("customer configuration generation exhausted"))?;
+            let stored = StoredCustomerConfig {
+                config: config.clone(),
+                version: CustomerConfigVersion { generation, sha256: prepared.request.customer_config_revision },
+                blueprint_sha256,
+                updated_by: input.verified_context.human_actor.actor_id.clone(),
+                updated_at_ms: input.now_ms,
+            };
+            let payload = protected_records::encode(tenant, RECORD_KIND,
+                &record_id(scope, generation), &stored)?;
+            let changed = if let Some(expected) = expected {
+                transaction.execute(
+                    "UPDATE solution_customer_configs SET generation=?5, revision=?6, record_json=?7
+                     WHERE org_id=?1 AND workspace_id=?2 AND deployment_id=?3 AND instance_id=?4
+                       AND generation=?8 AND revision=?9",
+                    params![scope.org_id, scope.workspace_id, scope.deployment_id, scope.instance_id,
+                        generation, stored.version.sha256, payload, expected.generation, expected.sha256],
+                )?
+            } else {
+                transaction.execute(
+                    "INSERT INTO solution_customer_configs
+                     (org_id, workspace_id, deployment_id, instance_id, generation, revision, record_json)
+                     VALUES (?1,?2,?3,?4,?5,?6,?7)
+                     ON CONFLICT (org_id, workspace_id, deployment_id, instance_id) DO NOTHING",
+                    params![scope.org_id, scope.workspace_id, scope.deployment_id, scope.instance_id,
+                        generation, stored.version.sha256, payload],
+                )?
+            };
+            if changed != 1 { bail!(CUSTOMER_CONFIG_CONFLICT); }
+            transaction.execute(
+                "INSERT INTO solution_customer_config_versions
+                 (org_id, workspace_id, deployment_id, instance_id, generation, revision, record_json)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7)",
+                params![scope.org_id, scope.workspace_id, scope.deployment_id, scope.instance_id,
+                    generation, stored.version.sha256, payload],
+            )?;
+            transaction.commit()?;
+            Ok(stored)
+        })
+    }
+}
+
+// Both backends support this additive schema. BIGINT retains the full signed
+// generation range in PostgreSQL and SQLite. The caller owns the transaction.
+pub(crate) const SCHEMA_V6: &str = "
+CREATE TABLE solution_customer_configs (
+    org_id TEXT NOT NULL, workspace_id TEXT NOT NULL, deployment_id TEXT NOT NULL,
+    instance_id TEXT NOT NULL, generation BIGINT NOT NULL CHECK (generation > 0),
+    revision TEXT NOT NULL, record_json TEXT NOT NULL,
+    PRIMARY KEY (org_id, workspace_id, deployment_id, instance_id)
+);
+CREATE TABLE solution_customer_config_versions (
+    org_id TEXT NOT NULL, workspace_id TEXT NOT NULL, deployment_id TEXT NOT NULL,
+    instance_id TEXT NOT NULL, generation BIGINT NOT NULL CHECK (generation > 0),
+    revision TEXT NOT NULL, record_json TEXT NOT NULL,
+    PRIMARY KEY (org_id, workspace_id, deployment_id, instance_id, generation)
+);
+UPDATE schema_metadata SET schema_version = 6;
+";
+
+#[cfg(feature = "storage-sqlite")]
+pub(super) fn migrate_sqlite(connection: &mut rusqlite::Connection) -> anyhow::Result<()> {
+    let transaction =
+        connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    transaction.execute_batch(SCHEMA_V6)?;
+    transaction.commit()?;
+    Ok(())
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
@@ -1420,7 +1420,7 @@ mod tests {
                     [],
                     |row| row.get(0),
                 )?;
-                assert_eq!(version, super::super::SCHEMA_VERSION);
+                assert_eq!(version, super::super::SCHEMA_VERSION as u64);
                 assert_eq!(table, "legacy_handoff_quarantine");
                 assert_eq!(deployment_key_columns, 1);
                 assert_eq!(attempts_table, "stateful_migration_attempts");

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/migration.rs
@@ -1420,7 +1420,7 @@ mod tests {
                     [],
                     |row| row.get(0),
                 )?;
-                assert_eq!(version, 5);
+                assert_eq!(version, super::super::SCHEMA_VERSION);
                 assert_eq!(table, "legacy_handoff_quarantine");
                 assert_eq!(deployment_key_columns, 1);
                 assert_eq!(attempts_table, "stateful_migration_attempts");

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/transfer.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/transfer.rs
@@ -1008,6 +1008,8 @@ mod tests {
             .unwrap();
         seed_session_messages(source_root.path());
         seed_runtime_events(source_root.path());
+        let customer_config =
+            super::super::customer_config_tests::seed_protected_config_for_transfer(&source);
 
         let request = StatefulBackendMigrationRequest {
             source_paths: source_paths.clone(),
@@ -1056,6 +1058,10 @@ mod tests {
             backend::StorageBackendConfig::Sqlite,
         )
         .unwrap();
+        super::super::customer_config_tests::assert_protected_config_after_transfer(
+            &round_trip,
+            &customer_config,
+        );
         round_trip
             .with_connection(|connection| {
                 let rowid: i64 = connection.query_row(

--- a/crates/tandem-solutions/src/customer_config.rs
+++ b/crates/tandem-solutions/src/customer_config.rs
@@ -136,6 +136,28 @@ pub fn customer_config_revision(config: &CustomerConfig) -> Result<String, Solut
     Ok(sha256(&canonical_json(config)?))
 }
 
+/// Validate the caller's current verified scope without reading customer data.
+/// The runtime must separately authorize the explicitly selected installation.
+pub fn validate_customer_config_scope(
+    context: &VerifiedTenantContext,
+    scope: &CustomerScope,
+    now_ms: u64,
+) -> Result<AuthorityBinding, SolutionError> {
+    let authority = crate::resolve::authority_binding(context, now_ms)?;
+    identifier(&scope.instance_id, "scope.instance_id")?;
+    if scope.org_id != authority.org_id
+        || scope.workspace_id != authority.workspace_id
+        || scope.deployment_id != authority.deployment_id
+    {
+        return Err(SolutionError::new(
+            "customer_scope_mismatch",
+            "scope",
+            "Select the authorized organization and installation",
+        ));
+    }
+    Ok(authority)
+}
+
 /// Produces inputs for the existing resolver, never an activation receipt.
 /// The eventual apply transaction must repeat the revision/authority checks
 /// atomically with persistence; this pure check does not lock a database.
@@ -146,12 +168,8 @@ pub fn prepare_customer_config(
 ) -> Result<PreparedCustomerConfig, SolutionError> {
     validate_blueprint(blueprint)?;
     let revision = customer_config_revision(config)?;
-    let authority = crate::resolve::authority_binding(input.verified_context, input.now_ms)?;
-    if config.scope != *input.selected_scope
-        || config.scope.org_id != authority.org_id
-        || config.scope.workspace_id != authority.workspace_id
-        || config.scope.deployment_id != authority.deployment_id
-    {
+    validate_customer_config_scope(input.verified_context, input.selected_scope, input.now_ms)?;
+    if config.scope != *input.selected_scope {
         return Err(SolutionError::new(
             "customer_scope_mismatch",
             "scope",

--- a/docs/CUSTOMER_CONFIGURATION_STATE.md
+++ b/docs/CUSTOMER_CONFIGURATION_STATE.md
@@ -1,0 +1,44 @@
+# Customer configuration state
+
+`OrchestrationStateStore` persists the existing `tandem-solutions` customer
+document separately from reusable packs and runtime component installation.
+It uses the selected SQLite or PostgreSQL backend, its transaction boundary,
+and the existing tenant/kind/record-bound encryption helpers.
+
+The storage key contains organization, workspace, deployment and installation.
+The caller supplies a verified user context and an explicitly authorized
+installation selection. Customer configuration cannot create that authority.
+The service must authorize reading/editing the installation and obtain current
+host-owned references, connector generations, subjects, departments, projects
+and policy before calling the store. The existing preparation function checks
+those bindings again with the revision loaded inside the transaction.
+
+Every change atomically updates the current document and appends a protected
+version record. Both copies bind the configuration digest, blueprint digest,
+actor and time. The expected version includes a monotonically increasing
+generation as well as the content digest, so changing A to B and back to A
+cannot make an earlier preview current. Concurrent writes use a database
+compare-and-set; a failed history append rolls back the document update.
+Saving unchanged content against the current version is a no-op.
+
+Schema version 6 adds the two scoped tables on both backends without rewriting
+existing runtime records. Existing backend transfer discovers them along with
+the rest of the stateful schema. No data downgrade or delete is introduced.
+
+The deployable document remains customer-sensitive, including opaque reference
+names. Reusable export still uses the blueprint-only template from
+`tandem-solutions`; it does not serialize stored customer configuration.
+Encryption follows the existing configured provider: local plaintext mode is
+still plaintext, and a local-key test is not production KMS recovery evidence.
+
+The shared regression suite runs against SQLite and real PostgreSQL in CI. It
+covers two organizations with the same installation name, reopen, scope and
+expiry rejection, concurrent edits, A/B/A stale versions, append-failure
+rollback, encrypted tenant substitution, sanitized template export and schema
+upgrade with existing runtime state.
+
+This storage adapter is not an HTTP installation API or an activation receipt.
+The authorized service/UI/CLI integration, current-policy checks before runtime
+effects, component materialization, durable apply/activation receipts and
+clean-host recovery remain required work. No solution is installed merely
+because its customer document has been saved.

--- a/docs/CUSTOMER_CONFIGURATION_STATE.md
+++ b/docs/CUSTOMER_CONFIGURATION_STATE.md
@@ -33,9 +33,12 @@ still plaintext, and a local-key test is not production KMS recovery evidence.
 
 The shared regression suite runs against SQLite and real PostgreSQL in CI. It
 covers two organizations with the same installation name, reopen, scope and
-expiry rejection, concurrent edits, A/B/A stale versions, append-failure
+expiry rejection, current reference checks on no-op saves, concurrent edits, A/B/A stale versions, append-failure
 rollback, encrypted tenant substitution, sanitized template export and schema
 upgrade with existing runtime state.
+The existing SQLite-to-PostgreSQL-to-SQLite transfer test also carries a real
+locally encrypted customer document and its version history, then decrypts the
+restored document. This is backend portability evidence, not off-site recovery.
 
 This storage adapter is not an HTTP installation API or an activation receipt.
 The authorized service/UI/CLI integration, current-policy checks before runtime


### PR DESCRIPTION
Customer configuration previously had only a pure validation/preparation contract. Add scoped durable storage through the existing OrchestrationStateStore, using transactional SQLite/PostgreSQL migrations, protected current documents and immutable history. Expected generation plus content digest prevents stale A/B/A edits; compare-and-set and history append share one transaction. Current trusted host bindings are checked again, including on no-op saves.

The service must still authorize the selected installation and load current trusted bindings. This Rust adapter does not install components, activate resources or expose HTTP/UI/CLI. Shareable export stays the existing blueprint-only template.

Verified exact candidate 9028d9918e8aebe1bd25ea1ef252d751d6919bf7:
- Solution Contract run34004055569 passed existing pure contracts, all six scoped SQLite/PostgreSQL regressions, protected SQLite → PostgreSQL → SQLite round trip and PostgreSQL-feature clippy (job101407951578).
- Engine CI run34004055624 passed Linux/macOS/Windows, browser and runtime/fast gates plus all 5,127 workspace tests (7 skipped; job101408601419).
- Security Assurance run34004055570 passed all release/container gates; ACME and Email Approval workflows also passed. This exact candidate is ready for review.

Regressions cover two organizations sharing an installation name, reopened store handles, scope/expiry rejection, concurrent writes, A/B/A stale versions, history-append rollback, encrypted tenant substitution, current references, sanitized export and schema upgrade preserving old runtime records. Test crypto uses the existing local provider; this is not off-site recovery evidence.

Stacks on #1937. Follow-on staging journal #1940 remains separate. Authorized service/UI/CLI, current policy at runtime effects, component materialization/activation, source-backed usability and clean-host recovery remain required. Keep TAN-827/TAN-834 open. No automatic merge.