### PR TITLE
TAN-834: stage tenant-owned routines behind execution barriers

### DIFF
--- a/.github/workflows/solution-contract.yml
+++ b/.github/workflows/solution-contract.yml
@@ -84,6 +84,8 @@ jobs:
         run: cargo test -p tandem-server --locked --features storage-postgres solution_installation_ --lib -- --test-threads=1
       - name: Verify native disabled agent staging and reconciliation
         run: cargo test -p tandem-server --locked --features storage-postgres agent_teams::solution_templates --lib
+      - name: Verify native routine staging and execution barriers
+        run: cargo test -p tandem-server --locked --features storage-postgres solution_routines::tests --lib
       - name: Verify disabled template cannot request spawn approval
         run: cargo test -p tandem-orchestrator --locked disabled_template_cannot --lib
       - name: Lint the PostgreSQL and SQLite store adapter

--- a/crates/tandem-server/src/app/state/app_state_impl_parts/part17.rs
+++ b/crates/tandem-server/src/app/state/app_state_impl_parts/part17.rs
@@ -141,8 +141,18 @@ impl AppState {
             let _ = fs::copy(&self.routines_path, &backup_path).await;
         }
         let tmp_path = config::paths::sibling_tmp_path(&self.routines_path);
-        fs::write(&tmp_path, payload).await?;
+        {
+            use tokio::io::AsyncWriteExt;
+            let mut file = fs::File::create(&tmp_path).await?;
+            file.write_all(payload.as_bytes()).await?;
+            file.sync_all().await?;
+        }
         fs::rename(&tmp_path, &self.routines_path).await?;
+        #[cfg(unix)]
+        if let Some(parent) = self.routines_path.parent() {
+            let parent = parent.to_path_buf();
+            tokio::task::spawn_blocking(move || std::fs::File::open(parent)?.sync_all()).await??;
+        }
         Ok(())
     }
 
@@ -173,10 +183,14 @@ impl AppState {
         &self,
         routine: RoutineSpec,
     ) -> Result<RoutineSpec, RoutineStoreError> {
+        solution_routines::require_unmanaged(&routine)?;
         let routine = normalize_routine(routine)?;
         let identity = RoutineIdentity::new(&routine.routine_id, &routine.tenant_context);
         let storage_key = identity.storage_key();
         let _operation = self.routine_persistence.lock().await;
+        if let Some(existing) = self.routines.read().await.get(&storage_key) {
+            solution_routines::require_unmanaged(existing)?;
+        }
         let previous = self
             .routines
             .write()
@@ -211,8 +225,10 @@ impl AppState {
         let Some(previous) = self.routines.read().await.get(&storage_key).cloned() else {
             return Ok(None);
         };
+        solution_routines::require_unmanaged(&previous)?;
         let mut routine = previous.clone();
         update(&mut routine);
+        solution_routines::require_unmanaged(&routine)?;
         routine.routine_id = previous.routine_id.clone();
         routine.tenant_context = previous.tenant_context.clone();
         let routine = normalize_routine(routine)?;
@@ -310,6 +326,9 @@ impl AppState {
         let identity = RoutineIdentity::new(routine_id, tenant_context);
         let storage_key = identity.storage_key();
         let _operation = self.routine_persistence.lock().await;
+        if let Some(existing) = self.routines.read().await.get(&storage_key) {
+            solution_routines::require_unmanaged(existing)?;
+        }
         let removed = self.routines.write().await.remove(&storage_key);
         let allow_empty_overwrite = self.routines.read().await.is_empty();
         if let Err(error) = self.persist_routines_inner(allow_empty_overwrite).await {
@@ -328,7 +347,7 @@ impl AppState {
         let mut plans = Vec::new();
         let mut guard = self.routines.write().await;
         for routine in guard.values_mut() {
-            if routine.status != RoutineStatus::Active {
+            if routine.status != RoutineStatus::Active || routine.installation_disabled() {
                 continue;
             }
             let Some(next_fire_at_ms) = routine.next_fire_at_ms else {
@@ -449,6 +468,11 @@ impl AppState {
         status: RoutineRunStatus,
         detail: Option<String>,
     ) -> RoutineRunRecord {
+        let status = if routine.installation_disabled() {
+            RoutineRunStatus::BlockedPolicy
+        } else {
+            status
+        };
         let now = now_ms();
         let record = RoutineRunRecord {
             run_id: format!("routine-run-{}", uuid::Uuid::new_v4()),
@@ -552,7 +576,21 @@ impl AppState {
     }
 
     pub async fn claim_next_queued_routine_run(&self) -> Option<RoutineRunRecord> {
+        let routines = self.routines.read().await.clone();
         let mut guard = self.routine_runs.write().await;
+        let mut blocked = false;
+        for row in guard.values_mut().filter(|row| row.status == RoutineRunStatus::Queued) {
+            let identity = RoutineIdentity::new(&row.routine_id, &row.tenant_context);
+            let routine = routines.get(&identity.storage_key());
+            if routine.is_some_and(RoutineSpec::installation_disabled)
+                || (crate::routines::types::solution_routine_id(&row.routine_id) && routine.is_none())
+            {
+                row.status = RoutineRunStatus::BlockedPolicy;
+                row.updated_at_ms = now_ms();
+                row.detail = Some("solution routine requires installation activation".to_string());
+                blocked = true;
+            }
+        }
         let next_run_id = guard
             .values()
             .filter(|row| row.status == RoutineRunStatus::Queued)
@@ -561,7 +599,14 @@ impl AppState {
                     .cmp(&b.created_at_ms)
                     .then_with(|| a.run_id.cmp(&b.run_id))
             })
-            .map(|row| row.run_id.clone())?;
+            .map(|row| row.run_id.clone());
+        let Some(next_run_id) = next_run_id else {
+            drop(guard);
+            if blocked {
+                let _ = self.persist_routine_runs().await;
+            }
+            return None;
+        };
         let now = now_ms();
         let row = guard.get_mut(&next_run_id)?;
         row.status = RoutineRunStatus::Running;

--- a/crates/tandem-server/src/app/state/mod.rs
+++ b/crates/tandem-server/src/app/state/mod.rs
@@ -122,6 +122,8 @@ mod prompt_context_blocks;
 mod prompt_context_hook;
 mod prompt_memory_context;
 mod slack_event_runtime;
+mod solution_routines;
+pub use solution_routines::solution_routine_from_artifact;
 mod tool_dispatch_outbox;
 
 pub(crate) use automation_v2_orchestration_goals::StartGoalRequest;
@@ -1286,6 +1288,11 @@ pub fn evaluate_routine_execution_policy(
     routine: &RoutineSpec,
     trigger_type: &str,
 ) -> RoutineExecutionDecision {
+    if routine.installation_disabled() {
+        return RoutineExecutionDecision::Blocked {
+            reason: "solution routine requires installation activation".to_string(),
+        };
+    }
     if !routine_uses_external_integrations(routine) {
         return RoutineExecutionDecision::Allowed;
     }

--- a/crates/tandem-server/src/app/state/solution_routines.rs
+++ b/crates/tandem-server/src/app/state/solution_routines.rs
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Frumu LTD
+// Licensed under the Business Source License 1.1
+
+//! Native routine staging for an already authorized installation. Ownership
+//! metadata is not authority: callers must revalidate the journal, current
+//! policy, signed artifact and host bindings before materializing this resource.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use tandem_solutions::{canonical_json, sha256, MAX_ARTIFACT_BYTES};
+
+use super::{normalize_routine, routine_store_index, AppState};
+use crate::routines::errors::RoutineStoreError;
+use crate::routines::types::{
+    solution_routine_id, RoutineIdentity, RoutineMisfirePolicy, RoutineSchedule, RoutineSpec,
+    RoutineStatus, SolutionRoutineOwner,
+};
+use tandem_types::TenantContext;
+
+fn managed(message: impl ToString) -> RoutineStoreError {
+    RoutineStoreError::ManagedResource {
+        message: message.to_string(),
+    }
+}
+
+pub(super) fn require_unmanaged(routine: &RoutineSpec) -> Result<(), RoutineStoreError> {
+    if solution_routine_id(&routine.routine_id) || routine.solution_owner.is_some() {
+        return Err(managed(
+            "solution routines require the installation lifecycle",
+        ));
+    }
+    Ok(())
+}
+
+fn bytes(value: &impl serde::Serialize) -> Result<Vec<u8>, RoutineStoreError> {
+    canonical_json(value).map_err(managed)
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RoutineArtifact {
+    name: String,
+    status: RoutineStatus,
+    schedule: RoutineSchedule,
+    timezone: String,
+    misfire_policy: String,
+    entrypoint: String,
+    args: serde_json::Value,
+    allowed_tools: Vec<String>,
+    output_targets: Vec<String>,
+    requires_approval: bool,
+    external_integrations_allowed: bool,
+}
+
+/// Decode the current text solution's reusable routine artifact. It supplies
+/// neither tenant/creator IDs nor installation ownership. Artifact verification
+/// remains the caller's responsibility (use the signed PackManager snapshot).
+pub fn solution_routine_from_artifact(
+    artifact: &[u8],
+    resource_id: &str,
+    tenant: &TenantContext,
+) -> Result<RoutineSpec, RoutineStoreError> {
+    if artifact.len() > MAX_ARTIFACT_BYTES {
+        return Err(managed("routine artifact is too large"));
+    }
+    let input: RoutineArtifact = serde_json::from_slice(artifact).map_err(managed)?;
+    if input.status != RoutineStatus::Paused || input.misfire_policy != "skip" {
+        return Err(managed(
+            "text solution routine requires paused status and skip misfire policy",
+        ));
+    }
+    Ok(RoutineSpec {
+        solution_owner: None,
+        routine_id: resource_id.to_string(),
+        tenant_context: tenant.clone(),
+        name: input.name,
+        status: RoutineStatus::Paused,
+        schedule: input.schedule,
+        timezone: input.timezone,
+        misfire_policy: RoutineMisfirePolicy::Skip,
+        entrypoint: input.entrypoint,
+        args: input.args,
+        allowed_tools: input.allowed_tools,
+        output_targets: input.output_targets,
+        creator_type: "solution".into(),
+        creator_id: String::new(),
+        requires_approval: input.requires_approval,
+        external_integrations_allowed: input.external_integrations_allowed,
+        next_fire_at_ms: None,
+        last_fired_at_ms: None,
+    })
+}
+
+impl AppState {
+    /// Stage an actual tenant-scoped native routine, returning its observed
+    /// fingerprint for the installation journal. This never activates it.
+    pub async fn stage_solution_routine(
+        &self,
+        mut routine: RoutineSpec,
+        mut owner: SolutionRoutineOwner,
+    ) -> Result<String, RoutineStoreError> {
+        if !routine.routine_id.starts_with("solution-")
+            || routine.routine_id.trim() != routine.routine_id
+            || routine.routine_id.len() > 256
+            || routine.routine_id.chars().any(char::is_control)
+            || routine.solution_owner.is_some()
+        {
+            return Err(managed(
+                "routine artifact requires an unowned stable solution ID",
+            ));
+        }
+        for reference in [
+            &owner.instance_id,
+            &owner.component_id,
+            &routine.tenant_context.org_id,
+            &routine.tenant_context.workspace_id,
+        ] {
+            if reference.is_empty()
+                || reference.len() > 256
+                || reference.trim() != reference
+                || reference.chars().any(char::is_control)
+            {
+                return Err(managed("solution routine requires complete ownership"));
+            }
+        }
+        if routine
+            .tenant_context
+            .deployment_id
+            .as_deref()
+            .is_none_or(str::is_empty)
+            || owner.composition_sha256.len() != 64
+            || !owner
+                .composition_sha256
+                .bytes()
+                .all(|b| b.is_ascii_hexdigit())
+        {
+            return Err(managed(
+                "solution routine requires deployment and reviewed composition",
+            ));
+        }
+        owner.enabled = false;
+        routine.creator_type = "solution".into();
+        routine.creator_id = owner.instance_id.clone();
+        routine.solution_owner = Some(owner);
+        routine.status = RoutineStatus::Paused;
+        routine.last_fired_at_ms = None;
+        routine = normalize_routine(routine)?;
+        // Activation computes a schedule from the activation time. Staging
+        // receipts must not change simply because a retry happens later.
+        routine.next_fire_at_ms = None;
+        let payload = bytes(&routine)?;
+        if payload.len() > MAX_ARTIFACT_BYTES {
+            return Err(managed("solution routine is too large"));
+        }
+        let fingerprint = sha256(&payload);
+        let identity = RoutineIdentity::new(&routine.routine_id, &routine.tenant_context);
+        let key = identity.storage_key();
+        let _operation = self.routine_persistence.lock().await;
+        // The existing native routine store has one AppState writer per host.
+        // Detect external edits or stale recovery snapshots instead of silently
+        // replacing them with this process's cached map.
+        let persisted = match tokio::fs::read(&self.routines_path).await {
+            Ok(raw) => {
+                let rows: HashMap<String, RoutineSpec> =
+                    serde_json::from_slice(&raw).map_err(managed)?;
+                let count = rows.len();
+                let indexed = routine_store_index(rows);
+                if indexed.len() != count {
+                    return Err(managed(
+                        "routine store has duplicate identities; reconcile before staging",
+                    ));
+                }
+                indexed
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(error) => return Err(managed(error)),
+        };
+        let cached = self.routines.read().await.clone();
+        if bytes(&persisted)? != bytes(&cached)? {
+            return Err(managed(
+                "routine store changed outside this writer; reload and reconcile",
+            ));
+        }
+        if let Some(existing) = cached.get(&key) {
+            if bytes(existing)? != payload {
+                return Err(managed("solution routine ownership or content conflict"));
+            }
+            return Ok(fingerprint);
+        }
+        self.routines.write().await.insert(key.clone(), routine);
+        if let Err(error) = self.persist_routines_inner(false).await {
+            self.routines.write().await.remove(&key);
+            return Err(RoutineStoreError::PersistFailed {
+                message: error.to_string(),
+            });
+        }
+        Ok(fingerprint)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tandem-server/src/app/state/solution_routines/tests.rs
+++ b/crates/tandem-server/src/app/state/solution_routines/tests.rs
@@ -1,0 +1,233 @@
+use super::*;
+use crate::app::state::{evaluate_routine_execution_policy, RoutineExecutionDecision};
+use crate::routines::types::RoutineRunStatus;
+
+fn fixture(org: &str) -> (RoutineSpec, SolutionRoutineOwner) {
+    let mut tenant = TenantContext::local_implicit();
+    tenant.org_id = org.into();
+    tenant.workspace_id = "workspace".into();
+    tenant.deployment_id = Some(format!("deployment-{org}"));
+    let artifact = include_bytes!(
+        "../../../../../tandem-solutions/fixtures/company-brain-text/routines/review-notes.json"
+    );
+    let routine =
+        solution_routine_from_artifact(artifact, "solution-test-review-notes", &tenant).unwrap();
+    let owner = SolutionRoutineOwner {
+        instance_id: "brain".into(),
+        component_id: "review-notes".into(),
+        composition_sha256: "a".repeat(64),
+        enabled: true,
+    };
+    (routine, owner)
+}
+
+fn state(directory: &std::path::Path) -> AppState {
+    let mut state = AppState::new_starting("staged-routine-test".into(), true);
+    state.routines_path = directory.join("routines.json");
+    state.routine_runs_path = directory.join("runs.json");
+    state
+}
+
+#[tokio::test]
+async fn solution_routine_staging_is_scoped_durable_and_idempotent() {
+    let directory = tempfile::tempdir().unwrap();
+    let original = state(directory.path());
+    let (a, owner) = fixture("org-a");
+    let (mut b, _) = fixture("org-b");
+    b.name = "Another customer's review".into();
+    let (first, second) = tokio::join!(
+        original.stage_solution_routine(a.clone(), owner.clone()),
+        original.stage_solution_routine(b.clone(), owner.clone())
+    );
+    let (first, second) = (first.unwrap(), second.unwrap());
+    assert_ne!(first, second);
+    let restarted = state(directory.path());
+    restarted.load_routines().await.unwrap();
+    assert_eq!(
+        restarted
+            .stage_solution_routine(a.clone(), owner.clone())
+            .await
+            .unwrap(),
+        first
+    );
+    assert_eq!(
+        restarted
+            .stage_solution_routine(b.clone(), owner)
+            .await
+            .unwrap(),
+        second
+    );
+    let observed = restarted
+        .get_routine_for_tenant(&a.routine_id, &a.tenant_context)
+        .await
+        .unwrap();
+    assert_eq!(observed.status, RoutineStatus::Paused);
+    assert!(observed.installation_disabled());
+    assert!(observed.next_fire_at_ms.is_none());
+    assert_eq!(sha256(&bytes(&observed).unwrap()), first);
+    assert!(restarted
+        .evaluate_routine_misfires(u64::MAX)
+        .await
+        .is_empty());
+    assert_eq!(
+        restarted
+            .list_routines_for_tenant(&a.tenant_context)
+            .await
+            .len(),
+        1
+    );
+    assert_eq!(
+        restarted
+            .list_routines_for_tenant(&b.tenant_context)
+            .await
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn solution_routine_rejects_conflicts_and_generic_activation() {
+    let directory = tempfile::tempdir().unwrap();
+    let state = state(directory.path());
+    let (routine, owner) = fixture("org-a");
+    let receipt = state
+        .stage_solution_routine(routine.clone(), owner.clone())
+        .await
+        .unwrap();
+    let mut changed = routine.clone();
+    changed.name = "changed".into();
+    assert!(state
+        .stage_solution_routine(changed, owner.clone())
+        .await
+        .is_err());
+    let mut other_owner = owner;
+    other_owner.instance_id = "another-installation".into();
+    assert!(state
+        .stage_solution_routine(routine.clone(), other_owner)
+        .await
+        .is_err());
+    assert!(state.put_routine(routine.clone()).await.is_err());
+    assert!(state
+        .update_routine_for_tenant(&routine.routine_id, &routine.tenant_context, |row| {
+            row.status = RoutineStatus::Active;
+            row.solution_owner = None;
+        })
+        .await
+        .is_err());
+    assert!(state
+        .delete_routine_for_tenant(&routine.routine_id, &routine.tenant_context)
+        .await
+        .is_err());
+    let observed = state
+        .get_routine_for_tenant(&routine.routine_id, &routine.tenant_context)
+        .await
+        .unwrap();
+    assert_eq!(sha256(&bytes(&observed).unwrap()), receipt);
+}
+
+#[tokio::test]
+async fn solution_routine_blocks_manual_approval_replay_and_missing_resource_queue() {
+    let directory = tempfile::tempdir().unwrap();
+    let state = state(directory.path());
+    let (routine, owner) = fixture("org-a");
+    state
+        .stage_solution_routine(routine.clone(), owner)
+        .await
+        .unwrap();
+    let observed = state
+        .get_routine_for_tenant(&routine.routine_id, &routine.tenant_context)
+        .await
+        .unwrap();
+    for trigger in ["manual", "scheduled", "approval"] {
+        assert!(matches!(
+            evaluate_routine_execution_policy(&observed, trigger),
+            RoutineExecutionDecision::Blocked { .. }
+        ));
+    }
+    let run = state
+        .create_routine_run(&observed, "manual", 1, RoutineRunStatus::Queued, None)
+        .await;
+    assert_eq!(run.status, RoutineRunStatus::BlockedPolicy);
+    // An old approval or restored run may put this back in the queue. The final
+    // claimant independently checks the actual current native resource.
+    for missing in [false, true] {
+        if missing {
+            state.routines.write().await.clear();
+        }
+        state
+            .update_routine_run_status(&run.run_id, RoutineRunStatus::Queued, None)
+            .await
+            .unwrap();
+        assert!(state.claim_next_queued_routine_run().await.is_none());
+        assert_eq!(
+            state.get_routine_run(&run.run_id).await.unwrap().status,
+            RoutineRunStatus::BlockedPolicy
+        );
+    }
+    let mut ordinary = routine;
+    ordinary.routine_id = "ordinary-paused".into();
+    assert_eq!(
+        evaluate_routine_execution_policy(&ordinary, "manual"),
+        RoutineExecutionDecision::Allowed
+    );
+    let regular = state
+        .create_routine_run(&ordinary, "manual", 1, RoutineRunStatus::Queued, None)
+        .await;
+    assert_eq!(
+        state.claim_next_queued_routine_run().await.unwrap().run_id,
+        regular.run_id
+    );
+}
+
+#[tokio::test]
+async fn solution_routine_detects_disk_drift_without_overwriting_manual_state() {
+    let directory = tempfile::tempdir().unwrap();
+    let state = state(directory.path());
+    let (routine, owner) = fixture("org-a");
+    let identity = RoutineIdentity::new(&routine.routine_id, &routine.tenant_context);
+    let manual = bytes(&HashMap::from([(identity.storage_key(), routine.clone())])).unwrap();
+    tokio::fs::write(&state.routines_path, &manual)
+        .await
+        .unwrap();
+    assert!(state
+        .stage_solution_routine(routine.clone(), owner.clone())
+        .await
+        .is_err());
+    state.load_routines().await.unwrap();
+    assert!(state.stage_solution_routine(routine, owner).await.is_err());
+    assert_eq!(tokio::fs::read(&state.routines_path).await.unwrap(), manual);
+}
+
+#[tokio::test]
+async fn solution_routine_failed_publication_rolls_back_cache() {
+    let directory = tempfile::tempdir().unwrap();
+    let state = state(directory.path());
+    let temporary = crate::config::paths::sibling_tmp_path(&state.routines_path);
+    tokio::fs::create_dir(&temporary).await.unwrap();
+    let (routine, owner) = fixture("org-a");
+    assert!(state
+        .stage_solution_routine(routine.clone(), owner.clone())
+        .await
+        .is_err());
+    assert!(state.list_routines().await.is_empty());
+    assert!(!state.routines_path.exists());
+    tokio::fs::remove_dir(temporary).await.unwrap();
+    assert!(state.stage_solution_routine(routine, owner).await.is_ok());
+}
+
+#[test]
+fn solution_routine_artifact_cannot_supply_authority() {
+    let (routine, _) = fixture("org-a");
+    assert_eq!(routine.misfire_policy, RoutineMisfirePolicy::Skip);
+    let mut artifact: serde_json::Value = serde_json::from_slice(include_bytes!(
+        "../../../../../tandem-solutions/fixtures/company-brain-text/routines/review-notes.json"
+    ))
+    .unwrap();
+    artifact["tenant_context"] = serde_json::json!({"org_id": "org-b"});
+    assert!(solution_routine_from_artifact(
+        &serde_json::to_vec(&artifact).unwrap(),
+        &routine.routine_id,
+        &routine.tenant_context
+    )
+    .is_err());
+}

--- a/crates/tandem-server/src/app/state/tests/routines.rs
+++ b/crates/tandem-server/src/app/state/tests/routines.rs
@@ -56,6 +56,7 @@ async fn routine_put_persists_and_loads() {
     state.routines_path = routines_path.clone();
 
     let routine = RoutineSpec {
+        solution_owner: None,
         routine_id: "routine-1".to_string(),
         tenant_context: tandem_types::TenantContext::local_implicit(),
         name: "Digest".to_string(),
@@ -94,6 +95,7 @@ async fn persist_routines_does_not_clobber_existing_store_with_empty_state() {
     writer.routines_path = routines_path.clone();
     writer
         .put_routine(RoutineSpec {
+            solution_owner: None,
             routine_id: "automation-guarded".to_string(),
             tenant_context: tandem_types::TenantContext::local_implicit(),
             name: "Guarded Automation".to_string(),
@@ -187,6 +189,7 @@ async fn evaluate_routine_misfires_respects_skip_run_once_and_catch_up() {
     state.routines_path = routines_path.clone();
 
     let base = |id: &str, policy: RoutineMisfirePolicy| RoutineSpec {
+        solution_owner: None,
         routine_id: id.to_string(),
         tenant_context: tandem_types::TenantContext::local_implicit(),
         name: id.to_string(),
@@ -251,6 +254,7 @@ async fn evaluate_routine_misfires_respects_skip_run_once_and_catch_up() {
 #[test]
 fn routine_policy_blocks_external_side_effects_by_default() {
     let routine = RoutineSpec {
+        solution_owner: None,
         routine_id: "routine-policy-1".to_string(),
         tenant_context: tandem_types::TenantContext::local_implicit(),
         name: "Connector routine".to_string(),
@@ -277,6 +281,7 @@ fn routine_policy_blocks_external_side_effects_by_default() {
 #[test]
 fn routine_policy_requires_approval_for_external_side_effects_when_enabled() {
     let routine = RoutineSpec {
+        solution_owner: None,
         routine_id: "routine-policy-2".to_string(),
         tenant_context: tandem_types::TenantContext::local_implicit(),
         name: "Connector routine".to_string(),
@@ -306,6 +311,7 @@ fn routine_policy_requires_approval_for_external_side_effects_when_enabled() {
 #[test]
 fn routine_policy_allows_non_external_entrypoints() {
     let routine = RoutineSpec {
+        solution_owner: None,
         routine_id: "routine-policy-3".to_string(),
         tenant_context: tandem_types::TenantContext::local_implicit(),
         name: "Internal mission routine".to_string(),
@@ -1082,6 +1088,7 @@ async fn routine_session_policy_roundtrip_normalizes_tools() {
 async fn routine_run_preserves_latest_session_id_after_session_clears() {
     let state = AppState::new_starting("routine-latest-session".to_string(), true);
     let routine = RoutineSpec {
+        solution_owner: None,
         routine_id: "routine-session-link".to_string(),
         tenant_context: tandem_types::TenantContext::local_implicit(),
         name: "Routine Session Link".to_string(),
@@ -1138,6 +1145,7 @@ async fn hosted_scheduled_routine_preserves_tenant_in_spec_run_and_session() {
     );
     hosted.deployment_id = Some("deployment-hosted-a".to_string());
     let routine = RoutineSpec {
+        solution_owner: None,
         routine_id: "hosted-scheduled".to_string(),
         tenant_context: hosted.clone(),
         name: "Hosted Scheduled".to_string(),

--- a/crates/tandem-server/src/http/routines_automations_parts/part01.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part01.rs
@@ -880,6 +880,10 @@ struct AutomationV2TaskResetPreview {
 
 pub(super) fn routine_error_response(error: RoutineStoreError) -> (StatusCode, Json<Value>) {
     match error {
+        RoutineStoreError::ManagedResource { message } => (
+            StatusCode::CONFLICT,
+            Json(json!({"error": message, "code": "SOLUTION_ROUTINE_MANAGED"})),
+        ),
         RoutineStoreError::InvalidRoutineId { routine_id } => (
             StatusCode::BAD_REQUEST,
             Json(json!({
@@ -965,6 +969,7 @@ pub(super) async fn routines_create(
         .unwrap_or_else(|| "unknown".to_string());
 
     let routine = RoutineSpec {
+        solution_owner: None,
         routine_id: input
             .routine_id
             .unwrap_or_else(|| Uuid::new_v4().to_string()),

--- a/crates/tandem-server/src/http/routines_automations_parts/part05.rs
+++ b/crates/tandem-server/src/http/routines_automations_parts/part05.rs
@@ -47,6 +47,7 @@ pub(super) fn automation_create_to_routine(
             (Vec::new(), false, true)
         };
     Ok(RoutineSpec {
+        solution_owner: None,
         routine_id: input
             .automation_id
             .unwrap_or_else(|| format!("automation-{}", uuid::Uuid::new_v4().simple())),

--- a/crates/tandem-server/src/pack_builder_parts/part01.rs
+++ b/crates/tandem-server/src/pack_builder_parts/part01.rs
@@ -1136,6 +1136,7 @@ impl PackBuilderTool {
                 .unwrap_or("team");
             let max_agents = input.max_agents.unwrap_or(4);
             let mut routine = RoutineSpec {
+                solution_owner: None,
                 routine_id: routine_id.clone(),
                 tenant_context: routine_tenant_context.clone(),
                 name: plan.routine_template.name.clone(),

--- a/crates/tandem-server/src/routines/errors.rs
+++ b/crates/tandem-server/src/routines/errors.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RoutineStoreError {
+    ManagedResource { message: String },
     InvalidRoutineId { routine_id: String },
     InvalidSchedule { detail: String },
     PersistFailed { message: String },

--- a/crates/tandem-server/src/routines/types.rs
+++ b/crates/tandem-server/src/routines/types.rs
@@ -83,8 +83,21 @@ pub enum RoutineStatus {
     Paused,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SolutionRoutineOwner {
+    pub instance_id: String,
+    pub component_id: String,
+    pub composition_sha256: String,
+    /// Only the installation activation lifecycle may enable this resource.
+    #[serde(default)]
+    pub enabled: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoutineSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub solution_owner: Option<SolutionRoutineOwner>,
     pub routine_id: String,
     #[serde(default, skip_serializing_if = "TenantContext::is_local_implicit")]
     pub tenant_context: TenantContext,
@@ -108,6 +121,19 @@ pub struct RoutineSpec {
     pub next_fire_at_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_fired_at_ms: Option<u64>,
+}
+
+impl RoutineSpec {
+    pub fn installation_disabled(&self) -> bool {
+        self.solution_owner
+            .as_ref()
+            .is_some_and(|owner| !owner.enabled)
+            || (solution_routine_id(&self.routine_id) && self.solution_owner.is_none())
+    }
+}
+
+pub(crate) fn solution_routine_id(id: &str) -> bool {
+    id.trim().to_ascii_lowercase().starts_with("solution-")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/docs/SOLUTION_ROUTINE_STAGING.md
+++ b/docs/SOLUTION_ROUTINE_STAGING.md
@@ -1,0 +1,41 @@
+# Native solution routine staging
+
+`stage_solution_routine` materializes a tenant-scoped `RoutineSpec` using the
+existing routine store. It sets paused status, disabled installation ownership,
+no fire time and no previous execution. The canonical receipt includes native
+content, tenant, installation, component and reviewed composition. Repeating
+staging after reopening the store returns the same receipt only for identical
+ownership and content. Customer routines with the same ID in different tenants
+remain independent.
+
+The caller must authorize the installation and revalidate its current journal,
+signed artifact and host bindings before claiming and performing this effect.
+`solution_routine_from_artifact` maps the current text fixture's reusable input
+into native types, including its string `skip` policy. Tenant, creator and
+ownership fields cannot come from the artifact. The initial artifact adapter
+accepts the text fixture's paused/skip schema; it is not a replacement for the
+native routine API's other scheduling policies.
+
+Paused alone is insufficient: existing routines support manual execution while
+paused. Installation ownership therefore provides a separate disabled state.
+Manual execution policy rejects it, scheduling skips it, run creation records a
+blocked run, and the final queue claimant rechecks the current native resource.
+Old approval/recovery records cannot run a staged or missing managed routine.
+Generic creation/update/delete cannot mutate managed resources or reserved
+`solution-` IDs. Existing ordinary paused routines retain manual-run behavior.
+Legacy manual IDs in the reserved namespace need an operator-reviewed migration.
+
+The adapter reuses the existing host's single AppState writer and persistence
+mutex. It detects disk/cache drift before staging and preserves conflicting
+manual state. The native persistence path now syncs the temporary file before
+rename and syncs the parent directory on Unix. Failed publication rolls back the
+cache; a failure after rename still requires reload/reconciliation. The store
+does not gain support for simultaneous independent engine processes writing the
+same routines file. Windows directory-entry power-loss durability is not proven
+by the process-restart tests.
+
+This is native staging, not activation or full installation acceptance. The
+authorized HTTP/service, live bindings, explicit activation and schedule start,
+upgrade/rollback, UI/CLI and encrypted clean-host recovery remain. No new public
+HTTP mutation route is introduced. Runtime/customer data must stay outside
+reusable pack exports.


### PR DESCRIPTION
Paused routines could still execute manually, so simply importing a paused solution fixture was not safe staging. Add installation ownership with an explicit disabled state, and a native adapter that writes an actual tenant-scoped RoutineSpec through the existing routine store. Canonical receipts include ownership and content; repeated staging after reopening is idempotent, and conflicts or disk/cache drift fail without replacing customer state.

The reusable text artifact cannot supply tenant/creator/ownership fields. Its current paused/skip input maps explicitly to native types. Staging forces disabled ownership, paused status and no fire time. Generic put/update/delete reject managed resources. Manual policy, scheduler selection, run creation and the final queue claimant all enforce the disabled state; stale approvals/restored queued runs cannot execute a staged or missing managed routine. Existing ordinary paused routines retain manual execution.

Native persistence now syncs its temporary file before rename, and the parent directory on Unix. The existing single AppState writer and mutex remain the supported host model; this does not add multi-process routine-file writers or prove Windows directory-entry power-loss durability.

Added six native tests for tenant separation, restart/idempotence, concurrent calls, ownership/content conflicts, mutation/activation guards, manual and queue/approval barriers, missing-resource recovery, disk drift/manual preservation, publication rollback and artifact authority rejection. Local Rustfmt, diff and source checks passed. Exact-head focused Solution Contract34008405173/job101419728426 passed all six new native routine tests, four agent tests, six customer tests, seven journal tests, protected transfer, core approval regression and PostgreSQL clippy. All six current workflows passed. Engine34008405080/workspace101420607660 verified 5,145 passed, seven skipped. Security34008405139 passed release101419728421, container101423711041 and aggregate101423951115. Ready for review at this exact head; no merge.

Stacks on #1942. Current signed candidate: 85638deba9dd37d96680494deebb366501097ba2. Callers still must authorize and revalidate the current installation journal, signed artifacts and host bindings. HTTP/service integration, explicit activation/schedule start, upgrades/rollback, UI/CLI, encrypted clean-host recovery and final Company Brain acceptance remain. Reserved legacy solution-* routine IDs require reviewed migration. Do not merge automatically or mark TAN-834 complete.