### PR TITLE
TAN-834: stage owned disabled native agent templates

### DIFF
--- a/.github/workflows/solution-contract.yml
+++ b/.github/workflows/solution-contract.yml
@@ -82,5 +82,9 @@ jobs:
         run: cargo test -p tandem-server --locked --features storage-postgres stateful_runtime::orchestration_store::transfer --lib -- --test-threads=1
       - name: Verify durable solution staging on both backends
         run: cargo test -p tandem-server --locked --features storage-postgres solution_installation_ --lib -- --test-threads=1
+      - name: Verify native disabled agent staging and reconciliation
+        run: cargo test -p tandem-server --locked --features storage-postgres agent_teams::solution_templates --lib
+      - name: Verify disabled template cannot request spawn approval
+        run: cargo test -p tandem-orchestrator --locked disabled_template_cannot --lib
       - name: Lint the PostgreSQL and SQLite store adapter
         run: cargo clippy -p tandem-server --locked --features storage-postgres --lib -- -D warnings

--- a/crates/tandem-orchestrator/src/agent_team.rs
+++ b/crates/tandem-orchestrator/src/agent_team.rs
@@ -34,6 +34,7 @@ pub enum SpawnBehavior {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SpawnDenyCode {
+    SpawnTemplateDisabled,
     SpawnPolicyMissing,
     SpawnPolicyDisabled,
     SpawnDeniedEdge,
@@ -121,8 +122,29 @@ pub struct SkillRequirement {
     pub path: Option<String>,
 }
 
+/// Ownership of a staged solution resource. This metadata is not authorization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SolutionTemplateOwner {
+    pub org_id: String,
+    pub workspace_id: String,
+    pub deployment_id: String,
+    pub instance_id: String,
+    pub component_id: String,
+    pub composition_sha256: String,
+}
+
+fn template_enabled_by_default() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentTemplate {
+    /// Existing templates remain enabled; installers explicitly stage disabled.
+    #[serde(default = "template_enabled_by_default")]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub solution_owner: Option<SolutionTemplateOwner>,
     #[serde(rename = "templateID")]
     pub template_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -280,6 +302,12 @@ impl SpawnPolicy {
         running_agents: usize,
         template: Option<&AgentTemplate>,
     ) -> SpawnDecision {
+        if template.is_some_and(|template| !template.enabled) {
+            return deny(
+                SpawnDenyCode::SpawnTemplateDisabled,
+                "agent template is staged or disabled".to_string(),
+            );
+        }
         if !self.enabled {
             return deny(
                 SpawnDenyCode::SpawnPolicyDisabled,
@@ -452,6 +480,42 @@ mod tests {
     }
 
     #[test]
+    fn disabled_template_cannot_be_promoted_to_spawn_approval() {
+        let mut policy = base_policy();
+        policy
+            .spawn_edges
+            .get_mut(&AgentRole::Orchestrator)
+            .unwrap()
+            .behavior = Some(SpawnBehavior::RequestOnly);
+        let req = SpawnRequest {
+            mission_id: Some("m1".into()),
+            parent_instance_id: Some("p1".into()),
+            source: SpawnSource::UiAction,
+            parent_role: Some(AgentRole::Orchestrator),
+            role: AgentRole::Worker,
+            template_id: Some("staged-worker".into()),
+            justification: "reviewed action".into(),
+            budget_override: None,
+        };
+        let mut template: AgentTemplate = serde_json::from_value(serde_json::json!({
+            "templateID": "staged-worker", "role": "worker"
+        }))
+        .unwrap();
+        // Old documents preserve enabled semantics, including approval policy.
+        assert!(template.enabled);
+        assert!(
+            policy
+                .evaluate(&req, 0, 0, Some(&template))
+                .requires_user_approval
+        );
+        template.enabled = false;
+        let decision = policy.evaluate(&req, 0, 0, Some(&template));
+        assert!(!decision.allowed);
+        assert!(!decision.requires_user_approval);
+        assert_eq!(decision.code, Some(SpawnDenyCode::SpawnTemplateDisabled));
+    }
+
+    #[test]
     fn policy_requires_justification() {
         let policy = base_policy();
         let req = SpawnRequest {
@@ -511,6 +575,8 @@ mod tests {
             budget_override: None,
         };
         let template = AgentTemplate {
+            enabled: true,
+            solution_owner: None,
             template_id: "worker-default".to_string(),
             display_name: Some("Worker".to_string()),
             avatar_url: None,

--- a/crates/tandem-server/src/agent_teams.rs
+++ b/crates/tandem-server/src/agent_teams.rs
@@ -26,6 +26,7 @@ include!("agent_teams_parts/predicate_evidence.rs");
 include!("agent_teams_parts/enterprise_authored_policy.rs");
 include!("agent_teams_parts/phase_tool_policy.rs");
 include!("agent_teams_parts/part01.rs");
+mod solution_templates;
 include!("agent_teams_parts/action_gate_approval.rs");
 include!("agent_teams_parts/part03.rs");
 include!("agent_teams_parts/part02.rs");

--- a/crates/tandem-server/src/agent_teams/solution_templates.rs
+++ b/crates/tandem-server/src/agent_teams/solution_templates.rs
@@ -272,16 +272,21 @@ mod tests {
             justification: "approved request".into(),
             budget_override: None,
         };
-        for override_approval in [false, true] {
-            let result = runtime
-                .spawn_with_approval_override(&state, request.clone(), override_approval)
-                .await;
-            assert!(!result.decision.allowed);
-            assert_eq!(
-                result.decision.code,
-                Some(tandem_orchestrator::SpawnDenyCode::SpawnTemplateDisabled)
-            );
-            assert!(result.instance.is_none());
+        for missing_from_cache in [false, true] {
+            if missing_from_cache {
+                runtime.templates.write().await.clear();
+            }
+            for override_approval in [false, true] {
+                let result = runtime
+                    .spawn_with_approval_override(&state, request.clone(), override_approval)
+                    .await;
+                assert!(!result.decision.allowed);
+                assert_eq!(
+                    result.decision.code,
+                    Some(tandem_orchestrator::SpawnDenyCode::SpawnTemplateDisabled)
+                );
+                assert!(result.instance.is_none());
+            }
         }
         assert!(runtime.list_spawn_approvals().await.is_empty());
         assert!(runtime.list_instances(None, None, None).await.is_empty());

--- a/crates/tandem-server/src/agent_teams/solution_templates.rs
+++ b/crates/tandem-server/src/agent_teams/solution_templates.rs
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+//! Native AgentTemplate staging. Callers must authorize the installation and
+//! revalidate its journal, signed artifacts and current host facts first. A
+//! returned fingerprint is an observed disabled resource, never activation.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::ensure;
+use tandem_orchestrator::{AgentTemplate, SolutionTemplateOwner};
+use tandem_solutions::{canonical_json, sha256, MAX_ARTIFACT_BYTES};
+
+use super::AgentTeamRuntime;
+
+impl AgentTeamRuntime {
+    /// Create or reconcile an exact disabled template without replacing a
+    /// pre-existing resource. Generic template mutation cannot activate it.
+    pub async fn stage_solution_template(
+        &self,
+        workspace_root: &str,
+        mut template: AgentTemplate,
+        owner: SolutionTemplateOwner,
+    ) -> anyhow::Result<String> {
+        validate_owner(&template, &owner)?;
+        template.enabled = false;
+        template.solution_owner = Some(owner);
+        let payload = canonical_json(&template)?;
+        ensure!(
+            payload.len() <= MAX_ARTIFACT_BYTES,
+            "solution template is too large"
+        );
+        let fingerprint = sha256(&payload);
+        let _operation = self.template_persistence.lock().await;
+        self.ensure_loaded_for_workspace(workspace_root).await?;
+        let path = PathBuf::from(workspace_root)
+            .join(".tandem/agent-team/templates")
+            .join(Self::template_filename(&template.template_id));
+        // Existing YAML/JSON aliases must not create duplicate template IDs.
+        if let Some(existing) = self.templates.read().await.get(&template.template_id) {
+            ensure!(
+                canonical_json(existing)? == payload,
+                "solution template ownership or content conflict"
+            );
+        }
+        tokio::task::spawn_blocking(move || persist_disabled(&path, &payload)).await??;
+        self.templates
+            .write()
+            .await
+            .insert(template.template_id.clone(), template);
+        Ok(fingerprint)
+    }
+}
+
+fn validate_owner(template: &AgentTemplate, owner: &SolutionTemplateOwner) -> anyhow::Result<()> {
+    ensure!(
+        template.template_id.starts_with("solution-")
+            && template.template_id.len() <= 240
+            && template
+                .template_id
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_'),
+        "solution template requires a portable stable resource ID"
+    );
+    for reference in [
+        &owner.org_id,
+        &owner.workspace_id,
+        &owner.deployment_id,
+        &owner.instance_id,
+        &owner.component_id,
+    ] {
+        ensure!(
+            !reference.is_empty()
+                && reference.len() <= 256
+                && reference.trim() == reference
+                && !reference.chars().any(char::is_control),
+            "solution template requires complete ownership"
+        );
+    }
+    ensure!(
+        owner.composition_sha256.len() == 64
+            && owner
+                .composition_sha256
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit()),
+        "solution template requires a reviewed composition digest"
+    );
+    ensure!(
+        template.solution_owner.is_none(),
+        "artifact must not supply installation ownership"
+    );
+    Ok(())
+}
+
+fn persist_disabled(path: &Path, payload: &[u8]) -> anyhow::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("missing template directory"))?;
+    std::fs::create_dir_all(parent)?;
+    let temporary = parent.join(format!(".solution-{}.tmp", uuid::Uuid::new_v4()));
+    let result = (|| {
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary)?;
+        file.write_all(payload)?;
+        file.sync_all()?;
+        drop(file);
+        // Hard-link publication is atomic and never replaces the destination.
+        // An interrupted writer leaves only an ignored .tmp or the whole file.
+        match std::fs::hard_link(&temporary, path) {
+            Ok(()) => (),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => (),
+            Err(error) => return Err(error.into()),
+        }
+        ensure!(
+            std::fs::symlink_metadata(path)?.file_type().is_file(),
+            "solution template destination is not a regular file"
+        );
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)?;
+        let mut existing = Vec::new();
+        (&file)
+            .take(MAX_ARTIFACT_BYTES as u64 + 1)
+            .read_to_end(&mut existing)?;
+        ensure!(
+            existing.len() <= MAX_ARTIFACT_BYTES,
+            "existing template is too large"
+        );
+        let observed: AgentTemplate = serde_yaml::from_slice(&existing)?;
+        ensure!(
+            canonical_json(&observed)? == payload,
+            "solution template ownership or content conflict"
+        );
+        file.sync_all()?;
+        #[cfg(unix)]
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    })();
+    let _ = std::fs::remove_file(temporary);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> (AgentTemplate, SolutionTemplateOwner) {
+        let mut template: AgentTemplate = serde_json::from_str(include_str!(
+            "../../../tandem-solutions/fixtures/company-brain-text/agents/central-brain.json"
+        ))
+        .unwrap();
+        template.template_id = "solution-test-central-brain".into();
+        let owner = SolutionTemplateOwner {
+            org_id: "org-a".into(),
+            workspace_id: "workspace-a".into(),
+            deployment_id: "deployment-a".into(),
+            instance_id: "brain-a".into(),
+            component_id: "central-brain".into(),
+            composition_sha256: "a".repeat(64),
+        };
+        (template, owner)
+    }
+
+    #[tokio::test]
+    async fn staged_template_survives_restart_and_reconciles_without_activation() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().to_str().unwrap();
+        let runtime = AgentTeamRuntime::new(dir.path().join("audit.jsonl"));
+        let (template, owner) = fixture();
+        let receipt = runtime
+            .stage_solution_template(workspace, template.clone(), owner.clone())
+            .await
+            .unwrap();
+        // Simulate a crash after native publication but before journal receipt.
+        let restarted = AgentTeamRuntime::new(dir.path().join("audit.jsonl"));
+        let observed = restarted
+            .get_template_for_workspace(workspace, &template.template_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!observed.enabled);
+        assert_eq!(observed.solution_owner, Some(owner.clone()));
+        assert_eq!(sha256(&canonical_json(&observed).unwrap()), receipt);
+        assert_eq!(
+            restarted
+                .stage_solution_template(workspace, template.clone(), owner.clone())
+                .await
+                .unwrap(),
+            receipt
+        );
+        let mut changed = template.clone();
+        changed.system_prompt = Some("changed content".into());
+        assert!(restarted
+            .stage_solution_template(workspace, changed, owner.clone())
+            .await
+            .is_err());
+        let mut other_owner = owner;
+        other_owner.org_id = "org-b".into();
+        assert!(restarted
+            .stage_solution_template(workspace, template.clone(), other_owner)
+            .await
+            .is_err());
+        assert!(restarted
+            .upsert_template(workspace, template.clone())
+            .await
+            .is_err());
+        assert!(restarted
+            .delete_template(workspace, &template.template_id)
+            .await
+            .is_err());
+        for alias in [
+            format!(" {} ", template.template_id),
+            template.template_id.to_ascii_uppercase(),
+        ] {
+            let mut aliased = template.clone();
+            aliased.template_id = alias.clone();
+            assert!(restarted.upsert_template(workspace, aliased).await.is_err());
+            assert!(restarted.delete_template(workspace, &alias).await.is_err());
+        }
+        assert!(
+            !restarted
+                .get_template_for_workspace(workspace, &template.template_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .enabled
+        );
+    }
+
+    #[tokio::test]
+    async fn native_staged_template_denies_spawn_even_with_approval_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().to_str().unwrap();
+        let runtime = AgentTeamRuntime::new(dir.path().join("audit"));
+        let (template, owner) = fixture();
+        runtime
+            .stage_solution_template(workspace, template.clone(), owner)
+            .await
+            .unwrap();
+        let observed = runtime
+            .get_template_for_workspace(workspace, &template.template_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let state = crate::test_support::test_state().await;
+        let policy = serde_json::from_value(serde_json::json!({
+            "enabled": true, "require_justification": false
+        }))
+        .unwrap();
+        runtime
+            .set_for_test(
+                Some(state.workspace_index.snapshot().await.root),
+                Some(policy),
+                vec![observed],
+            )
+            .await;
+        let request = tandem_orchestrator::SpawnRequest {
+            mission_id: Some("staging-test".into()),
+            parent_instance_id: None,
+            source: tandem_orchestrator::SpawnSource::UiAction,
+            parent_role: None,
+            role: tandem_orchestrator::AgentRole::Worker,
+            template_id: Some(template.template_id),
+            justification: "approved request".into(),
+            budget_override: None,
+        };
+        for override_approval in [false, true] {
+            let result = runtime
+                .spawn_with_approval_override(&state, request.clone(), override_approval)
+                .await;
+            assert!(!result.decision.allowed);
+            assert_eq!(
+                result.decision.code,
+                Some(tandem_orchestrator::SpawnDenyCode::SpawnTemplateDisabled)
+            );
+            assert!(result.instance.is_none());
+        }
+        assert!(runtime.list_spawn_approvals().await.is_empty());
+        assert!(runtime.list_instances(None, None, None).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_native_writers_reconcile_one_complete_resource() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().to_str().unwrap();
+        let first = AgentTeamRuntime::new(dir.path().join("first-audit"));
+        let second = AgentTeamRuntime::new(dir.path().join("second-audit"));
+        let (template, owner) = fixture();
+        let (a, b) = tokio::join!(
+            first.stage_solution_template(workspace, template.clone(), owner.clone()),
+            second.stage_solution_template(workspace, template, owner)
+        );
+        assert_eq!(a.unwrap(), b.unwrap());
+        let files = std::fs::read_dir(dir.path().join(".tandem/agent-team/templates"))
+            .unwrap()
+            .count();
+        assert_eq!(files, 1);
+    }
+
+    #[tokio::test]
+    async fn native_stage_preserves_manual_file_and_rejects_artifact_ownership() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().to_str().unwrap();
+        let runtime = AgentTeamRuntime::new(dir.path().join("audit"));
+        let (mut template, owner) = fixture();
+        template.solution_owner = Some(owner.clone());
+        assert!(runtime
+            .stage_solution_template(workspace, template.clone(), owner.clone())
+            .await
+            .is_err());
+        assert!(!dir.path().join(".tandem").exists());
+        template.solution_owner = None;
+        let path = dir
+            .path()
+            .join(".tandem/agent-team/templates/solution-test-central-brain.yaml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let manual = canonical_json(&template).unwrap();
+        std::fs::write(&path, &manual).unwrap();
+        assert!(runtime
+            .stage_solution_template(workspace, template, owner)
+            .await
+            .is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), manual);
+    }
+}

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -1460,6 +1460,23 @@ impl AgentTeamRuntime {
                 .and_then(|id| templates.get(id).cloned())
         };
 
+        // A reserved solution ID may have been durably published by another
+        // process (or not yet inserted into this cache). Never substitute the
+        // generic default agent for a missing managed resource.
+        if template.is_none() && req.template_id.as_deref().is_some_and(|id| {
+            Self::template_filename(id).to_ascii_lowercase().starts_with("solution-")
+        }) {
+            return SpawnResult {
+                decision: SpawnDecision {
+                    allowed: false,
+                    code: Some(SpawnDenyCode::SpawnTemplateDisabled),
+                    reason: Some("solution template is unavailable or not active".to_string()),
+                    requires_user_approval: false,
+                },
+                instance: None,
+            };
+        }
+
         if req.parent_role.is_none() {
             if let Some(parent_id) = req.parent_instance_id.as_deref() {
                 let instances = self.instances.read().await;

--- a/crates/tandem-server/src/agent_teams_parts/part01.rs
+++ b/crates/tandem-server/src/agent_teams_parts/part01.rs
@@ -23,6 +23,7 @@ use crate::AppState;
 pub struct AgentTeamRuntime {
     policy: Arc<RwLock<Option<SpawnPolicy>>>,
     templates: Arc<RwLock<HashMap<String, AgentTemplate>>>,
+    template_persistence: Arc<tokio::sync::Mutex<()>>,
     instances: Arc<RwLock<HashMap<String, AgentInstance>>>,
     budgets: Arc<RwLock<HashMap<String, InstanceBudgetState>>>,
     mission_budgets: Arc<RwLock<HashMap<String, MissionBudgetState>>>,
@@ -1091,6 +1092,7 @@ impl AgentTeamRuntime {
         Self {
             policy: Arc::new(RwLock::new(None)),
             templates: Arc::new(RwLock::new(HashMap::new())),
+            template_persistence: Arc::new(tokio::sync::Mutex::new(())),
             instances: Arc::new(RwLock::new(HashMap::new())),
             budgets: Arc::new(RwLock::new(HashMap::new())),
             mission_budgets: Arc::new(RwLock::new(HashMap::new())),
@@ -1154,7 +1156,18 @@ impl AgentTeamRuntime {
         workspace_root: &str,
         template: AgentTemplate,
     ) -> anyhow::Result<AgentTemplate> {
+        let _operation = self.template_persistence.lock().await;
+        anyhow::ensure!(
+            !Self::template_filename(&template.template_id).to_ascii_lowercase().starts_with("solution-")
+                && template.solution_owner.is_none(),
+            "solution templates require the installation lifecycle"
+        );
         self.ensure_loaded_for_workspace(workspace_root).await?;
+        anyhow::ensure!(
+            self.templates.read().await.get(&template.template_id)
+                .is_none_or(|existing| existing.solution_owner.is_none()),
+            "solution templates require the installation lifecycle"
+        );
         let templates_dir = self.templates_dir_for_loaded_workspace().await?;
         fs::create_dir_all(&templates_dir).await?;
         let path = templates_dir.join(Self::template_filename(&template.template_id));
@@ -1172,7 +1185,17 @@ impl AgentTeamRuntime {
         workspace_root: &str,
         template_id: &str,
     ) -> anyhow::Result<bool> {
+        let _operation = self.template_persistence.lock().await;
+        anyhow::ensure!(
+            !Self::template_filename(template_id).to_ascii_lowercase().starts_with("solution-"),
+            "solution templates require the installation lifecycle"
+        );
         self.ensure_loaded_for_workspace(workspace_root).await?;
+        anyhow::ensure!(
+            self.templates.read().await.get(template_id)
+                .is_none_or(|existing| existing.solution_owner.is_none()),
+            "solution templates require the installation lifecycle"
+        );
         let templates_dir = self.templates_dir_for_loaded_workspace().await?;
         let path = templates_dir.join(Self::template_filename(template_id));
         let existed = self.templates.write().await.remove(template_id).is_some();
@@ -1422,7 +1445,7 @@ impl AgentTeamRuntime {
                 .read()
                 .await
                 .values()
-                .find(|t| t.role == req.role)
+                .find(|t| t.enabled && t.role == req.role)
                 .cloned()
             {
                 req.template_id = Some(found.template_id.clone());
@@ -1498,6 +1521,8 @@ impl AgentTeamRuntime {
         }
 
         let template = template.unwrap_or_else(|| AgentTemplate {
+            enabled: true,
+            solution_owner: None,
             template_id: "default-template".to_string(),
             display_name: None,
             avatar_url: None,

--- a/crates/tandem-server/src/app/state/tests/automations_parts/part02.rs
+++ b/crates/tandem-server/src/app/state/tests/automations_parts/part02.rs
@@ -508,6 +508,8 @@ async fn automation_agent_templates_fall_back_to_global_workspace_library() {
         .upsert_template(
             &global_workspace_root,
             tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "shared-copywriter".to_string(),
                 display_name: Some("Shared Copywriter".to_string()),
                 avatar_url: None,
@@ -579,6 +581,8 @@ async fn automation_agent_model_falls_back_to_effective_config_default() {
         approval_policy: None,
     };
     let template = tandem_orchestrator::AgentTemplate {
+        enabled: true,
+        solution_owner: None,
         template_id: "shared-copywriter".to_string(),
         display_name: Some("Shared Copywriter".to_string()),
         avatar_url: None,

--- a/crates/tandem-server/src/http/tests/agent_teams.rs
+++ b/crates/tandem-server/src/http/tests/agent_teams.rs
@@ -64,6 +64,8 @@ async fn agent_team_spawn_approved_with_policy_and_template() {
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,
@@ -151,6 +153,8 @@ async fn agent_team_spawn_uses_managed_worktree_and_cancel_cleans_it_up() {
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,
@@ -276,6 +280,8 @@ async fn agent_team_spawn_agent_tool_uses_same_policy_gate() {
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,
@@ -383,6 +389,8 @@ async fn agent_team_cancel_instance_endpoint_updates_status() {
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,
@@ -484,6 +492,8 @@ async fn agent_team_capability_policy_denies_network_tool_by_default() {
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,
@@ -604,6 +614,8 @@ async fn agent_team_provider_usage_event_updates_token_usage() {
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,
@@ -733,6 +745,8 @@ async fn agent_team_request_only_spawn_surfaces_in_approvals_endpoint() {
             }),
             vec![
                 tandem_orchestrator::AgentTemplate {
+                    enabled: true,
+                    solution_owner: None,
                     template_id: "worker-default".to_string(),
                     display_name: None,
                     avatar_url: None,
@@ -744,6 +758,8 @@ async fn agent_team_request_only_spawn_surfaces_in_approvals_endpoint() {
                     capabilities: tandem_orchestrator::CapabilitySpec::default(),
                 },
                 tandem_orchestrator::AgentTemplate {
+                    enabled: true,
+                    solution_owner: None,
                     template_id: "tester-default".to_string(),
                     display_name: None,
                     avatar_url: None,
@@ -878,6 +894,8 @@ async fn agent_team_missions_endpoint_returns_rollup_counts() {
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,

--- a/crates/tandem-server/src/http/tests/missions.rs
+++ b/crates/tandem-server/src/http/tests/missions.rs
@@ -288,6 +288,8 @@ async fn agent_standup_compose_builds_workflow_automation_from_templates() {
         .upsert_template(
             &workspace_root,
             tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "frontend-ui".to_string(),
                 display_name: Some("Alice (Frontend UI)".to_string()),
                 avatar_url: None,
@@ -489,6 +491,8 @@ async fn agent_standup_compose_uses_global_saved_agents_across_workspaces() {
         .upsert_template(
             &default_workspace_root,
             tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "shared-copywriter".to_string(),
                 display_name: Some("Shared Copywriter".to_string()),
                 avatar_url: None,
@@ -580,6 +584,8 @@ async fn mission_started_triggers_orchestrator_runtime_spawn_for_assigned_agent(
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,
@@ -726,6 +732,8 @@ async fn mission_total_budget_exhaustion_blocks_followup_spawn() {
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,
@@ -848,6 +856,8 @@ async fn mission_canceled_triggers_orchestrator_runtime_instance_cancellation() 
                 skill_sources: Default::default(),
             }),
             vec![tandem_orchestrator::AgentTemplate {
+                enabled: true,
+                solution_owner: None,
                 template_id: "worker-default".to_string(),
                 display_name: None,
                 avatar_url: None,

--- a/docs/SOLUTION_AGENT_STAGING.md
+++ b/docs/SOLUTION_AGENT_STAGING.md
@@ -22,8 +22,9 @@ process-restart tests.
 
 Old template documents default to enabled. Disabled templates cannot pass spawn
 policy, including the approval override path, and are excluded from automatic
-role selection. Generic template upsert/delete cannot mutate managed templates
-or the reserved `solution-` ID namespace. Existing manually created IDs in that
+role selection. Spawn never substitutes a default agent for an uncached solution
+template. Generic upsert/delete reject managed templates and the reserved
+`solution-` ID filename namespace. Existing manually created IDs in that
 namespace therefore require an operator-reviewed migration before editing;
 the adapter does not take them over. Installed IDs must also be portable under
 the existing template filename mapping (ASCII letters, digits, hyphen, underscore).

--- a/docs/SOLUTION_AGENT_STAGING.md
+++ b/docs/SOLUTION_AGENT_STAGING.md
@@ -1,0 +1,35 @@
+# Native solution agent staging
+
+`AgentTeamRuntime::stage_solution_template` writes an actual disabled
+`AgentTemplate` into the existing workspace template directory. It forces
+`enabled: false` and binds organization, workspace, deployment, installation,
+component and reviewed composition in `solution_owner`. It returns a canonical
+fingerprint of the observed resource for the existing installation journal.
+
+The caller must authorize the selected installation, reload its current journal,
+verify the current signed artifact and host-owned bindings, and claim the
+component before this effect. Metadata and a composition hash are not grants.
+This native adapter does not yet supply that HTTP/service orchestration.
+
+Publication writes and syncs a complete temporary file, then uses an atomic
+non-replacing hard link in the same directory. A crash leaves an ignored
+temporary file or a complete disabled template. Retry compares the exact typed
+content and ownership on disk before reporting the same receipt. Conflicting
+manual content or another installation is never overwritten. Filesystems that
+do not support hard links fail closed. Unix also syncs the containing directory;
+Windows power-loss durability of the directory entry is not established by the
+process-restart tests.
+
+Old template documents default to enabled. Disabled templates cannot pass spawn
+policy, including the approval override path, and are excluded from automatic
+role selection. Generic template upsert/delete cannot mutate managed templates
+or the reserved `solution-` ID namespace. Existing manually created IDs in that
+namespace therefore require an operator-reviewed migration before editing;
+the adapter does not take them over. Installed IDs must also be portable under
+the existing template filename mapping (ASCII letters, digits, hyphen, underscore).
+
+Only reusable pack content belongs in template files. Customer records, private
+notes and credentials stay in their governed stores. This does not implement
+routine staging, live host binding resolution, installation authorization,
+activation, upgrade, rollback, shared resource deletion, UI/CLI or clean-host
+recovery. Staged resources are not a ready Company Brain product.


### PR DESCRIPTION
Native AgentTemplates could not represent a disabled staged resource, and generic mutations could overwrite an installation. Add explicit enabled state (legacy documents default to enabled), installation ownership and a native staging adapter using the existing template directory. Publish complete synced content without replacing an existing file; retries compare ownership and canonical content before returning a journal-compatible resource fingerprint. Interrupted staging remains disabled across restart.

Spawn policy rejects disabled templates before approval handling, including the runtime approval override path. Automatic role selection excludes disabled templates. Generic upsert/delete reject managed resources and the reserved solution ID filename namespace, including whitespace and case aliases.

Four native integration tests cover actual file publication/restart/reconciliation, conflicting owners/content, manual-file preservation, parallel writers, generic mutation aliases and runtime spawn with approval override. A core regression preserves legacy enabled semantics and rejects approval requests for disabled templates. Focused CI is configured; Rustfmt and diff checks passed locally. Actual focused Rust execution and the full workspace suite passed on this candidate; release and container checks also passed.

Stacks on #1940. This is the native agent resource adapter, not the completed installation service. Callers must authorize and revalidate the current journal, signed artifacts and host-owned bindings. Routine staging, HTTP/UI/CLI integration, activation, upgrade/rollback, clean-host recovery and product acceptance remain. Reusable template files must not contain private customer data. Hard-link publication requires filesystem support; Unix directory sync is included, Windows power-loss directory durability is not proven. Reserved legacy solution-* IDs require a reviewed migration before generic editing. No automatic merge; do not close TAN-834.

Current signed candidate: 54e3b41bec44a3926edb37710743175d4efc1294. Review added a fail-closed runtime check for uncached managed template IDs: never substitute the generic default agent during publication/cache lag. The runtime regression now covers cached and uncached templates with and without approval override. Exact-head Solution Contract34007708140/job101417883308 passed: four native tests, the core approval regression, six customer tests, seven journal tests, populated protected transfer and PostgreSQL clippy. Enforcement Model Drift also passed. Full Engine CI34007708138 passed (5,139 workspace tests, seven skipped). Security34007708157 passed release101417899680, container101421921464 and aggregate101422170789. Ready for review at this exact head; no merge.