### PR TITLE
TAN-826: validate signed solution packs and load pinned artifact snapshots

### DIFF
--- a/.github/workflows/solution-contract.yml
+++ b/.github/workflows/solution-contract.yml
@@ -82,3 +82,5 @@ jobs:
         run: cargo test -p tandem-server --locked --features storage-postgres stateful_runtime::orchestration_store::transfer --lib -- --test-threads=1
       - name: Lint the PostgreSQL and SQLite store adapter
         run: cargo clippy -p tandem-server --locked --features storage-postgres --lib -- -D warnings
+      - name: Verify solution packs and existing pack lifecycle
+        run: cargo test -p tandem-server --locked --features storage-postgres pack_manager --lib -- --test-threads=1

--- a/crates/tandem-server/src/pack_manager.rs
+++ b/crates/tandem-server/src/pack_manager.rs
@@ -24,6 +24,10 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 use zip::{write::SimpleFileOptions, CompressionMethod, ZipArchive, ZipWriter};
 
+#[path = "pack_manager_solution.rs"]
+mod solution;
+pub use solution::SolutionPackArtifacts;
+
 const MARKER_FILE: &str = "tandempack.yaml";
 const INDEX_FILE: &str = "index.json";
 const CURRENT_FILE: &str = "current";
@@ -69,6 +73,8 @@ pub struct PackInstallRecord {
     pub pack_type: String,
     pub install_path: String,
     pub sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub solution_content_sha256: Option<String>,
     pub installed_at_ms: u64,
     pub source: Value,
     #[serde(default)]
@@ -91,6 +97,8 @@ pub struct PackInspection {
     pub risk: Value,
     pub permission_sheet: Value,
     pub workflow_extensions: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub solution: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,6 +211,11 @@ impl PackManager {
         let risk = inspect_risk(&manifest, &installed);
         let permission_sheet = inspect_permission_sheet(&manifest, &risk);
         let workflow_extensions = inspect_workflow_extensions(&manifest);
+        let solution = if installed.pack_type == "solution" {
+            Some(solution::inspection(&install_path, &installed)?)
+        } else {
+            None
+        };
         Ok(PackInspection {
             installed,
             manifest,
@@ -210,6 +223,7 @@ impl PackManager {
             risk,
             permission_sheet,
             workflow_extensions,
+            solution,
         })
     }
 
@@ -322,7 +336,7 @@ impl PackManager {
                 n == "1" || n == "true" || n == "yes" || n == "on"
             })
             .unwrap_or(false);
-        if strict_secret_scan && !secret_hits.is_empty() {
+        if (strict_secret_scan || manifest.pack_type == "solution") && !secret_hits.is_empty() {
             let _ = tokio::fs::remove_dir_all(&stage_root).await;
             return Err(anyhow!(
                 "embedded_secret_detected: {} potential secret(s) found (first: {})",
@@ -331,6 +345,11 @@ impl PackManager {
             ));
         }
         let signature_status = verify_pack_signature(&stage_unpacked)?;
+        let solution_content_sha256 = if manifest.pack_type == "solution" {
+            Some(solution::verified_digest(&stage_unpacked, &manifest)?)
+        } else {
+            None
+        };
         if signature_policy == PackSignaturePolicy::RequireTrusted
             && pack_signature_required()
             && matches!(signature_status, PackSignatureStatus::Unsigned)
@@ -373,6 +392,7 @@ impl PackManager {
             pack_type: manifest.pack_type.clone(),
             install_path: install_target.to_string_lossy().to_string(),
             sha256,
+            solution_content_sha256,
             installed_at_ms: now_ms(),
             source: if input.source.is_null() {
                 serde_json::json!({
@@ -563,7 +583,12 @@ impl PackManager {
         tokio::fs::create_dir_all(parent).await?;
         reject_symlink_path(parent, "pack export directory")?;
         let temporary = parent.join(format!(".export-{}.tmp", Uuid::new_v4()));
-        if let Err(error) = zip_directory(&pack_dir, &temporary) {
+        let export_result = if record.pack_type == "solution" {
+            solution::export(&pack_dir, &temporary, &record)
+        } else {
+            zip_directory(&pack_dir, &temporary)
+        };
+        if let Err(error) = export_result {
             let _ = std::fs::remove_file(&temporary);
             return Err(error);
         }
@@ -945,6 +970,9 @@ fn validate_manifest(
     validate_pack_identifier("manifest.type", &manifest.pack_type)?;
     if let Some(pack_id) = manifest.pack_id.as_deref() {
         validate_pack_identifier("manifest.pack_id", pack_id)?;
+    }
+    if manifest.pack_type == "solution" {
+        solution::validate(install_root)?;
     }
     if let Some(marketplace) = manifest_value
         .pointer("/marketplace")
@@ -1420,11 +1448,17 @@ fn verify_pack_signature(root: &Path) -> anyhow::Result<PackSignatureStatus> {
     if !signature_path.exists() {
         return Ok(PackSignatureStatus::Unsigned);
     }
-    let envelope: PackSignatureEnvelope = serde_json::from_slice(
-        &std::fs::read(&signature_path)
-            .with_context(|| format!("read {}", signature_path.display()))?,
-    )
-    .context("parse tandempack.sig JSON")?;
+    let signature = std::fs::read(&signature_path)
+        .with_context(|| format!("read {}", signature_path.display()))?;
+    verify_pack_signature_bytes(&signature, pack_content_digest(root)?)
+}
+
+fn verify_pack_signature_bytes(
+    signature: &[u8],
+    digest: [u8; 32],
+) -> anyhow::Result<PackSignatureStatus> {
+    let envelope: PackSignatureEnvelope =
+        serde_json::from_slice(signature).context("parse tandempack.sig JSON")?;
     validate_pack_identifier("signature.key_id", &envelope.key_id)?;
     let trusted_keys = trusted_pack_public_keys()?;
     let public_key = trusted_keys
@@ -1435,7 +1469,6 @@ fn verify_pack_signature(root: &Path) -> anyhow::Result<PackSignatureStatus> {
         .ok_or_else(|| anyhow!("pack signature must be a base64 Ed25519 signature"))?;
     let verifying_key =
         VerifyingKey::from_bytes(public_key).context("invalid trusted pack public key")?;
-    let digest = pack_content_digest(root)?;
     verifying_key
         .verify_strict(&digest, &Signature::from_bytes(&signature_bytes))
         .context("pack signature verification failed")?;
@@ -1655,3 +1688,7 @@ pub fn map_missing_capability_error(
 #[cfg(test)]
 #[path = "pack_manager_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "pack_manager_solution_tests.rs"]
+mod solution_tests;

--- a/crates/tandem-server/src/pack_manager_solution.rs
+++ b/crates/tandem-server/src/pack_manager_solution.rs
@@ -192,7 +192,11 @@ fn verify_snapshot(snapshot: &Snapshot) -> anyhow::Result<String> {
     // Verify exactly the in-memory bytes returned/exported, not a second tree
     // read which could change between signature verification and artifact use.
     let mut hasher = Sha256::new();
-    for (path, bytes) in &snapshot.files {
+    let mut ordered = snapshot.files.iter().collect::<Vec<_>>();
+    // Match pack_content_digest's existing Path ordering exactly. Changing
+    // this to flat string ordering would change some nested-file signatures.
+    ordered.sort_by(|(left, _), (right, _)| Path::new(left).cmp(Path::new(right)));
+    for (path, bytes) in ordered {
         if path == PACK_SIGNATURE_FILE {
             continue;
         }

--- a/crates/tandem-server/src/pack_manager_solution.rs
+++ b/crates/tandem-server/src/pack_manager_solution.rs
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+//! Self-contained, pinned solution artifacts through the existing PackManager.
+//! These bytes are reusable product content, not customer state or activation.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::ensure;
+use tandem_solutions::{
+    parse_blueprint, SolutionBlueprint, MAX_ARTIFACT_BYTES, MAX_BLUEPRINT_BYTES,
+};
+
+use super::*;
+
+#[derive(Debug)]
+pub struct SolutionPackArtifacts {
+    pub blueprint: SolutionBlueprint,
+    /// Exact verified bytes, keyed by blueprint component ID for ResolutionInput.
+    pub artifacts: BTreeMap<String, Vec<u8>>,
+}
+
+struct Snapshot {
+    files: BTreeMap<String, Vec<u8>>,
+    solution: SolutionPackArtifacts,
+}
+
+fn portable_path(value: &str) -> anyhow::Result<String> {
+    ensure!(
+        !value.contains(['\\', ':'])
+            && value
+                .split('/')
+                .all(|part| !part.is_empty() && part != "." && part != ".."),
+        "solution entry must be a portable relative file path"
+    );
+    safe_relative_pack_path(value)?;
+    Ok(value.into())
+}
+
+fn snapshot(root: &Path) -> anyhow::Result<Snapshot> {
+    reject_symlink_path(root, "solution pack")?;
+    let mut files = BTreeMap::new();
+    let mut stack = vec![root.to_path_buf()];
+    let mut total = 0usize;
+    let mut entries_seen = 0usize;
+    while let Some(directory) = stack.pop() {
+        for entry in fs::read_dir(directory)? {
+            let entry = entry?;
+            entries_seen += 1;
+            ensure!(
+                entries_seen <= MAX_FILES * MAX_PATH_DEPTH,
+                "solution tree exceeds entry limit"
+            );
+            ensure!(
+                entry.path().strip_prefix(root)?.components().count() <= MAX_PATH_DEPTH,
+                "solution path exceeds depth limit"
+            );
+            let kind = entry.file_type()?;
+            ensure!(!kind.is_symlink(), "solution pack contains a symbolic link");
+            if kind.is_dir() {
+                stack.push(entry.path());
+                continue;
+            }
+            ensure!(kind.is_file(), "solution pack contains a non-regular file");
+            ensure!(
+                files.len() < MAX_FILES,
+                "solution pack exceeds file count limit"
+            );
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(root)?
+                .to_str()
+                .ok_or_else(|| anyhow!("solution pack path must be UTF-8"))?
+                .replace('\\', "/");
+            portable_path(&relative)?;
+            let mut bytes = Vec::new();
+            File::open(&path)?
+                .take(MAX_FILE_BYTES + 1)
+                .read_to_end(&mut bytes)?;
+            ensure!(
+                bytes.len() as u64 <= MAX_FILE_BYTES,
+                "solution file exceeds size limit"
+            );
+            total = total
+                .checked_add(bytes.len())
+                .ok_or_else(|| anyhow!("solution size overflow"))?;
+            ensure!(
+                total as u64 <= MAX_EXTRACTED_BYTES,
+                "solution exceeds extracted size limit"
+            );
+            ensure!(
+                files.insert(relative, bytes).is_none(),
+                "duplicate solution file path"
+            );
+        }
+    }
+    let marker = files
+        .get(MARKER_FILE)
+        .ok_or_else(|| anyhow!("solution manifest missing"))?;
+    ensure!(
+        marker.len() <= MAX_BLUEPRINT_BYTES,
+        "solution manifest exceeds size limit"
+    );
+    let manifest: PackManifest = serde_yaml::from_slice(marker)?;
+    ensure!(manifest.pack_type == "solution", "expected solution pack");
+    let blueprint_path = portable_path(
+        manifest
+            .entrypoints
+            .get("solution")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("solution pack requires entrypoints.solution"))?,
+    )?;
+    ensure!(
+        blueprint_path != MARKER_FILE && blueprint_path != PACK_SIGNATURE_FILE,
+        "solution blueprint must be a separate file"
+    );
+    let blueprint_bytes = files
+        .get(&blueprint_path)
+        .ok_or_else(|| anyhow!("solution blueprint missing"))?;
+    ensure!(
+        blueprint_bytes.len() <= MAX_BLUEPRINT_BYTES,
+        "solution blueprint exceeds size limit"
+    );
+    let blueprint = parse_blueprint(std::str::from_utf8(blueprint_bytes)?)?;
+    let pack_id = manifest.pack_id.as_deref().unwrap_or(&manifest.name);
+    ensure!(
+        blueprint.solution.id == pack_id && blueprint.solution.version == manifest.version,
+        "solution identity must match its pack manifest"
+    );
+    let mut allowed: BTreeSet<String> = [
+        MARKER_FILE.into(),
+        PACK_SIGNATURE_FILE.into(),
+        blueprint_path.clone(),
+    ]
+    .into();
+    let mut artifacts = BTreeMap::new();
+    for (id, component) in &blueprint.components {
+        ensure!(
+            component.artifact.pack_id == pack_id && component.artifact.version == manifest.version,
+            "solution v1 requires a self-contained locked artifact closure"
+        );
+        let path = portable_path(&component.artifact.path)?;
+        ensure!(
+            path != MARKER_FILE && path != PACK_SIGNATURE_FILE && path != blueprint_path,
+            "solution component must reference an artifact file"
+        );
+        let bytes = files
+            .get(&path)
+            .ok_or_else(|| anyhow!("solution component {id} artifact missing"))?;
+        ensure!(
+            bytes.len() <= MAX_ARTIFACT_BYTES,
+            "solution artifact exceeds size limit"
+        );
+        ensure!(
+            format!("{:x}", Sha256::digest(bytes)) == component.artifact.sha256,
+            "solution component {id} artifact digest mismatch"
+        );
+        allowed.insert(path);
+        artifacts.insert(id.clone(), bytes.clone());
+    }
+    ensure!(
+        files.keys().all(|path| allowed.contains(path)),
+        "solution contains undeclared files; keep customer state outside reusable packs"
+    );
+    // Reuse the pack scanner's patterns, with no size or .example exemptions
+    // for the allowlisted solution payload. Do not log matched credential bytes.
+    for (path, bytes) in &files {
+        if path == PACK_SIGNATURE_FILE {
+            continue;
+        }
+        ensure!(
+            !SECRET_SCAN_PATTERNS.iter().any(|needle| bytes
+                .windows(needle.len())
+                .any(|window| window == needle.as_bytes())),
+            "embedded_secret_detected in solution file {path}"
+        );
+    }
+    Ok(Snapshot {
+        files,
+        solution: SolutionPackArtifacts {
+            blueprint,
+            artifacts,
+        },
+    })
+}
+
+fn verify_snapshot(snapshot: &Snapshot) -> anyhow::Result<String> {
+    let signature = snapshot
+        .files
+        .get(PACK_SIGNATURE_FILE)
+        .ok_or_else(|| anyhow!("solution artifact loading requires a trusted signature"))?;
+    // Verify exactly the in-memory bytes returned/exported, not a second tree
+    // read which could change between signature verification and artifact use.
+    let mut hasher = Sha256::new();
+    for (path, bytes) in &snapshot.files {
+        if path == PACK_SIGNATURE_FILE {
+            continue;
+        }
+        hasher.update((path.len() as u64).to_be_bytes());
+        hasher.update(path.as_bytes());
+        hasher.update((bytes.len() as u64).to_be_bytes());
+        hasher.update(bytes);
+    }
+    let digest = hasher.finalize();
+    let hexadecimal = format!("{digest:x}");
+    verify_pack_signature_bytes(signature, digest.into())?;
+    Ok(hexadecimal)
+}
+
+pub(super) fn verified_digest(root: &Path, manifest: &PackManifest) -> anyhow::Result<String> {
+    let snapshot = snapshot(root)?;
+    ensure!(
+        snapshot.solution.blueprint.solution.id
+            == manifest.pack_id.as_deref().unwrap_or(&manifest.name)
+            && snapshot.solution.blueprint.solution.version == manifest.version,
+        "solution differs from selected install manifest"
+    );
+    verify_snapshot(&snapshot)
+}
+
+fn verify_installed(snapshot: &Snapshot, record: &PackInstallRecord) -> anyhow::Result<()> {
+    let digest = verify_snapshot(snapshot)?;
+    ensure!(record.solution_content_sha256.as_deref() == Some(digest.as_str()),
+        "solution content differs from install receipt or lacks a validated receipt; reinstall a verified archive");
+    ensure!(
+        snapshot.solution.blueprint.solution.id == record.pack_id
+            && snapshot.solution.blueprint.solution.version == record.version,
+        "solution no longer matches its installed identity"
+    );
+    Ok(())
+}
+
+pub(super) fn validate(root: &Path) -> anyhow::Result<()> {
+    snapshot(root)?;
+    Ok(())
+}
+
+pub(super) fn inspection(root: &Path, record: &PackInstallRecord) -> anyhow::Result<Value> {
+    let snapshot = snapshot(root)?;
+    verify_installed(&snapshot, record)?;
+    Ok(serde_json::json!({
+        "blueprint": snapshot.solution.blueprint,
+        "runtime_materialized": false,
+        "activation_required": true,
+    }))
+}
+
+pub(super) fn export(root: &Path, output: &Path, record: &PackInstallRecord) -> anyhow::Result<()> {
+    let snapshot = snapshot(root)?;
+    verify_installed(&snapshot, record)?;
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(output)?;
+    let mut writer = ZipWriter::new(file);
+    let options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+    for (path, bytes) in &snapshot.files {
+        writer.start_file(path, options)?;
+        std::io::Write::write_all(&mut writer, bytes)?;
+    }
+    writer.finish()?;
+    Ok(())
+}
+
+impl PackManager {
+    /// Service must separately authorize pack access and installation scope.
+    /// Always returns a freshly trusted, self-contained immutable byte snapshot.
+    pub async fn solution_artifacts(
+        &self,
+        selector: &str,
+    ) -> anyhow::Result<SolutionPackArtifacts> {
+        let index = self.read_index().await?;
+        let record =
+            select_record(&index, Some(selector), None).ok_or_else(|| anyhow!("pack not found"))?;
+        ensure!(record.pack_type == "solution", "pack is not a solution");
+        let lock = self.pack_lock(&record.name).await;
+        let _guard = lock.lock().await;
+        let root = self.validated_record_install_path(&record)?;
+        let snapshot = snapshot(&root)?;
+        verify_installed(&snapshot, &record)?;
+        Ok(snapshot.solution)
+    }
+}

--- a/crates/tandem-server/src/pack_manager_solution_tests.rs
+++ b/crates/tandem-server/src/pack_manager_solution_tests.rs
@@ -62,6 +62,34 @@ fn export_request(name: &str) -> PackExportRequest {
 
 #[tokio::test]
 #[serial_test::serial(pack_signature_env)]
+async fn solution_pack_snapshot_preserves_existing_nested_path_signature_order() {
+    let root = tempfile::tempdir().unwrap();
+    let mut entries = fixture();
+    let mut blueprint: Value = serde_json::from_str(&entries[1].1).unwrap();
+    entries[2].0 = "artifacts.json".into();
+    entries[3].0 = "artifacts/review.json".into();
+    blueprint["components"]["central-brain"]["artifact"]["path"] = entries[2].0.clone().into();
+    blueprint["components"]["review-notes"]["artifact"]["path"] = entries[3].0.clone().into();
+    entries[1].1 = serde_json::to_string(&blueprint).unwrap();
+    let archive = root.path().join("ordered.zip");
+    let key = signed(&archive, &entries);
+    let _keys = EnvGuard::set("TANDEM_PACK_TRUSTED_PUBLIC_KEYS", &key);
+    let manager = PackManager::new(root.path().join("packs"));
+    manager.install(request(&archive)).await.unwrap();
+    assert_eq!(
+        manager
+            .solution_artifacts("tandem.company-brain")
+            .await
+            .unwrap()
+            .artifacts
+            .len(),
+        2
+    );
+    manager.export(export_request("ordered.zip")).await.unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
 async fn solution_pack_signed_artifacts_feed_existing_resolver_and_round_trip() {
     use std::collections::{BTreeMap, BTreeSet};
     use tandem_enterprise_contract::{

--- a/crates/tandem-server/src/pack_manager_solution_tests.rs
+++ b/crates/tandem-server/src/pack_manager_solution_tests.rs
@@ -1,0 +1,332 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+use super::tests::{write_signed_zip, EnvGuard};
+use super::*;
+
+fn fixture() -> Vec<(String, String)> {
+    [
+        (
+            MARKER_FILE,
+            include_str!("../../tandem-solutions/fixtures/company-brain-text/tandempack.yaml"),
+        ),
+        (
+            "solution.json",
+            include_str!("../../tandem-solutions/fixtures/company-brain-text/solution.json"),
+        ),
+        (
+            "agents/central-brain.json",
+            include_str!(
+                "../../tandem-solutions/fixtures/company-brain-text/agents/central-brain.json"
+            ),
+        ),
+        (
+            "routines/review-notes.json",
+            include_str!(
+                "../../tandem-solutions/fixtures/company-brain-text/routines/review-notes.json"
+            ),
+        ),
+    ]
+    .into_iter()
+    .map(|(path, bytes)| (path.into(), bytes.into()))
+    .collect()
+}
+
+fn signed(path: &Path, entries: &[(String, String)]) -> String {
+    write_signed_zip(
+        path,
+        &entries
+            .iter()
+            .map(|(path, bytes)| (path.as_str(), bytes.as_str()))
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn request(path: &Path) -> PackInstallRequest {
+    PackInstallRequest {
+        path: Some(path.to_string_lossy().into_owned()),
+        url: None,
+        expected_sha256: None,
+        source: Value::Null,
+    }
+}
+
+fn export_request(name: &str) -> PackExportRequest {
+    PackExportRequest {
+        pack_id: Some("tandem.company-brain".into()),
+        name: None,
+        version: Some("0.1.0".into()),
+        output_path: Some(name.into()),
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_pack_signed_artifacts_feed_existing_resolver_and_round_trip() {
+    use std::collections::{BTreeMap, BTreeSet};
+    use tandem_enterprise_contract::{
+        AuthorityChain, HumanActor, RequestPrincipal, TenantContext, TenantContextAssertionClaims,
+        VerifiedTenantContext,
+    };
+    use tandem_solutions::{InstallRequest, ModelBinding, ResolutionInput};
+    let root = tempfile::tempdir().unwrap();
+    let archive = root.path().join("solution.zip");
+    let key = signed(&archive, &fixture());
+    let _keys = EnvGuard::set("TANDEM_PACK_TRUSTED_PUBLIC_KEYS", &key);
+    let manager = PackManager::new(root.path().join("packs"));
+    let installed = manager.install(request(&archive)).await.unwrap();
+    assert!(!installed.routines_enabled);
+    assert!(installed.solution_content_sha256.is_some());
+    let inspection = manager.inspect("tandem.company-brain").await.unwrap();
+    assert_eq!(
+        inspection.solution.as_ref().unwrap()["activation_required"],
+        true
+    );
+    let source = manager
+        .solution_artifacts("tandem.company-brain")
+        .await
+        .unwrap();
+    let context: VerifiedTenantContext = TenantContextAssertionClaims::new_v1(
+        "issuer",
+        "runtime",
+        1000,
+        2000,
+        "synthetic",
+        TenantContext::explicit_user_workspace(
+            "org-a",
+            "workspace-a",
+            Some("deployment-a".into()),
+            "owner-a",
+        ),
+        HumanActor::tandem_user("owner-a"),
+        AuthorityChain::from_request(RequestPrincipal::authenticated_user("owner-a", "fixture")),
+        vec!["workspace:user".into()],
+    )
+    .into();
+    let install = InstallRequest {
+        instance_id: "company-brain".into(),
+        customer_config_revision: "a".repeat(64),
+        optional_components: ["review-notes".into()].into(),
+        preferences: BTreeMap::new(),
+        connectors: BTreeMap::new(),
+        models: [("economy".into(), "fixture".into())].into(),
+    };
+    let models = [(
+        "fixture".into(),
+        ModelBinding {
+            provider: "local".into(),
+            model: "fixture".into(),
+            credential_ref: "secret-ref:local-fixture".into(),
+            uses_network: false,
+        },
+    )]
+    .into();
+    let readiness: BTreeSet<String> =
+        ["governed-memory".into(), "verified-user-context".into()].into();
+    let plan = tandem_solutions::resolve(
+        &source.blueprint,
+        ResolutionInput {
+            request: &install,
+            verified_context: &context,
+            now_ms: 1500,
+            engine_version: "0.7.2",
+            deployment_policy: &source.blueprint.constraints,
+            available_deployment_requirements: &readiness,
+            approved_models: &models,
+            artifacts: &source.artifacts,
+        },
+    )
+    .unwrap();
+    assert_eq!(plan.install_order, ["central-brain", "review-notes"]);
+    let export = manager
+        .export(export_request("reusable.zip"))
+        .await
+        .unwrap();
+    let other = PackManager::new(root.path().join("other"));
+    other
+        .install(request(Path::new(&export.path)))
+        .await
+        .unwrap();
+    let imported = other
+        .solution_artifacts("tandem.company-brain")
+        .await
+        .unwrap();
+    assert_eq!(source.blueprint, imported.blueprint);
+    assert_eq!(source.artifacts, imported.artifacts);
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_pack_invalid_closure_or_customer_files_leave_no_install() {
+    for failure in [
+        "missing",
+        "digest",
+        "external",
+        "customer",
+        "path",
+        "entrypoint",
+        "secret",
+        "large-secret",
+        "example-secret",
+    ] {
+        let root = tempfile::tempdir().unwrap();
+        let mut entries = fixture();
+        let mut blueprint: Value = serde_json::from_str(&entries[1].1).unwrap();
+        match failure {
+            "missing" => {
+                entries.remove(2);
+            }
+            "digest" => {
+                blueprint["components"]["central-brain"]["artifact"]["sha256"] =
+                    Value::String("b".repeat(64))
+            }
+            "external" => {
+                blueprint["components"]["central-brain"]["artifact"]["pack_id"] =
+                    "other.pack".into()
+            }
+            "customer" => entries.push((
+                "customer.yaml".into(),
+                "private: synthetic-customer-value".into(),
+            )),
+            "path" => {
+                blueprint["components"]["central-brain"]["artifact"]["path"] =
+                    "../outside.json".into()
+            }
+            "entrypoint" => {
+                entries[0].1 = entries[0]
+                    .1
+                    .replace("solution: solution.json", "solution: ../outside.json")
+            }
+            "secret" | "large-secret" | "example-secret" => {
+                entries[2].1 = concat!("gh", "p_", "synthetic-fixture").into();
+                if failure == "large-secret" {
+                    entries[2].1 =
+                        " ".repeat(SECRET_SCAN_MAX_FILE_BYTES as usize + 1) + &entries[2].1;
+                }
+                if failure == "example-secret" {
+                    entries[2].0 = "agents/central-brain.example.json".into();
+                    blueprint["components"]["central-brain"]["artifact"]["path"] =
+                        entries[2].0.clone().into();
+                }
+                blueprint["components"]["central-brain"]["artifact"]["sha256"] =
+                    format!("{:x}", Sha256::digest(entries[2].1.as_bytes())).into();
+            }
+            _ => unreachable!(),
+        }
+        entries[1].1 = serde_json::to_string(&blueprint).unwrap();
+        let archive = root.path().join("invalid.zip");
+        let key = signed(&archive, &entries);
+        let _keys = EnvGuard::set("TANDEM_PACK_TRUSTED_PUBLIC_KEYS", &key);
+        let _scan = EnvGuard::set("TANDEM_PACK_SECRET_SCAN_STRICT", "false");
+        let manager = PackManager::new(root.path().join("packs"));
+        assert!(
+            manager.install(request(&archive)).await.is_err(),
+            "{failure}"
+        );
+        assert!(manager.list().await.unwrap().is_empty(), "{failure}");
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_pack_export_rejects_nearby_customer_state_and_revoked_trust() {
+    let root = tempfile::tempdir().unwrap();
+    let archive = root.path().join("solution.zip");
+    let key = signed(&archive, &fixture());
+    let _keys = EnvGuard::set("TANDEM_PACK_TRUSTED_PUBLIC_KEYS", &key);
+    let manager = PackManager::new(root.path().join("packs"));
+    let installed = manager.install(request(&archive)).await.unwrap();
+    let customer = Path::new(&installed.install_path).join("customer-private.json");
+    fs::write(&customer, "synthetic private state").unwrap();
+    assert!(manager
+        .solution_artifacts("tandem.company-brain")
+        .await
+        .is_err());
+    assert!(manager.export(export_request("private.zip")).await.is_err());
+    assert!(!root.path().join("packs/exports/private.zip").exists());
+    fs::remove_file(customer).unwrap();
+    let _revoked = EnvGuard::set("TANDEM_PACK_TRUSTED_PUBLIC_KEYS", "");
+    assert!(manager
+        .solution_artifacts("tandem.company-brain")
+        .await
+        .is_err());
+    assert!(manager.export(export_request("revoked.zip")).await.is_err());
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_pack_resigned_same_version_cannot_replace_installed_content() {
+    let root = tempfile::tempdir().unwrap();
+    let archive = root.path().join("solution.zip");
+    let mut entries = fixture();
+    let key = signed(&archive, &entries);
+    let _keys = EnvGuard::set("TANDEM_PACK_TRUSTED_PUBLIC_KEYS", &key);
+    let manager = PackManager::new(root.path().join("packs"));
+    let installed = manager.install(request(&archive)).await.unwrap();
+    let mut blueprint: Value = serde_json::from_str(&entries[1].1).unwrap();
+    blueprint["ui_features"] = serde_json::json!(["chat", "memory", "changed"]);
+    entries[1].1 = serde_json::to_string(&blueprint).unwrap();
+    let replacement = root.path().join("replacement.zip");
+    signed(&replacement, &entries);
+    let unpacked = root.path().join("replacement");
+    fs::create_dir(&unpacked).unwrap();
+    safe_extract_zip(&replacement, &unpacked).unwrap();
+    for relative in ["solution.json", PACK_SIGNATURE_FILE] {
+        fs::copy(
+            unpacked.join(relative),
+            Path::new(&installed.install_path).join(relative),
+        )
+        .unwrap();
+    }
+    assert!(matches!(
+        verify_pack_signature(Path::new(&installed.install_path)).unwrap(),
+        PackSignatureStatus::Verified { .. }
+    ));
+    assert!(manager
+        .solution_artifacts("tandem.company-brain")
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("install receipt"));
+    assert!(manager
+        .export(export_request("replacement.zip"))
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_pack_invalid_upgrade_preserves_prior_pointer_and_artifacts() {
+    let root = tempfile::tempdir().unwrap();
+    let archive = root.path().join("solution.zip");
+    let mut entries = fixture();
+    let key = signed(&archive, &entries);
+    let _keys = EnvGuard::set("TANDEM_PACK_TRUSTED_PUBLIC_KEYS", &key);
+    let manager = PackManager::new(root.path().join("packs"));
+    manager.install(request(&archive)).await.unwrap();
+    let original = manager
+        .solution_artifacts("tandem.company-brain")
+        .await
+        .unwrap();
+    entries[0].1 = entries[0].1.replace("0.1.0", "0.2.0");
+    entries[1].1 = entries[1].1.replace("0.1.0", "0.2.0");
+    entries.remove(2);
+    let upgrade = root.path().join("upgrade.zip");
+    signed(&upgrade, &entries);
+    assert!(manager.install(request(&upgrade)).await.is_err());
+    assert_eq!(manager.list().await.unwrap().len(), 1);
+    assert_eq!(
+        fs::read_to_string(root.path().join("packs/tandem.company-brain/current"))
+            .unwrap()
+            .trim(),
+        "0.1.0"
+    );
+    assert_eq!(
+        manager
+            .solution_artifacts("tandem.company-brain")
+            .await
+            .unwrap()
+            .artifacts,
+        original.artifacts
+    );
+}

--- a/crates/tandem-server/src/pack_manager_tests.rs
+++ b/crates/tandem-server/src/pack_manager_tests.rs
@@ -16,7 +16,7 @@ fn write_zip(path: &Path, entries: &[(&str, &str)]) {
     zip.finish().expect("finish");
 }
 
-fn write_signed_zip(path: &Path, entries: &[(&str, &str)]) -> String {
+pub(super) fn write_signed_zip(path: &Path, entries: &[(&str, &str)]) -> String {
     let mut ordered = entries
         .iter()
         .map(|(name, body)| ((*name).to_string(), body.as_bytes().to_vec()))
@@ -56,13 +56,13 @@ fn write_signed_zip(path: &Path, entries: &[(&str, &str)]) -> String {
     )
 }
 
-struct EnvGuard {
+pub(super) struct EnvGuard {
     key: &'static str,
     previous: Option<String>,
 }
 
 impl EnvGuard {
-    fn set(key: &'static str, value: &str) -> Self {
+    pub(super) fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var(key).ok();
         std::env::set_var(key, value);
         Self { key, previous }

--- a/crates/tandem-server/src/pack_manager_tests.rs
+++ b/crates/tandem-server/src/pack_manager_tests.rs
@@ -21,7 +21,7 @@ pub(super) fn write_signed_zip(path: &Path, entries: &[(&str, &str)]) -> String 
         .iter()
         .map(|(name, body)| ((*name).to_string(), body.as_bytes().to_vec()))
         .collect::<Vec<_>>();
-    ordered.sort_by(|left, right| left.0.cmp(&right.0));
+    ordered.sort_by(|left, right| Path::new(&left.0).cmp(Path::new(&right.0)));
     let mut hasher = Sha256::new();
     for (name, body) in &ordered {
         hasher.update((name.len() as u64).to_be_bytes());

--- a/crates/tandem-solutions/fixtures/company-brain-text/tandempack.yaml
+++ b/crates/tandem-solutions/fixtures/company-brain-text/tandempack.yaml
@@ -1,0 +1,6 @@
+name: tandem.company-brain
+pack_id: tandem.company-brain
+version: 0.1.0
+type: solution
+entrypoints:
+  solution: solution.json

--- a/docs/SOLUTION_PACKS.md
+++ b/docs/SOLUTION_PACKS.md
@@ -1,0 +1,56 @@
+# Validated solution packs
+
+`type: solution` extends the existing PackManager. It uses the same ZIP archive,
+trusted Ed25519 signature, extraction limits, staging/index/current lifecycle and
+operator-only ingestion APIs. It does not install runtime resources or activate
+routines. Existing workflow pack behavior is preserved.
+
+The initial format requires `entrypoints.solution` to name a version 1
+SolutionBlueprint. Its identity/version must match the pack. Every component's
+artifact is pinned to this pack ID/version and its exact SHA-256 bytes. Required
+and optional artifacts both belong to the self-contained closure. Unsupported
+external pack references fail closed; they are not fetched during installation.
+
+The allowlist contains only `tandempack.yaml`, `tandempack.sig`, the blueprint and
+its declared artifacts. Extra files, symlinks, unsafe paths, missing files or
+digest mismatches reject the solution. Existing secret scan patterns apply to
+all allowlisted payload bytes without file-size or `.example` exemptions. These
+patterns are a heuristic, not a classification of every possible private value.
+Publishers must package reusable product content, not customer data.
+
+`PackManager::solution_artifacts` supplies verified bytes keyed by component ID
+for the existing resolver. The host must separately authorize access and provide
+current identities, model/connector bindings, customer configuration and policy.
+Inspection exposes the blueprint's components, constraints, memory declarations
+and required/optional dependencies. It never claims runtime materialization.
+
+## Integrity and export
+
+Installed solution records bind a canonical content digest as well as the
+existing archive digest. Loading, inspection and export verify current publisher
+trust and this installed-content binding. A new valid signature on changed
+same-version content cannot silently replace the original install receipt.
+
+Verification operates on the exact in-memory file snapshot returned to the
+planner or written to the exported archive. Export never does an unchecked second
+tree walk after verifying a snapshot. Adding a customer file beside installed
+artifacts rejects export; it is not included or silently removed while retaining
+an invalid signature. Legacy records that merely used the free-form `solution`
+type lack the new validated digest and must be reinstalled from a verified archive.
+
+## Text fixture and remaining work
+
+The current `company-brain-text` fixture supplies the manifest, solution.json,
+agents/central-brain.json and routines/review-notes.json. Package exactly those
+four files plus the normal signature; exclude the neighboring customer YAML
+fixtures. Regression tests sign this allowlisted content using the existing
+synthetic publisher helper, install it, feed its bytes into the actual resolver,
+and export/reinstall it with the same content. Synthetic signing keys are not
+production publisher trust configuration.
+
+This is validated ingestion and artifact loading. Runtime installation-reference
+guards/shared dependency ownership on uninstall, materialization, activation,
+external-effect compensation and upgrade/rollback acceptance remain installer
+work. The existing uninstall operation changes pack files/indexes only; it does
+not claim rollback of installed runtime resources or customer data. Keep TAN-826
+and the complete solution acceptance open until those integrations are proven.


### PR DESCRIPTION
PackManager previously accepted a free-form solution type without validating its blueprint or supplying pinned artifacts to the resolver. Extend the existing archive/staging/trust/index lifecycle with a self-contained SolutionBlueprint closure, exact artifact digests, mandatory solution secret-pattern checks and a reusable-file allowlist. Add a current-trust artifact loader and solution inspection metadata; file installation still leaves routines disabled.

Solution records bind the canonical content digest alongside the archive digest. Loading, inspection and export verify exactly the signed byte snapshot being returned, as well as its installed-content binding. Changed content with a new valid same-version signature cannot silently replace an installation. Export rejects nearby undeclared customer files and writes the verified snapshot without a second unchecked tree walk. Existing workflow behavior stays on its current path.

Added the minimal text fixture manifest and six integration regressions covering signed install → actual resolver → export/reinstall, nine invalid closure/path/customer/secret cases (including large and example-file scanner exemptions), revoked trust, undeclared nearby customer files, resigned same-version replacement and failed upgrade preserving the prior pointer. CI runs new and existing PackManager tests with PostgreSQL-feature compilation. Local Rustfmt/diff/include-path/module-size checks and exact fixture artifact hashes passed; actual current-head focused CI passed all 19 PackManager tests, six customer backend tests, protected backend transfer and PostgreSQL clippy. Full Engine CI passed (5,133 workspace tests, seven skipped); release composition, engine container and aggregate security also passed. All five workflows passed on the exact candidate; ready for review.

Stacks on #1939. This slice covers validated ingestion and byte loading. Hosted installation authorization, runtime materialization, shared installation-reference guards on uninstall, activation, production publisher distribution and full lifecycle acceptance remain. Legacy free-form solution records require verified reinstallation. Secret patterns remain heuristic, not arbitrary private-data classification. Keep TAN-826 and overall acceptance open. No automatic merge.

Current signed candidate: 58d23c92849a2e52c945d50bcb796693350f654f. Snapshot verification preserves the existing Path-based signature ordering, covered by a nested-path regression. Solution Contract run34006030036 and Engine CI34006030062 passed on this candidate. Release/security run34006030030 passed, including release101413305319, engine container101417416758 and aggregate101417632172.