### PR TITLE
feat(solutions): authorize preview, configuration and disabled native installation (TAN-834)

### DIFF
--- a/.github/workflows/solution-contract.yml
+++ b/.github/workflows/solution-contract.yml
@@ -46,6 +46,8 @@ jobs:
       # edit must run this check without triggering the full engine matrix.
       - name: Test solution planning contract
         run: cargo test -p tandem-solutions --locked
+      - name: Verify concrete provider installation routing metadata
+        run: cargo test -p tandem-providers --locked installation_metadata --lib
 
       - name: Lint solution contract and fixture
         run: cargo clippy -p tandem-solutions --all-targets --locked -- -D warnings
@@ -86,6 +88,10 @@ jobs:
         run: cargo test -p tandem-server --locked --features storage-postgres agent_teams::solution_templates --lib
       - name: Verify native routine staging and execution barriers
         run: cargo test -p tandem-server --locked --features storage-postgres solution_routines::tests --lib
+      - name: Verify authorized solution service from signed pack through native restart
+        run: cargo test -p tandem-server --locked --features storage-postgres solution_service_ --lib -- --test-threads=1
+      - name: Verify enterprise solution HTTP identity boundary
+        run: cargo test -p tandem-enterprise-server --locked routes_enterprise_solutions --lib
       - name: Verify disabled template cannot request spawn approval
         run: cargo test -p tandem-orchestrator --locked disabled_template_cannot --lib
       - name: Lint the PostgreSQL and SQLite store adapter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8369,6 +8369,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tandem-data-boundary",
  "tandem-types",
  "tempfile",

--- a/crates/tandem-enterprise-server/src/http/mod.rs
+++ b/crates/tandem-enterprise-server/src/http/mod.rs
@@ -6,9 +6,9 @@ mod routes_enterprise_cross_tenant;
 mod routes_enterprise_google_drive;
 mod routes_enterprise_lifecycle;
 mod routes_enterprise_onboarding;
-mod routes_enterprise_solutions;
 mod routes_enterprise_org_units;
 mod routes_enterprise_policies;
+mod routes_enterprise_solutions;
 
 pub fn apply_routes(router: tandem_server::ServerRouter) -> tandem_server::ServerRouter {
     routes_enterprise_policies::apply(routes_enterprise_cross_tenant::apply(

--- a/crates/tandem-enterprise-server/src/http/mod.rs
+++ b/crates/tandem-enterprise-server/src/http/mod.rs
@@ -6,6 +6,7 @@ mod routes_enterprise_cross_tenant;
 mod routes_enterprise_google_drive;
 mod routes_enterprise_lifecycle;
 mod routes_enterprise_onboarding;
+mod routes_enterprise_solutions;
 mod routes_enterprise_org_units;
 mod routes_enterprise_policies;
 

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_onboarding.rs
@@ -28,7 +28,7 @@ const GOOGLE_DRIVE_PROVIDER: &str = "google_drive";
 const GOOGLE_DRIVE_SOURCE_TYPE: &str = "google_drive";
 
 pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
-    router
+    super::routes_enterprise_solutions::apply(router)
         .route("/enterprise/readiness", get(get_enterprise_readiness))
         .route(
             "/enterprise/onboarding-plans/preview",

--- a/crates/tandem-enterprise-server/src/http/routes_enterprise_solutions.rs
+++ b/crates/tandem-enterprise-server/src/http/routes_enterprise_solutions.rs
@@ -1,0 +1,129 @@
+use axum::{
+    extract::{Extension, State},
+    http::StatusCode,
+    routing::post,
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tandem_enterprise_contract::VerifiedTenantContext;
+use tandem_server::{
+    solution_installation::{SolutionConfigurationRequest, SolutionStagingRequest},
+    stateful_runtime::orchestration_store::CustomerConfigVersion,
+    AppState,
+};
+
+use super::routes_enterprise::EnterpriseResult;
+
+pub(super) fn apply(router: Router<AppState>) -> Router<AppState> {
+    router
+        .route(
+            "/enterprise/onboarding-plans/solutions/preview",
+            post(preview),
+        )
+        .route(
+            "/enterprise/onboarding-plans/solutions/configuration",
+            post(save),
+        )
+        .route("/enterprise/onboarding-plans/solutions/stage", post(stage))
+}
+
+fn identity(
+    verified: Option<Extension<VerifiedTenantContext>>,
+) -> Result<VerifiedTenantContext, (StatusCode, Json<Value>)> {
+    verified.map(|Extension(context)| context).ok_or_else(|| {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"code": "VERIFIED_IDENTITY_REQUIRED"})),
+        )
+    })
+}
+
+fn rejected() -> (StatusCode, Json<Value>) {
+    // Do not expose storage paths, source names or cross-tenant lookup errors.
+    (
+        StatusCode::CONFLICT,
+        Json(json!({"code": "SOLUTION_REVIEW_REQUIRED",
+        "message": "Current authorization, host prerequisites, configuration or native state could not be validated. Refresh the installation review."})),
+    )
+}
+
+async fn preview(
+    State(state): State<AppState>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Json(request): Json<SolutionConfigurationRequest>,
+) -> EnterpriseResult<Value> {
+    let verified = identity(verified)?;
+    let result = state
+        .preview_solution_configuration(&verified, &request)
+        .await
+        .map_err(|_| rejected())?;
+    Ok(Json(json!(result)))
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SaveRequest {
+    request: SolutionConfigurationRequest,
+    expected_version: Option<CustomerConfigVersion>,
+}
+
+async fn save(
+    State(state): State<AppState>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Json(request): Json<SaveRequest>,
+) -> EnterpriseResult<Value> {
+    let verified = identity(verified)?;
+    let result = state
+        .save_solution_configuration(&verified, request.request, request.expected_version)
+        .await
+        .map_err(|_| rejected())?;
+    Ok(Json(json!(result)))
+}
+
+async fn stage(
+    State(state): State<AppState>,
+    verified: Option<Extension<VerifiedTenantContext>>,
+    Json(request): Json<SolutionStagingRequest>,
+) -> EnterpriseResult<Value> {
+    let verified = identity(verified)?;
+    let result = state
+        .stage_solution_installation(&verified, request)
+        .await
+        .map_err(|_| rejected())?;
+    Ok(Json(
+        json!({"installation": result, "activation_required": true, "solution_ready": false}),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn solution_preview_requires_verified_identity_before_pack_lookup() {
+        let state = tandem_server::test_support::test_state().await;
+        let request = json!({"pack_selector": "private-pack", "configuration": {
+            "schema_version": "1", "scope": {"org_id": "org-a", "workspace_id": "dep-a",
+                "deployment_id": "dep-a", "instance_id": "brain"},
+            "profile_ref": "profile-ref:org-a", "timezone": "UTC", "locale": "en",
+            "constraints": {"allowed_providers": [], "allow_network_egress": false,
+                "max_tokens_per_run": 1, "max_concurrent_runs": 1, "max_daily_cost_microusd": 0}
+        }});
+        let response = apply(Router::new())
+            .with_state(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/enterprise/onboarding-plans/solutions/preview")
+                    .header("content-type", "application/json")
+                    .body(Body::from(request.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/tandem-providers/Cargo.toml
+++ b/crates/tandem-providers/Cargo.toml
@@ -18,6 +18,7 @@ keyring = "2"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"

--- a/crates/tandem-providers/src/installation_metadata.rs
+++ b/crates/tandem-providers/src/installation_metadata.rs
@@ -1,0 +1,81 @@
+//! Installation snapshots describe the concrete provider object, never infer
+//! locality from a user-chosen provider ID. They do not authorize dispatch.
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProviderInstallationMetadata {
+    pub uses_network: bool,
+    pub routing_sha256: String,
+    pub is_test_provider: bool,
+}
+
+impl ProviderInstallationMetadata {
+    pub(crate) fn network(provider_id: &str, endpoint: &str) -> Self {
+        Self::new(provider_id, endpoint, true, false)
+    }
+
+    pub(crate) fn local_echo() -> Self {
+        Self::new("local", "builtin-echo-v1", false, true)
+    }
+
+    fn new(provider_id: &str, endpoint: &str, uses_network: bool, is_test_provider: bool) -> Self {
+        // Length-delimited input; only an opaque hash leaves the provider. No
+        // credential values or raw endpoint URLs enter a customer plan.
+        let mut digest = Sha256::new();
+        digest.update(b"tandem-provider-route-v1");
+        for value in [provider_id, endpoint] {
+            digest.update((value.len() as u64).to_be_bytes());
+            digest.update(value.as_bytes());
+        }
+        Self {
+            uses_network,
+            routing_sha256: format!("{:x}", digest.finalize()),
+            is_test_provider,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AppConfig, ProviderConfig, ProviderRegistry};
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn installation_metadata_does_not_trust_a_network_provider_named_local() {
+        let local = ProviderRegistry::new(AppConfig::default());
+        let rows = local.installation_models().await;
+        let (_, metadata) = rows.iter().find(|(info, _)| info.id == "local").unwrap();
+        assert_eq!(
+            metadata.as_ref(),
+            Some(&ProviderInstallationMetadata::local_echo())
+        );
+        let config = |url: &str| AppConfig {
+            providers: HashMap::from([(
+                "local".into(),
+                ProviderConfig {
+                    url: Some(url.into()),
+                    api_key: None,
+                    default_model: Some("text-model".into()),
+                },
+            )]),
+            default_provider: Some("local".into()),
+        };
+        let network = ProviderRegistry::new(config("https://provider.example/v1"));
+        let rows = network.installation_models().await;
+        let (_, metadata) = rows.iter().find(|(info, _)| info.id == "local").unwrap();
+        let before = metadata.as_ref().unwrap();
+        assert!(before.uses_network);
+        assert!(!before.is_test_provider);
+        network.reload(config("https://changed.example/v1")).await;
+        let changed = network.installation_models().await;
+        assert_ne!(
+            before.routing_sha256,
+            changed[0].1.as_ref().unwrap().routing_sha256
+        );
+        let serialized = serde_json::to_string(before).unwrap();
+        assert!(!serialized.contains("provider.example"));
+    }
+}

--- a/crates/tandem-providers/src/lib.rs
+++ b/crates/tandem-providers/src/lib.rs
@@ -1,5 +1,7 @@
 mod dispatch_authority;
 mod guarded_dispatch;
+mod installation_metadata;
+pub use installation_metadata::ProviderInstallationMetadata;
 pub use dispatch_authority::ProviderDispatchAuthority;
 pub mod provider_auth_store;
 

--- a/crates/tandem-providers/src/lib.rs
+++ b/crates/tandem-providers/src/lib.rs
@@ -1,8 +1,8 @@
 mod dispatch_authority;
 mod guarded_dispatch;
 mod installation_metadata;
-pub use installation_metadata::ProviderInstallationMetadata;
 pub use dispatch_authority::ProviderDispatchAuthority;
+pub use installation_metadata::ProviderInstallationMetadata;
 pub mod provider_auth_store;
 
 pub use provider_auth_store::*;

--- a/crates/tandem-providers/src/lib_parts/part01.rs
+++ b/crates/tandem-providers/src/lib_parts/part01.rs
@@ -838,6 +838,11 @@ pub struct TokenUsage {
 }
 #[async_trait]
 pub trait Provider: Send + Sync {
+    /// Unknown adapters remain usable by legacy callers, but cannot be
+    /// approved for solution installation until they describe their route.
+    fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
+        None
+    }
     fn info(&self) -> ProviderInfo;
     async fn complete(&self, prompt: &str, model_override: Option<&str>) -> anyhow::Result<String>;
     async fn complete_with_auth_override(
@@ -1139,6 +1144,14 @@ impl ProviderRegistry {
             .await
             .iter()
             .map(|p| p.info())
+            .collect()
+    }
+
+    pub async fn installation_models(
+        &self,
+    ) -> Vec<(ProviderInfo, Option<ProviderInstallationMetadata>)> {
+        self.providers.read().await.iter()
+            .map(|provider| (provider.info(), provider.installation_metadata()))
             .collect()
     }
 
@@ -1789,6 +1802,9 @@ struct LocalEchoProvider;
 
 #[async_trait]
 impl Provider for LocalEchoProvider {
+    fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
+        Some(ProviderInstallationMetadata::local_echo())
+    }
     fn info(&self) -> ProviderInfo {
         ProviderInfo {
             id: "local".to_string(),

--- a/crates/tandem-providers/src/lib_parts/part02.rs
+++ b/crates/tandem-providers/src/lib_parts/part02.rs
@@ -1,5 +1,8 @@
 #[async_trait]
 impl Provider for OpenAICompatibleProvider {
+    fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
+        Some(ProviderInstallationMetadata::network(&self.id, &self.base_url))
+    }
     fn info(&self) -> ProviderInfo {
         ProviderInfo {
             id: self.id.clone(),
@@ -474,6 +477,9 @@ fn codex_supported_models(context_window: usize) -> Vec<ModelInfo> {
 
 #[async_trait]
 impl Provider for OpenAIResponsesProvider {
+    fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
+        Some(ProviderInstallationMetadata::network(&self.id, &self.base_url))
+    }
     fn info(&self) -> ProviderInfo {
         ProviderInfo {
             id: self.id.clone(),
@@ -1344,6 +1350,9 @@ struct CohereProvider {
 
 #[async_trait]
 impl Provider for AnthropicProvider {
+    fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
+        Some(ProviderInstallationMetadata::network("anthropic", "https://api.anthropic.com/v1/messages"))
+    }
     fn info(&self) -> ProviderInfo {
         ProviderInfo {
             id: "anthropic".to_string(),
@@ -1474,6 +1483,9 @@ impl Provider for AnthropicProvider {
 
 #[async_trait]
 impl Provider for CohereProvider {
+    fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
+        Some(ProviderInstallationMetadata::network("cohere", &self.base_url))
+    }
     fn info(&self) -> ProviderInfo {
         ProviderInfo {
             id: "cohere".to_string(),

--- a/crates/tandem-server/src/agent_teams/solution_templates.rs
+++ b/crates/tandem-server/src/agent_teams/solution_templates.rs
@@ -15,6 +15,52 @@ use tandem_solutions::{canonical_json, sha256, MAX_ARTIFACT_BYTES};
 use super::AgentTeamRuntime;
 
 impl AgentTeamRuntime {
+    /// Observe an already staged receipt without recreating a missing file or
+    /// trusting a stale cache. Ownership is checked before exposing a digest.
+    pub async fn observe_solution_template(
+        &self,
+        workspace_root: &str,
+        resource_id: &str,
+        owner: &SolutionTemplateOwner,
+    ) -> anyhow::Result<String> {
+        ensure!(
+            resource_id.starts_with("solution-")
+                && resource_id
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || b"_-".contains(&byte)),
+            "invalid solution resource ID"
+        );
+        let _operation = self.template_persistence.lock().await;
+        let path = PathBuf::from(workspace_root)
+            .join(".tandem/agent-team/templates")
+            .join(Self::template_filename(resource_id));
+        let owner = owner.clone();
+        let resource_id = resource_id.to_owned();
+        tokio::task::spawn_blocking(move || {
+            ensure!(
+                std::fs::symlink_metadata(&path)?.file_type().is_file(),
+                "solution template is not a regular file"
+            );
+            let mut raw = Vec::new();
+            std::fs::File::open(path)?
+                .take(MAX_ARTIFACT_BYTES as u64 + 1)
+                .read_to_end(&mut raw)?;
+            ensure!(
+                raw.len() <= MAX_ARTIFACT_BYTES,
+                "solution template is too large"
+            );
+            let observed: AgentTemplate = serde_yaml::from_slice(&raw)?;
+            ensure!(
+                !observed.enabled
+                    && observed.template_id == resource_id
+                    && observed.solution_owner.as_ref() == Some(&owner),
+                "solution template ownership or activation conflict"
+            );
+            Ok(sha256(&canonical_json(&observed)?))
+        })
+        .await?
+    }
+
     /// Create or reconcile an exact disabled template without replacing a
     /// pre-existing resource. Generic template mutation cannot activate it.
     pub async fn stage_solution_template(

--- a/crates/tandem-server/src/app/state/solution_routines.rs
+++ b/crates/tandem-server/src/app/state/solution_routines.rs
@@ -93,6 +93,36 @@ pub fn solution_routine_from_artifact(
 }
 
 impl AppState {
+    /// Read the native primary file without recreating a missing staged
+    /// resource. Generic in-memory getters cannot establish a durable receipt.
+    pub async fn observe_solution_routine(
+        &self,
+        identity: &RoutineIdentity,
+        owner: &SolutionRoutineOwner,
+    ) -> Result<String, RoutineStoreError> {
+        let _operation = self.routine_persistence.lock().await;
+        let raw = tokio::fs::read(&self.routines_path)
+            .await
+            .map_err(managed)?;
+        let rows: HashMap<String, RoutineSpec> = serde_json::from_slice(&raw).map_err(managed)?;
+        let count = rows.len();
+        let rows = routine_store_index(rows);
+        if count != rows.len() {
+            return Err(managed("duplicate routine identities"));
+        }
+        let routine = rows
+            .get(&identity.storage_key())
+            .ok_or_else(|| managed("staged routine missing"))?;
+        if routine.solution_owner.as_ref() != Some(owner)
+            || !routine.installation_disabled()
+            || routine.status != RoutineStatus::Paused
+            || routine.next_fire_at_ms.is_some()
+        {
+            return Err(managed("solution routine ownership or activation conflict"));
+        }
+        Ok(sha256(&bytes(routine)?))
+    }
+
     /// Stage an actual tenant-scoped native routine, returning its observed
     /// fingerprint for the installation journal. This never activates it.
     pub async fn stage_solution_routine(

--- a/crates/tandem-server/src/encrypted_file_store.rs
+++ b/crates/tandem-server/src/encrypted_file_store.rs
@@ -459,7 +459,9 @@ tokio::task_local! {
 /// Run synchronous protected storage off the async executor. Production uses
 /// its configured crypto provider as usual; tests carry their isolated crypto
 /// context into the blocking thread instead of silently falling back to env.
-pub(crate) async fn spawn_protected_blocking<F, T>(operation: F) -> Result<T, tokio::task::JoinError>
+pub(crate) async fn spawn_protected_blocking<F, T>(
+    operation: F,
+) -> Result<T, tokio::task::JoinError>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
@@ -472,7 +474,8 @@ where
             return TEST_CRYPTO.sync_scope(crypto, operation);
         }
         operation()
-    }).await
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/crates/tandem-server/src/encrypted_file_store.rs
+++ b/crates/tandem-server/src/encrypted_file_store.rs
@@ -456,6 +456,25 @@ tokio::task_local! {
     static TEST_CRYPTO: ProtectedFileCrypto;
 }
 
+/// Run synchronous protected storage off the async executor. Production uses
+/// its configured crypto provider as usual; tests carry their isolated crypto
+/// context into the blocking thread instead of silently falling back to env.
+pub(crate) async fn spawn_protected_blocking<F, T>(operation: F) -> Result<T, tokio::task::JoinError>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    #[cfg(test)]
+    let test_crypto = TEST_CRYPTO.try_with(Clone::clone).ok();
+    tokio::task::spawn_blocking(move || {
+        #[cfg(test)]
+        if let Some(crypto) = test_crypto {
+            return TEST_CRYPTO.sync_scope(crypto, operation);
+        }
+        operation()
+    }).await
+}
+
 #[cfg(test)]
 pub(crate) async fn with_test_crypto_provider<F, T>(
     provider: MemoryCryptoProvider,

--- a/crates/tandem-server/src/http.rs
+++ b/crates/tandem-server/src/http.rs
@@ -92,6 +92,7 @@ pub(crate) mod mcp_inventory;
 pub(crate) mod mcp_run_as;
 pub(crate) mod memory_audit_store;
 mod middleware;
+pub(crate) use middleware::enrich_verified_context_with_org_unit_grants;
 mod mission_builder;
 mod mission_builder_host;
 mod mission_builder_runtime;

--- a/crates/tandem-server/src/http/middleware.rs
+++ b/crates/tandem-server/src/http/middleware.rs
@@ -276,7 +276,7 @@ fn denial_audit_failure_response(error: &str) -> Response {
         .into_response()
 }
 
-async fn enrich_verified_context_with_org_unit_grants(
+pub(crate) async fn enrich_verified_context_with_org_unit_grants(
     state: &AppState,
     verified: &mut VerifiedTenantContext,
     hosted_memberships: Option<Vec<OrganizationUnitMembership>>,

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -108,8 +108,8 @@ pub mod runtime;
 pub mod runtime_event_log;
 pub mod shared_resources;
 pub mod signal_triage;
-pub mod stateful_runtime;
 pub mod solution_installation;
+pub mod stateful_runtime;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 pub mod util;

--- a/crates/tandem-server/src/lib.rs
+++ b/crates/tandem-server/src/lib.rs
@@ -109,6 +109,7 @@ pub mod runtime_event_log;
 pub mod shared_resources;
 pub mod signal_triage;
 pub mod stateful_runtime;
+pub mod solution_installation;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 pub mod util;

--- a/crates/tandem-server/src/pack_manager.rs
+++ b/crates/tandem-server/src/pack_manager.rs
@@ -1692,3 +1692,7 @@ mod tests;
 #[cfg(test)]
 #[path = "pack_manager_solution_tests.rs"]
 mod solution_tests;
+
+#[cfg(test)]
+#[path = "pack_manager_installation_tests.rs"]
+mod installation_tests;

--- a/crates/tandem-server/src/pack_manager_installation_tests.rs
+++ b/crates/tandem-server/src/pack_manager_installation_tests.rs
@@ -281,6 +281,31 @@ async fn solution_service_rechecks_native_grants_sources_scope_and_revocation() 
         async {
             let fixture = Fixture::new().await;
             let request = fixture.review_and_save().await;
+            let mut conflicting =
+                fixture.state.enterprise.connectors.read().await["connector-a"].clone();
+            conflicting.state = tandem_enterprise_contract::ConnectorLifecycleState::Revoked;
+            fixture
+                .state
+                .enterprise
+                .connectors
+                .write()
+                .await
+                .insert("duplicate-native-key".into(), conflicting);
+            assert!(
+                fixture
+                    .state
+                    .stage_solution_installation(&fixture.verified, request.clone())
+                    .await
+                    .is_err(),
+                "duplicate native connector IDs cannot resolve arbitrarily to an active row"
+            );
+            fixture
+                .state
+                .enterprise
+                .connectors
+                .write()
+                .await
+                .remove("duplicate-native-key");
             fixture
                 .state
                 .enterprise

--- a/crates/tandem-server/src/pack_manager_installation_tests.rs
+++ b/crates/tandem-server/src/pack_manager_installation_tests.rs
@@ -1,0 +1,433 @@
+use super::solution_tests::{fixture, request, signed};
+use super::tests::EnvGuard;
+use super::*;
+use crate::solution_installation::{SolutionConfigurationRequest, SolutionStagingRequest};
+use crate::stateful_runtime::orchestration_store::{
+    OrchestrationStateStore, SolutionComponentProgress,
+};
+use crate::AppState;
+use tandem_enterprise_contract::{
+    hosted_policy::hosted_unit_principal, AccessPermission, AuthorityChain, ConnectorInstance,
+    DataClass, HumanActor, OrganizationUnitAccessGrant, PrincipalRef, RequestPrincipal,
+    ResourceKind, ResourceRef, SourceBinding, TenantContext, TenantContextAssertionClaims,
+    VerifiedTenantContext,
+};
+
+struct Fixture {
+    root: tempfile::TempDir,
+    state: AppState,
+    verified: VerifiedTenantContext,
+    configuration: SolutionConfigurationRequest,
+    _keys: EnvGuard,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let archive = root.path().join("solution.zip");
+        let key = signed(&archive, &fixture());
+        let keys = EnvGuard::set("TANDEM_PACK_TRUSTED_PUBLIC_KEYS", &key);
+        let mut state = crate::test_support::test_state().await;
+        state.automation_v2_runs_path = root.path().join("runtime/runs.json");
+        state.routines_path = root.path().join("routines.json");
+        state.routine_runs_path = root.path().join("routine-runs.json");
+        state.enterprise.hosted_policy_revision_path =
+            root.path().join("hosted-policy-revision.json");
+        state.pack_manager = Arc::new(PackManager::new(root.path().join("packs")));
+        state.pack_manager.install(request(&archive)).await.unwrap();
+        let settings = serde_json::json!({"solution_installation": {
+            "schema_version": 1,
+            "policy": {"allowed_providers": ["local"], "allow_network_egress": false,
+                "max_tokens_per_run": 1024, "max_concurrent_runs": 1, "max_daily_cost_microusd": 0},
+            "models": {"local.fixture": {"provider_id": "local", "model_id": "echo-1",
+                "credential_ref": "secret-ref:local-fixture", "allow_test_provider": true}}
+        }});
+        let mut runtime = state.runtime.wait().clone();
+        runtime.config =
+            tandem_core::ConfigStore::new(root.path().join("config.json"), Some(settings))
+                .await
+                .unwrap();
+        runtime.providers = tandem_providers::ProviderRegistry::new(Default::default());
+        runtime.workspace_index = tandem_runtime::WorkspaceIndex::new(root.path()).await;
+        state.runtime = Arc::new(std::sync::OnceLock::from(runtime));
+        let tenant =
+            TenantContext::explicit_user_workspace("org-a", "dep-a", Some("dep-a".into()), "alice");
+        let now = crate::now_ms();
+        let mut claims = TenantContextAssertionClaims::new_v1(
+            "tandem-web",
+            "tandem-runtime",
+            now,
+            now + 300_000,
+            "assertion-a",
+            tenant.clone(),
+            HumanActor::tandem_user("alice"),
+            AuthorityChain::from_request(RequestPrincipal::authenticated_user(
+                "alice",
+                "tandem-web",
+            )),
+            vec!["hosted:role:admin".into()],
+        );
+        claims.policy_version = Some(1);
+        claims.capabilities = vec!["hosted.use".into(), "hosted.admin".into()];
+        claims.org_units = vec!["eng".into()];
+        let mut resource = ResourceRef::new("org-a", "dep-a", ResourceKind::Document, "notes");
+        resource.project_id = Some("project-a".into());
+        state.enterprise.connectors.write().await.insert(
+            "connector-a".into(),
+            ConnectorInstance::active(
+                "connector-a",
+                tenant.clone(),
+                "synthetic",
+                PrincipalRef::human_user("alice"),
+                now,
+            ),
+        );
+        state.enterprise.source_bindings.write().await.insert(
+            "notes".into(),
+            SourceBinding::enabled(
+                "notes",
+                tenant.clone(),
+                "connector-a",
+                "synthetic",
+                "notes",
+                resource.clone(),
+                DataClass::Internal,
+                PrincipalRef::human_user("alice"),
+                now,
+            ),
+        );
+        state
+            .enterprise
+            .org_unit_access_grants
+            .write()
+            .await
+            .insert(
+                "read-notes".into(),
+                OrganizationUnitAccessGrant::active(
+                    "read-notes",
+                    tenant,
+                    hosted_unit_principal("eng"),
+                    resource,
+                    now,
+                )
+                .with_permissions(vec![AccessPermission::Read])
+                .with_data_classes(vec![DataClass::Internal]),
+            );
+        let mut config = tandem_solutions::parse_customer_config(include_str!(
+            "../../tandem-solutions/fixtures/company-brain-text/customer-a.yaml"
+        ))
+        .unwrap();
+        config.scope.workspace_id = "dep-a".into();
+        config.scope.deployment_id = "dep-a".into();
+        config.profile_ref = "profile-ref:org-a".into();
+        config
+            .data_refs
+            .insert("notes".into(), "data-ref:notes".into());
+        config.memory_spaces.insert(
+            "private".into(),
+            tandem_solutions::CustomerMemorySpace::PrivateUser {
+                subject_id: "alice".into(),
+            },
+        );
+        config.optional_components.insert("review-notes".into());
+        let this = Self {
+            root,
+            state,
+            verified: claims.into(),
+            configuration: SolutionConfigurationRequest {
+                pack_selector: "tandem.company-brain".into(),
+                configuration: config,
+            },
+            _keys: keys,
+        };
+        this.policy(1, true).await;
+        this
+    }
+
+    async fn policy(&self, version: u64, active: bool) {
+        let now = crate::now_ms();
+        let path = self.root.path().join("policy.json");
+        let raw = serde_json::to_vec(&serde_json::json!({
+            "schema_version": 1, "policy_version": version, "organization_id": "org-a", "deployment_id": "dep-a",
+            "generated_at": chrono::DateTime::from_timestamp_millis(now as i64).unwrap(),
+            "users": [{"id": "alice", "email": null, "username": null, "role": "admin",
+                "capabilities": ["hosted.use", "hosted.admin"], "is_active": active, "email_verified": true}],
+            "org_units": [{"id": "eng", "slug": "eng", "display_name": "Engineering", "kind": "department", "state": "active"}],
+            "org_unit_memberships": [{"unit_id": "eng", "user_id": "alice"}], "deployment_grants": []
+        })).unwrap();
+        std::fs::write(&path, raw).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        self.state
+            .enterprise
+            .hosted_policy
+            .configure_test_source("org-a", "dep-a", path);
+        self.state.reload_hosted_policy().await.unwrap();
+    }
+
+    async fn review_and_save(&self) -> SolutionStagingRequest {
+        let preview = self
+            .state
+            .preview_solution_configuration(&self.verified, &self.configuration)
+            .await
+            .unwrap();
+        assert!(!preview.solution_ready);
+        assert!(preview.plan.host_facts_sha256.is_some());
+        assert_eq!(preview.plan.constraints.max_tokens_per_run, 1024);
+        let stored = self
+            .state
+            .save_solution_configuration(&self.verified, self.configuration.clone(), None)
+            .await
+            .unwrap();
+        SolutionStagingRequest {
+            pack_selector: self.configuration.pack_selector.clone(),
+            scope: stored.config.scope,
+            config_version: stored.version,
+            reviewed_composition: preview.composition_sha256,
+            expected_generation: None,
+        }
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_service_signed_pack_preview_save_stage_restart_and_drift() {
+    crate::encrypted_file_store::with_test_crypto_provider(
+        tandem_memory::MemoryCryptoProvider::local_key([0x39; 32]),
+        None,
+        async {
+            let fixture = Fixture::new().await;
+            let paths = crate::OrchestrationStorePaths::from_automation_runs_path(
+                &fixture.state.automation_v2_runs_path,
+            );
+            assert!(!paths.database_path.exists());
+            fixture
+                .state
+                .preview_solution_configuration(&fixture.verified, &fixture.configuration)
+                .await
+                .unwrap();
+            assert!(
+                !paths.database_path.exists(),
+                "preview must not create a state database"
+            );
+            let request = fixture.review_and_save().await;
+            let staged = fixture
+                .state
+                .stage_solution_installation(&fixture.verified, request.clone())
+                .await
+                .unwrap();
+            assert!(staged.all_components_staged());
+            assert_eq!(staged.generation, 5);
+            let mut restarted = fixture.state.clone();
+            restarted.agent_teams = crate::agent_teams::AgentTeamRuntime::new(
+                fixture.root.path().join("restart-audit.jsonl"),
+            );
+            restarted.load_routines().await.unwrap();
+            assert_eq!(
+                restarted
+                    .stage_solution_installation(&fixture.verified, request.clone())
+                    .await
+                    .unwrap(),
+                staged
+            );
+            let agent = &staged.plan.components["central-brain"].resource_id;
+            let workspace = fixture.state.workspace_index.snapshot().await.root;
+            let path = Path::new(&workspace)
+                .join(".tandem/agent-team/templates")
+                .join(format!("{agent}.yaml"));
+            let observed: tandem_orchestrator::AgentTemplate =
+                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            assert!(!observed.enabled);
+            assert_eq!(observed.default_budget.max_tokens, Some(1024));
+            assert_eq!(observed.default_model.unwrap()["model_id"], "echo-1");
+            std::fs::remove_file(&path).unwrap();
+            assert!(restarted
+                .stage_solution_installation(&fixture.verified, request)
+                .await
+                .is_err());
+            assert!(
+                !path.exists(),
+                "staged receipt validation must not recreate a deleted resource"
+            );
+            let store = OrchestrationStateStore::from_automation_runs_path(
+                &fixture.state.automation_v2_runs_path,
+            )
+            .unwrap();
+            assert_eq!(
+                store
+                    .solution_installation(
+                        &fixture.verified,
+                        &fixture.configuration.configuration.scope,
+                        crate::now_ms()
+                    )
+                    .unwrap()
+                    .unwrap(),
+                staged
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_service_rechecks_native_grants_sources_scope_and_revocation() {
+    crate::encrypted_file_store::with_test_crypto_provider(
+        tandem_memory::MemoryCryptoProvider::local_key([0x39; 32]),
+        None,
+        async {
+            let fixture = Fixture::new().await;
+            let request = fixture.review_and_save().await;
+            fixture
+                .state
+                .enterprise
+                .source_bindings
+                .write()
+                .await
+                .get_mut("notes")
+                .unwrap()
+                .updated_at_ms += 1;
+            assert!(
+                fixture
+                    .state
+                    .stage_solution_installation(&fixture.verified, request.clone())
+                    .await
+                    .is_err(),
+                "same source ID with changed revision must invalidate preview"
+            );
+            fixture
+                .state
+                .enterprise
+                .source_bindings
+                .write()
+                .await
+                .get_mut("notes")
+                .unwrap()
+                .updated_at_ms -= 1;
+            let mut other = fixture.configuration.clone();
+            other.configuration.scope.org_id = "org-b".into();
+            assert!(fixture
+                .state
+                .preview_solution_configuration(&fixture.verified, &other)
+                .await
+                .is_err());
+            other = fixture.configuration.clone();
+            other.configuration.memory_spaces.insert(
+                "private".into(),
+                tandem_solutions::CustomerMemorySpace::PrivateUser {
+                    subject_id: "bob".into(),
+                },
+            );
+            assert!(fixture
+                .state
+                .preview_solution_configuration(&fixture.verified, &other)
+                .await
+                .is_err());
+            let grant = fixture
+                .state
+                .enterprise
+                .org_unit_access_grants
+                .write()
+                .await
+                .remove("read-notes")
+                .unwrap();
+            assert!(
+                fixture
+                    .state
+                    .preview_solution_configuration(&fixture.verified, &fixture.configuration)
+                    .await
+                    .is_err(),
+                "hosted admin does not imply document read access"
+            );
+            fixture
+                .state
+                .enterprise
+                .org_unit_access_grants
+                .write()
+                .await
+                .insert("read-notes".into(), grant);
+            fixture.policy(2, false).await;
+            assert!(fixture
+                .state
+                .stage_solution_installation(&fixture.verified, request)
+                .await
+                .is_err());
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_service_uses_operator_policy_and_resumes_partial_native_failure() {
+    crate::encrypted_file_store::with_test_crypto_provider(
+        tandem_memory::MemoryCryptoProvider::local_key([0x39; 32]),
+        None,
+        async {
+            let fixture = Fixture::new().await;
+            fixture
+                .state
+                .config
+                .patch_runtime(serde_json::json!({"solution_installation": {
+                    "policy": {"max_tokens_per_run": 999999, "allow_network_egress": true}
+                }}))
+                .await
+                .unwrap();
+            let request = fixture.review_and_save().await;
+            // An existing malformed native file blocks the second component after
+            // the first has a durable receipt. Recovery requires resolving that
+            // concrete conflict; the service cannot overwrite it.
+            std::fs::write(&fixture.state.routines_path, b"manual conflict").unwrap();
+            assert!(fixture
+                .state
+                .stage_solution_installation(&fixture.verified, request.clone())
+                .await
+                .is_err());
+            assert_eq!(
+                std::fs::read(&fixture.state.routines_path).unwrap(),
+                b"manual conflict"
+            );
+            let store = OrchestrationStateStore::from_automation_runs_path(
+                &fixture.state.automation_v2_runs_path,
+            )
+            .unwrap();
+            let interrupted = store
+                .solution_installation(&fixture.verified, &request.scope, crate::now_ms())
+                .unwrap()
+                .unwrap();
+            assert!(matches!(
+                interrupted.components["central-brain"],
+                SolutionComponentProgress::Staged { .. }
+            ));
+            assert!(matches!(
+                interrupted.components["review-notes"],
+                SolutionComponentProgress::Claimed { .. }
+            ));
+            std::fs::remove_file(&fixture.state.routines_path).unwrap();
+            let (first, second) = tokio::join!(
+                fixture
+                    .state
+                    .stage_solution_installation(&fixture.verified, request.clone()),
+                fixture
+                    .state
+                    .stage_solution_installation(&fixture.verified, request.clone())
+            );
+            assert!(first.is_ok() || second.is_ok());
+            let resumed = fixture
+                .state
+                .stage_solution_installation(&fixture.verified, request)
+                .await
+                .unwrap();
+            assert!(resumed.all_components_staged());
+            assert_eq!(
+                resumed.components["central-brain"],
+                interrupted.components["central-brain"]
+            );
+            assert_eq!(resumed.components.len(), 2);
+        },
+    )
+    .await;
+}

--- a/crates/tandem-server/src/pack_manager_solution_tests.rs
+++ b/crates/tandem-server/src/pack_manager_solution_tests.rs
@@ -4,7 +4,7 @@
 use super::tests::{write_signed_zip, EnvGuard};
 use super::*;
 
-fn fixture() -> Vec<(String, String)> {
+pub(super) fn fixture() -> Vec<(String, String)> {
     [
         (
             MARKER_FILE,
@@ -32,7 +32,7 @@ fn fixture() -> Vec<(String, String)> {
     .collect()
 }
 
-fn signed(path: &Path, entries: &[(String, String)]) -> String {
+pub(super) fn signed(path: &Path, entries: &[(String, String)]) -> String {
     write_signed_zip(
         path,
         &entries
@@ -42,7 +42,7 @@ fn signed(path: &Path, entries: &[(String, String)]) -> String {
     )
 }
 
-fn request(path: &Path) -> PackInstallRequest {
+pub(super) fn request(path: &Path) -> PackInstallRequest {
     PackInstallRequest {
         path: Some(path.to_string_lossy().into_owned()),
         url: None,
@@ -154,6 +154,7 @@ async fn solution_pack_signed_artifacts_feed_existing_resolver_and_round_trip() 
     let plan = tandem_solutions::resolve(
         &source.blueprint,
         ResolutionInput {
+            host_facts_sha256: None,
             request: &install,
             verified_context: &context,
             now_ms: 1500,

--- a/crates/tandem-server/src/solution_installation/host_facts.rs
+++ b/crates/tandem-server/src/solution_installation/host_facts.rs
@@ -1,0 +1,234 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{ensure, Context};
+use serde::{Deserialize, Serialize};
+use tandem_enterprise_contract::{AccessDecision, AccessPermission, VerifiedTenantContext};
+use tandem_solutions::{
+    canonical_json, sha256, validate_customer_config_scope, ConnectorBinding, Constraints,
+    CustomerConfigInput, CustomerScope, ModelBinding,
+};
+
+use crate::AppState;
+
+/// This section is read only from the existing operator ConfigStore. It is
+/// never accepted as an API argument or inside customer configuration.
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct HostSettings {
+    pub schema_version: u32,
+    pub policy: Constraints,
+    pub models: BTreeMap<String, HostModel>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct HostModel {
+    pub provider_id: String,
+    pub model_id: String,
+    /// Existing provider/account credential reference, never its value.
+    pub credential_ref: String,
+    /// Local echo is a diagnostic, never an implicit production fallback.
+    #[serde(default)]
+    pub allow_test_provider: bool,
+}
+
+pub(super) struct HostFacts {
+    pub context: VerifiedTenantContext,
+    pub digest: String,
+    pub policy: Constraints,
+    pub references: BTreeSet<String>,
+    pub connectors: BTreeMap<String, ConnectorBinding>,
+    pub subjects: BTreeSet<String>,
+    pub units: BTreeSet<String>,
+    pub projects: BTreeSet<String>,
+    pub models: BTreeMap<String, ModelBinding>,
+    pub readiness: BTreeSet<String>,
+}
+
+impl HostFacts {
+    pub fn configuration<'a>(&'a self, scope: &'a CustomerScope) -> CustomerConfigInput<'a> {
+        CustomerConfigInput {
+            verified_context: &self.context,
+            selected_scope: scope,
+            now_ms: crate::now_ms(),
+            current_revision: None,
+            expected_revision: None,
+            host_policy: &self.policy,
+            approved_references: &self.references,
+            approved_connectors: &self.connectors,
+            approved_subjects: &self.subjects,
+            approved_org_units: &self.units,
+            approved_projects: &self.projects,
+        }
+    }
+}
+
+impl AppState {
+    pub(super) async fn solution_host_facts(
+        &self,
+        verified: &VerifiedTenantContext,
+        scope: &CustomerScope,
+    ) -> anyhow::Result<HostFacts> {
+        let mut context = verified.clone();
+        let memberships = self
+            .enterprise
+            .hosted_policy
+            .project(&mut context)
+            .map_err(anyhow::Error::msg)?
+            .context("synchronized hosted identity required")?;
+        self.enterprise
+            .hosted_policy
+            .authorize_permission(Some(&context), AccessPermission::HostedAdmin)
+            .map_err(anyhow::Error::msg)?;
+        crate::http::enrich_verified_context_with_org_unit_grants(
+            self,
+            &mut context,
+            Some(memberships),
+        )
+        .await;
+        validate_customer_config_scope(&context, scope, crate::now_ms())?;
+        let layers = self.config.get_layers_value().await;
+        // Project/global/runtime overlays are writable through ordinary config
+        // APIs. Only the operator's managed or startup CLI layer can authorize
+        // installation policy. A customer override must not widen it.
+        let settings: HostSettings = serde_json::from_value(
+            layers
+                .get("cli")
+                .and_then(|value| value.get("solution_installation"))
+                .or_else(|| {
+                    layers
+                        .get("managed")
+                        .and_then(|value| value.get("solution_installation"))
+                })
+                .cloned()
+                .context("operator solution_installation configuration required")?,
+        )?;
+        ensure!(
+            settings.schema_version == 1,
+            "unsupported host installation settings version"
+        );
+        let providers = self.providers.installation_models().await;
+        let mut models = BTreeMap::new();
+        let mut model_routes = BTreeMap::new();
+        for (binding_id, binding) in &settings.models {
+            let matches: Vec<_> = providers
+                .iter()
+                .filter(|(info, _)| info.id == binding.provider_id)
+                .collect();
+            // Repeated IDs after configuration normalization are ambiguous.
+            if matches.len() != 1 {
+                continue;
+            }
+            let (info, Some(metadata)) = matches[0] else {
+                continue;
+            };
+            if metadata.is_test_provider && !binding.allow_test_provider {
+                continue;
+            }
+            if !info.models.iter().any(|model| {
+                model.id == binding.model_id && model.provider_id == binding.provider_id
+            }) {
+                continue;
+            }
+            models.insert(
+                binding_id.clone(),
+                ModelBinding {
+                    provider: binding.provider_id.clone(),
+                    model: binding.model_id.clone(),
+                    credential_ref: binding.credential_ref.clone(),
+                    uses_network: metadata.uses_network,
+                },
+            );
+            model_routes.insert(binding_id.clone(), metadata.clone());
+        }
+        let tenant = &context.tenant_context;
+        let view = self
+            .enterprise_org_unit_view(tenant)
+            .await
+            .map_err(anyhow::Error::msg)?;
+        let units: BTreeSet<_> = view
+            .units
+            .iter()
+            .filter(|unit| unit.state.is_active())
+            .map(|unit| unit.unit_id.clone())
+            .collect();
+        let mut references = BTreeSet::from([format!("profile-ref:{}", scope.org_id)]);
+        let mut projects = BTreeSet::new();
+        let mut sources = BTreeMap::new();
+        let mut source_connectors = BTreeMap::new();
+        let strict = context
+            .strict_projection
+            .as_ref()
+            .context("strict identity required")?;
+        // Hold both native registry read locks while projecting source references.
+        let source_rows = self.enterprise.source_bindings.read().await;
+        let connector_rows = self.enterprise.connectors.read().await;
+        for source in source_rows.values() {
+            if source.tenant_context.org_id != scope.org_id
+                || source.tenant_context.workspace_id != scope.workspace_id
+                || source.tenant_context.deployment_id.as_deref()
+                    != Some(scope.deployment_id.as_str())
+                || !source.state.allows_ingestion()
+                || !source.ingestion_policy.allow_prompt_context
+            {
+                continue;
+            }
+            let Some(connector) = connector_rows.values().find(|row| {
+                row.connector_id == source.connector_id
+                    && row.tenant_matches(tenant)
+                    && row.state.allows_ingestion()
+            }) else {
+                continue;
+            };
+            if strict
+                .evaluate_access(
+                    &source.resource_ref,
+                    AccessPermission::Read,
+                    source.data_class,
+                    crate::now_ms(),
+                )
+                .decision
+                != AccessDecision::Allow
+            {
+                continue;
+            }
+            ensure!(
+                !sources.contains_key(&source.binding_id),
+                "ambiguous source binding ID"
+            );
+            references.insert(format!("data-ref:{}", source.binding_id));
+            if let Some(project) = &source.resource_ref.project_id {
+                projects.insert(project.clone());
+            }
+            sources.insert(source.binding_id.clone(), source.clone());
+            source_connectors.insert(connector.connector_id.clone(), connector.clone());
+        }
+        drop(connector_rows);
+        drop(source_rows);
+        self.enterprise
+            .hosted_policy
+            .authorize_permission(Some(&context), AccessPermission::HostedAdmin)
+            .map_err(anyhow::Error::msg)?;
+        // Include complete source records and concrete route metadata so an ID
+        // that is rebound to another destination cannot reuse a reviewed plan.
+        // All private details stay host-side; only this digest enters the lock.
+        let digest = sha256(&canonical_json(&serde_json::json!({
+            "schema_version": 1, "settings": settings, "models": models, "routes": model_routes,
+            "sources": sources, "connectors": source_connectors, "units": units,
+            "hosted_revision": view.hosted_policy_revision,
+        }))?);
+        Ok(HostFacts {
+            subjects: BTreeSet::from([context.human_actor.actor_id.clone()]),
+            context,
+            digest,
+            policy: settings.policy,
+            references,
+            connectors: BTreeMap::new(),
+            units,
+            projects,
+            models,
+            // These are existing native facilities, not customer-declared flags.
+            readiness: BTreeSet::from(["governed-memory".into(), "verified-user-context".into()]),
+        })
+    }
+}

--- a/crates/tandem-server/src/solution_installation/host_facts.rs
+++ b/crates/tandem-server/src/solution_installation/host_facts.rs
@@ -173,11 +173,18 @@ impl AppState {
             {
                 continue;
             }
-            let Some(connector) = connector_rows.values().find(|row| {
-                row.connector_id == source.connector_id
-                    && row.tenant_matches(tenant)
-                    && row.state.allows_ingestion()
-            }) else {
+            let matching_connectors: Vec<_> = connector_rows
+                .values()
+                .filter(|row| row.connector_id == source.connector_id && row.tenant_matches(tenant))
+                .collect();
+            ensure!(
+                matching_connectors.len() <= 1,
+                "ambiguous source connector ID"
+            );
+            let Some(connector) = matching_connectors
+                .first()
+                .filter(|row| row.state.allows_ingestion())
+            else {
                 continue;
             };
             if strict
@@ -201,7 +208,7 @@ impl AppState {
                 projects.insert(project.clone());
             }
             sources.insert(source.binding_id.clone(), source.clone());
-            source_connectors.insert(connector.connector_id.clone(), connector.clone());
+            source_connectors.insert(connector.connector_id.clone(), (**connector).clone());
         }
         drop(connector_rows);
         drop(source_rows);

--- a/crates/tandem-server/src/solution_installation/mod.rs
+++ b/crates/tandem-server/src/solution_installation/mod.rs
@@ -1,0 +1,121 @@
+//! Authenticated customer configuration and installation orchestration over
+//! existing PackManager, host registries and protected state. No new identity,
+//! pack, credential or memory registry is introduced here.
+
+mod host_facts;
+mod staging;
+pub use staging::SolutionStagingRequest;
+
+use anyhow::ensure;
+use serde::{Deserialize, Serialize};
+use tandem_enterprise_contract::VerifiedTenantContext;
+use tandem_solutions::{
+    prepare_customer_config, resolve, CustomerConfig, ResolutionInput, ResolvedPlan,
+};
+
+use crate::stateful_runtime::orchestration_store::{CustomerConfigVersion, StoredCustomerConfig};
+use crate::{AppState, OrchestrationStateStore};
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SolutionConfigurationRequest {
+    pub pack_selector: String,
+    pub configuration: CustomerConfig,
+}
+
+#[derive(Serialize)]
+pub struct SolutionConfigurationPreview {
+    pub plan: ResolvedPlan,
+    pub composition_sha256: String,
+    pub activation_required: bool,
+    pub solution_ready: bool,
+}
+
+impl AppState {
+    /// Nonmutating draft preview: does not open/create the state database and
+    /// cannot install resources. The caller cannot supply approved host facts.
+    pub async fn preview_solution_configuration(
+        &self,
+        verified: &VerifiedTenantContext,
+        request: &SolutionConfigurationRequest,
+    ) -> anyhow::Result<SolutionConfigurationPreview> {
+        ensure!(request.pack_selector.len() <= 512, "invalid pack selector");
+        ensure!(
+            serde_json::to_vec(&request.configuration)?.len()
+                <= tandem_solutions::MAX_BLUEPRINT_BYTES,
+            "customer configuration exceeds the document size limit"
+        );
+        let facts = self
+            .solution_host_facts(verified, &request.configuration.scope)
+            .await?;
+        let pack = self
+            .pack_manager
+            .solution_artifacts(&request.pack_selector)
+            .await?;
+        let prepared = prepare_customer_config(
+            &pack.blueprint,
+            &request.configuration,
+            facts.configuration(&request.configuration.scope),
+        )?;
+        let plan = resolve(
+            &pack.blueprint,
+            ResolutionInput {
+                host_facts_sha256: Some(&facts.digest),
+                request: &prepared.request,
+                verified_context: &facts.context,
+                now_ms: crate::now_ms(),
+                engine_version: env!("CARGO_PKG_VERSION"),
+                deployment_policy: &prepared.deployment_policy,
+                available_deployment_requirements: &facts.readiness,
+                approved_models: &facts.models,
+                artifacts: &pack.artifacts,
+            },
+        )?;
+        Ok(SolutionConfigurationPreview {
+            composition_sha256: plan.composition_hash()?,
+            plan,
+            activation_required: true,
+            solution_ready: false,
+        })
+    }
+
+    /// Save in the existing encrypted customer store with generation+digest
+    /// compare-and-swap. A saved document is not approval to install or run.
+    pub async fn save_solution_configuration(
+        &self,
+        verified: &VerifiedTenantContext,
+        request: SolutionConfigurationRequest,
+        expected: Option<CustomerConfigVersion>,
+    ) -> anyhow::Result<StoredCustomerConfig> {
+        ensure!(request.pack_selector.len() <= 512, "invalid pack selector");
+        let facts = self
+            .solution_host_facts(verified, &request.configuration.scope)
+            .await?;
+        let pack = self
+            .pack_manager
+            .solution_artifacts(&request.pack_selector)
+            .await?;
+        let path = self.automation_v2_runs_path.clone();
+        let state = self.clone();
+        crate::encrypted_file_store::spawn_protected_blocking(move || {
+            state
+                .enterprise
+                .hosted_policy
+                .authorize_permission(
+                    Some(&facts.context),
+                    tandem_enterprise_contract::AccessPermission::HostedAdmin,
+                )
+                .map_err(anyhow::Error::msg)?;
+            let store = OrchestrationStateStore::from_automation_runs_path(&path)?;
+            let mut input = facts.configuration(&request.configuration.scope);
+            input.expected_revision = expected.as_ref().map(|version| version.sha256.as_str());
+            store.save_customer_configuration(
+                &pack.blueprint,
+                &request.configuration,
+                input,
+                expected.as_ref(),
+            )
+        })
+        .await?
+    }
+}

--- a/crates/tandem-server/src/solution_installation/staging.rs
+++ b/crates/tandem-server/src/solution_installation/staging.rs
@@ -1,0 +1,322 @@
+use anyhow::{ensure, Context};
+use serde::Deserialize;
+use tandem_enterprise_contract::{AccessPermission, VerifiedTenantContext};
+use tandem_orchestrator::{AgentTemplate, SolutionTemplateOwner};
+use tandem_solutions::{ComponentKind, CustomerScope};
+
+use crate::stateful_runtime::orchestration_store::{
+    CustomerConfigVersion, OrchestrationStateStore, SolutionComponentProgress,
+    SolutionInstallation, SolutionInstallationInput, SolutionInstallationTransition,
+};
+use crate::{AppState, RoutineIdentity, SolutionRoutineOwner};
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SolutionStagingRequest {
+    pub pack_selector: String,
+    pub scope: CustomerScope,
+    pub config_version: CustomerConfigVersion,
+    pub reviewed_composition: String,
+    pub expected_generation: Option<u64>,
+}
+
+enum Transition {
+    Begin,
+    Claim {
+        component: String,
+        attempt: String,
+    },
+    Record {
+        component: String,
+        attempt: String,
+        fingerprint: String,
+    },
+}
+
+impl AppState {
+    async fn transition_solution(
+        &self,
+        verified: &VerifiedTenantContext,
+        request: &SolutionStagingRequest,
+        expected_generation: Option<u64>,
+        transition: Transition,
+    ) -> anyhow::Result<SolutionInstallation> {
+        let facts = self.solution_host_facts(verified, &request.scope).await?;
+        let pack = self
+            .pack_manager
+            .solution_artifacts(&request.pack_selector)
+            .await?;
+        let request = request.clone();
+        let state = self.clone();
+        crate::encrypted_file_store::spawn_protected_blocking(move || {
+            state
+                .enterprise
+                .hosted_policy
+                .authorize_permission(Some(&facts.context), AccessPermission::HostedAdmin)
+                .map_err(anyhow::Error::msg)?;
+            let store =
+                OrchestrationStateStore::from_automation_runs_path(&state.automation_v2_runs_path)?;
+            let transition = match &transition {
+                Transition::Begin => SolutionInstallationTransition::Begin,
+                Transition::Claim { component, attempt } => SolutionInstallationTransition::Claim {
+                    component_id: component,
+                    attempt_id: attempt,
+                },
+                Transition::Record {
+                    component,
+                    attempt,
+                    fingerprint,
+                } => SolutionInstallationTransition::RecordStaged {
+                    component_id: component,
+                    attempt_id: attempt,
+                    resource_sha256: fingerprint,
+                },
+            };
+            store.transition_solution_installation(
+                SolutionInstallationInput {
+                    host_facts_sha256: Some(&facts.digest),
+                    configuration: facts.configuration(&request.scope),
+                    expected_config: &request.config_version,
+                    blueprint: &pack.blueprint,
+                    engine_version: env!("CARGO_PKG_VERSION"),
+                    available_deployment_requirements: &facts.readiness,
+                    approved_models: &facts.models,
+                    artifacts: &pack.artifacts,
+                    reviewed_composition: &request.reviewed_composition,
+                },
+                expected_generation,
+                transition,
+            )
+        })
+        .await?
+    }
+
+    /// Apply the reviewed intent only to disabled native resources. Each
+    /// transition reloads configuration, current authority, routes and signed
+    /// pack bytes. Claimed native effects reconcile at their stable IDs; this
+    /// protocol must not be reused for arbitrary external connector effects.
+    pub async fn stage_solution_installation(
+        &self,
+        verified: &VerifiedTenantContext,
+        request: SolutionStagingRequest,
+    ) -> anyhow::Result<SolutionInstallation> {
+        ensure!(request.pack_selector.len() <= 512, "invalid pack selector");
+        let mut journal = self
+            .transition_solution(
+                verified,
+                &request,
+                request.expected_generation,
+                Transition::Begin,
+            )
+            .await?;
+        ensure!(
+            journal.plan.components.values().all(|component| matches!(
+                component.kind,
+                ComponentKind::AgentTemplate | ComponentKind::Routine
+            )),
+            "selected component requires an installation adapter that is not available"
+        );
+        let workspace = self.workspace_index.snapshot().await.root;
+        for component in journal.plan.install_order.clone() {
+            let attempt = match &journal.components[&component] {
+                SolutionComponentProgress::Pending => {
+                    let attempt = uuid::Uuid::new_v4().to_string();
+                    journal = self
+                        .transition_solution(
+                            verified,
+                            &request,
+                            Some(journal.generation),
+                            Transition::Claim {
+                                component: component.clone(),
+                                attempt: attempt.clone(),
+                            },
+                        )
+                        .await?;
+                    attempt
+                }
+                SolutionComponentProgress::Claimed { attempt_id }
+                | SolutionComponentProgress::Staged { attempt_id, .. } => attempt_id.clone(),
+            };
+            // Repeating Begin revalidates current intent even on an already
+            // claimed/staged resource; no lease expiry or takeover occurs.
+            journal = self
+                .transition_solution(
+                    verified,
+                    &request,
+                    Some(journal.generation),
+                    Transition::Begin,
+                )
+                .await?;
+            let pack = self
+                .pack_manager
+                .solution_artifacts(&request.pack_selector)
+                .await?;
+            ensure!(
+                tandem_solutions::blueprint_hash(&pack.blueprint)? == journal.plan.blueprint_sha256,
+                "pack changed before native effect"
+            );
+            self.enterprise
+                .hosted_policy
+                .authorize_permission(Some(verified), AccessPermission::HostedAdmin)
+                .map_err(anyhow::Error::msg)?;
+            let locked = &journal.plan.components[&component];
+            let artifact = pack
+                .artifacts
+                .get(&component)
+                .context("signed component artifact missing")?;
+            ensure!(
+                tandem_solutions::sha256(artifact) == locked.artifact.sha256,
+                "component artifact changed"
+            );
+            let already_staged = matches!(
+                journal.components[&component],
+                SolutionComponentProgress::Staged { .. }
+            );
+            let template_owner = SolutionTemplateOwner {
+                org_id: request.scope.org_id.clone(),
+                workspace_id: request.scope.workspace_id.clone(),
+                deployment_id: request.scope.deployment_id.clone(),
+                instance_id: request.scope.instance_id.clone(),
+                component_id: component.clone(),
+                composition_sha256: journal.composition_sha256.clone(),
+            };
+            let fingerprint = match locked.kind {
+                ComponentKind::AgentTemplate => {
+                    if already_staged {
+                        self.agent_teams
+                            .observe_solution_template(
+                                &workspace,
+                                &locked.resource_id,
+                                &template_owner,
+                            )
+                            .await?
+                    } else {
+                        let mut template: AgentTemplate = serde_json::from_slice(artifact)?;
+                        // The first text adapter is deliberately tool-free. A
+                        // future capability adapter must validate real grants.
+                        ensure!(
+                            template.capabilities.tool_allowlist.is_empty()
+                                && !template.capabilities.net_scopes.enabled,
+                            "text agent requests unsupported capabilities"
+                        );
+                        template.template_id = locked.resource_id.clone();
+                        template.default_budget.max_tokens = Some(
+                            template
+                                .default_budget
+                                .max_tokens
+                                .unwrap_or(u64::MAX)
+                                .min(journal.plan.constraints.max_tokens_per_run),
+                        );
+                        let classes = &pack.blueprint.components[&component].model_classes;
+                        ensure!(
+                            classes.len() <= 1,
+                            "text adapter requires one default model class"
+                        );
+                        if let Some(class) = classes.iter().next() {
+                            let binding = &journal
+                                .plan
+                                .models
+                                .get(class)
+                                .context("reviewed model binding missing")?
+                                .binding;
+                            template.default_model = Some(
+                                serde_json::json!({"provider_id": binding.provider, "model_id": binding.model}),
+                            );
+                        } else {
+                            template.default_model = None;
+                        }
+                        self.agent_teams
+                            .stage_solution_template(&workspace, template, template_owner)
+                            .await?
+                    }
+                }
+                ComponentKind::Routine => {
+                    let owner = SolutionRoutineOwner {
+                        instance_id: request.scope.instance_id.clone(),
+                        component_id: component.clone(),
+                        composition_sha256: journal.composition_sha256.clone(),
+                        enabled: false,
+                    };
+                    let tenant = &verified.tenant_context;
+                    if already_staged {
+                        self.observe_solution_routine(
+                            &RoutineIdentity::new(&locked.resource_id, tenant),
+                            &owner,
+                        )
+                        .await
+                    } else {
+                        let mut routine = crate::solution_routine_from_artifact(
+                            artifact,
+                            &locked.resource_id,
+                            tenant,
+                        )
+                        .map_err(|error| anyhow::anyhow!("routine artifact rejected: {error:?}"))?;
+                        ensure!(
+                            routine.allowed_tools.is_empty()
+                                && routine.output_targets.is_empty()
+                                && !routine.external_integrations_allowed,
+                            "text routine requests unsupported external effects"
+                        );
+                        routine.timezone = self
+                            .solution_configuration_timezone(verified, &request)
+                            .await?;
+                        self.stage_solution_routine(routine, owner).await
+                    }
+                    .map_err(|error| anyhow::anyhow!("native routine conflict: {error:?}"))?
+                }
+                _ => anyhow::bail!("unsupported native component"),
+            };
+            if let SolutionComponentProgress::Staged {
+                resource_sha256, ..
+            } = &journal.components[&component]
+            {
+                ensure!(
+                    *resource_sha256 == fingerprint,
+                    "staged resource drift; explicit reconciliation required"
+                );
+            } else {
+                journal = self
+                    .transition_solution(
+                        verified,
+                        &request,
+                        Some(journal.generation),
+                        Transition::Record {
+                            component,
+                            attempt,
+                            fingerprint,
+                        },
+                    )
+                    .await?;
+            }
+        }
+        self.transition_solution(
+            verified,
+            &request,
+            Some(journal.generation),
+            Transition::Begin,
+        )
+        .await
+    }
+
+    async fn solution_configuration_timezone(
+        &self,
+        verified: &VerifiedTenantContext,
+        request: &SolutionStagingRequest,
+    ) -> anyhow::Result<String> {
+        let facts = self.solution_host_facts(verified, &request.scope).await?;
+        let request = request.clone();
+        let path = self.automation_v2_runs_path.clone();
+        crate::encrypted_file_store::spawn_protected_blocking(move || {
+            let store = OrchestrationStateStore::from_automation_runs_path(&path)?;
+            let stored = store
+                .customer_configuration(&facts.context, &request.scope, crate::now_ms())?
+                .context("customer configuration missing")?;
+            ensure!(
+                stored.version == request.config_version,
+                "customer configuration changed before native effect"
+            );
+            Ok(stored.config.timezone)
+        })
+        .await?
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installation_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installation_tests.rs
@@ -17,6 +17,7 @@ struct InstallationFixture {
     models: BTreeMap<String, ModelBinding>,
     artifacts: BTreeMap<String, Vec<u8>>,
     readiness: BTreeSet<String>,
+    host_facts: Option<String>,
 }
 
 #[cfg(feature = "storage-postgres")]
@@ -84,6 +85,7 @@ impl InstallationFixture {
             .insert("review-notes".into());
         Self {
             customer: fixture,
+            host_facts: None,
             models: [("local.fixture".into(), ModelBinding {
                 provider: "local".into(), model: "synthetic-model".into(),
                 credential_ref: "secret-ref:local-fixture".into(), uses_network: false,
@@ -129,6 +131,7 @@ impl InstallationFixture {
         let plan = resolve(
             &self.customer.blueprint,
             ResolutionInput {
+                host_facts_sha256: self.host_facts.as_deref(),
                 request: &prepared.request,
                 verified_context: &self.customer.context,
                 now_ms: 1500,
@@ -149,6 +152,7 @@ impl InstallationFixture {
         digest: &'a str,
     ) -> SolutionInstallationInput<'a> {
         SolutionInstallationInput {
+            host_facts_sha256: self.host_facts.as_deref(),
             configuration: self.configuration(),
             expected_config: &config.version,
             blueprint: &self.customer.blueprint,
@@ -562,5 +566,40 @@ fn solution_installation_schema_upgrade_preserves_configuration() {
             .unwrap();
         store.initialize().unwrap();
         assert_eq!(fixture.read(store), record);
+    });
+}
+
+#[test]
+#[serial]
+fn solution_installation_rejects_host_rebinding_before_claim_or_receipt() {
+    for_each_backend(|_, store| {
+        let mut fixture = InstallationFixture::new("a");
+        fixture.host_facts = Some(sha256(b"approved endpoint and source revision 1"));
+        let (config, digest) = fixture.seed(store);
+        let begin = store.transition_solution_installation(
+            fixture.input(&config, &digest), None, SolutionInstallationTransition::Begin,
+        ).unwrap();
+        let mut rebound = fixture.clone();
+        rebound.host_facts = Some(sha256(b"same IDs, changed endpoint or source"));
+        assert!(store.transition_solution_installation(
+            rebound.input(&config, &digest), Some(begin.generation),
+            SolutionInstallationTransition::Claim { component_id: "central-brain", attempt_id: "one" },
+        ).unwrap_err().to_string().contains("preview is stale"));
+        assert_eq!(fixture.read(store), begin);
+        let claimed = store.transition_solution_installation(
+            fixture.input(&config, &digest), Some(begin.generation),
+            SolutionInstallationTransition::Claim { component_id: "central-brain", attempt_id: "one" },
+        ).unwrap();
+        let receipt = sha256(b"disabled native component");
+        for host_facts in [rebound.host_facts.clone(), None] {
+            rebound.host_facts = host_facts;
+            assert!(store.transition_solution_installation(
+                rebound.input(&config, &digest), Some(claimed.generation),
+                SolutionInstallationTransition::RecordStaged {
+                    component_id: "central-brain", attempt_id: "one", resource_sha256: &receipt,
+                },
+            ).unwrap_err().to_string().contains("preview is stale"));
+            assert_eq!(fixture.read(store), claimed);
+        }
     });
 }

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installation_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installation_tests.rs
@@ -576,29 +576,54 @@ fn solution_installation_rejects_host_rebinding_before_claim_or_receipt() {
         let mut fixture = InstallationFixture::new("a");
         fixture.host_facts = Some(sha256(b"approved endpoint and source revision 1"));
         let (config, digest) = fixture.seed(store);
-        let begin = store.transition_solution_installation(
-            fixture.input(&config, &digest), None, SolutionInstallationTransition::Begin,
-        ).unwrap();
+        let begin = store
+            .transition_solution_installation(
+                fixture.input(&config, &digest),
+                None,
+                SolutionInstallationTransition::Begin,
+            )
+            .unwrap();
         let mut rebound = fixture.clone();
         rebound.host_facts = Some(sha256(b"same IDs, changed endpoint or source"));
-        assert!(store.transition_solution_installation(
-            rebound.input(&config, &digest), Some(begin.generation),
-            SolutionInstallationTransition::Claim { component_id: "central-brain", attempt_id: "one" },
-        ).unwrap_err().to_string().contains("preview is stale"));
+        assert!(store
+            .transition_solution_installation(
+                rebound.input(&config, &digest),
+                Some(begin.generation),
+                SolutionInstallationTransition::Claim {
+                    component_id: "central-brain",
+                    attempt_id: "one"
+                },
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("preview is stale"));
         assert_eq!(fixture.read(store), begin);
-        let claimed = store.transition_solution_installation(
-            fixture.input(&config, &digest), Some(begin.generation),
-            SolutionInstallationTransition::Claim { component_id: "central-brain", attempt_id: "one" },
-        ).unwrap();
+        let claimed = store
+            .transition_solution_installation(
+                fixture.input(&config, &digest),
+                Some(begin.generation),
+                SolutionInstallationTransition::Claim {
+                    component_id: "central-brain",
+                    attempt_id: "one",
+                },
+            )
+            .unwrap();
         let receipt = sha256(b"disabled native component");
         for host_facts in [rebound.host_facts.clone(), None] {
             rebound.host_facts = host_facts;
-            assert!(store.transition_solution_installation(
-                rebound.input(&config, &digest), Some(claimed.generation),
-                SolutionInstallationTransition::RecordStaged {
-                    component_id: "central-brain", attempt_id: "one", resource_sha256: &receipt,
-                },
-            ).unwrap_err().to_string().contains("preview is stale"));
+            assert!(store
+                .transition_solution_installation(
+                    rebound.input(&config, &digest),
+                    Some(claimed.generation),
+                    SolutionInstallationTransition::RecordStaged {
+                        component_id: "central-brain",
+                        attempt_id: "one",
+                        resource_sha256: &receipt,
+                    },
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("preview is stale"));
             assert_eq!(fixture.read(store), claimed);
         }
     });

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installations.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installations.rs
@@ -26,6 +26,7 @@ pub const SOLUTION_INSTALLATION_CONFLICT: &str =
 /// Host-owned inputs, never deserialized from an HTTP install request. Every
 /// transition resolves again against the configuration read in its transaction.
 pub struct SolutionInstallationInput<'a> {
+    pub host_facts_sha256: Option<&'a str>,
     pub configuration: CustomerConfigInput<'a>,
     pub expected_config: &'a CustomerConfigVersion,
     pub blueprint: &'a SolutionBlueprint,
@@ -165,6 +166,7 @@ impl OrchestrationStateStore {
                 ..config_input
             })?;
             let plan = resolve(input.blueprint, ResolutionInput {
+                host_facts_sha256: input.host_facts_sha256,
                 request: &prepared.request, verified_context: context, now_ms,
                 engine_version: input.engine_version, deployment_policy: &prepared.deployment_policy,
                 available_deployment_requirements: input.available_deployment_requirements,

--- a/crates/tandem-solutions/examples/plan_fixture.rs
+++ b/crates/tandem-solutions/examples/plan_fixture.rs
@@ -53,6 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let plan = resolve(
         &blueprint,
         ResolutionInput {
+            host_facts_sha256: None,
             request: &request,
             verified_context: &context,
             now_ms: 1500,

--- a/crates/tandem-solutions/src/contract.rs
+++ b/crates/tandem-solutions/src/contract.rs
@@ -209,6 +209,9 @@ pub struct AuthorityBinding {
 /// recheck current identities, bindings, policies, digests and ownership.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResolvedPlan {
+    /// Current host facts are part of the reviewed composition, not authority.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_facts_sha256: Option<String>,
     pub schema_version: String,
     pub resolver_version: String,
     pub engine_version: String,

--- a/crates/tandem-solutions/src/resolve.rs
+++ b/crates/tandem-solutions/src/resolve.rs
@@ -11,6 +11,9 @@ use tandem_enterprise_contract::{TenantSource, VerifiedTenantContext};
 /// CapabilityResolver readiness checks. Never deserialize this from a browser,
 /// model response, or solution pack. No network or wall clock access occurs here.
 pub struct ResolutionInput<'a> {
+    /// Digest of the host-owned source and provider routing snapshot. Callers
+    /// that install resources must supply it; None preserves pure legacy plans.
+    pub host_facts_sha256: Option<&'a str>,
     pub request: &'a InstallRequest,
     pub verified_context: &'a VerifiedTenantContext,
     pub now_ms: u64,
@@ -29,6 +32,9 @@ pub fn resolve(
     input: ResolutionInput<'_>,
 ) -> Result<ResolvedPlan, SolutionError> {
     validate_blueprint(blueprint)?;
+    if let Some(value) = input.host_facts_sha256 {
+        digest(value, "host_facts_sha256")?;
+    }
     let request = input.request;
     identifier(&request.instance_id, "instance_id")?;
     digest(
@@ -254,6 +260,7 @@ pub fn resolve(
         .cloned()
         .collect();
     Ok(ResolvedPlan {
+        host_facts_sha256: input.host_facts_sha256.map(str::to_owned),
         schema_version: SCHEMA_VERSION.into(),
         resolver_version: RESOLVER_VERSION.into(),
         engine_version: engine.to_string(),

--- a/crates/tandem-solutions/tests/customer_configuration.rs
+++ b/crates/tandem-solutions/tests/customer_configuration.rs
@@ -97,6 +97,7 @@ impl Fixture {
         resolve(
             &self.blueprint,
             ResolutionInput {
+                host_facts_sha256: None,
                 request: &prepared.request,
                 verified_context: &self.context,
                 now_ms: 1500,

--- a/crates/tandem-solutions/tests/resolution.rs
+++ b/crates/tandem-solutions/tests/resolution.rs
@@ -67,9 +67,16 @@ impl Fixture {
         }
     }
     fn plan(&self) -> Result<ResolvedPlan, SolutionError> {
+        self.plan_with_host_facts(None)
+    }
+    fn plan_with_host_facts(
+        &self,
+        host_facts_sha256: Option<&str>,
+    ) -> Result<ResolvedPlan, SolutionError> {
         resolve(
             &self.blueprint,
             ResolutionInput {
+                host_facts_sha256,
                 request: &self.request,
                 approved_models: &self.approved_models,
                 verified_context: &self.context,
@@ -413,6 +420,7 @@ fn expired_local_or_inconsistent_identity_never_falls_back_to_shared() {
 fn incompatible_engine_and_missing_host_readiness_fail_before_planning() {
     let fixture = Fixture::new();
     let mut input = ResolutionInput {
+        host_facts_sha256: None,
         request: &fixture.request,
         approved_models: &fixture.approved_models,
         verified_context: &fixture.context,
@@ -428,6 +436,7 @@ fn incompatible_engine_and_missing_host_readiness_fail_before_planning() {
     );
     let empty = Default::default();
     input = ResolutionInput {
+        host_facts_sha256: None,
         request: &fixture.request,
         approved_models: &fixture.approved_models,
         verified_context: &fixture.context,
@@ -545,4 +554,32 @@ fn generated_schema_matches_checked_in_contract() {
         serde_json::to_value(blueprint_schema()).unwrap(),
         checked_in
     );
+}
+
+#[test]
+fn reviewed_composition_binds_host_fact_revision_and_preserves_legacy_locks() {
+    let fixture = Fixture::new();
+    let old = fixture.plan().unwrap();
+    let bytes = serde_json::to_vec(&old).unwrap();
+    assert!(!String::from_utf8(bytes.clone())
+        .unwrap()
+        .contains("host_facts_sha256"));
+    let roundtrip: ResolvedPlan = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(
+        old.composition_hash().unwrap(),
+        roundtrip.composition_hash().unwrap()
+    );
+    let first = sha256(b"source binding revision 1; provider endpoint A");
+    let second = sha256(b"source binding revision 2; provider endpoint B");
+    let a = fixture.plan_with_host_facts(Some(&first)).unwrap();
+    let b = fixture.plan_with_host_facts(Some(&second)).unwrap();
+    assert_eq!(a.host_facts_sha256.as_deref(), Some(first.as_str()));
+    assert_ne!(
+        old.composition_hash().unwrap(),
+        a.composition_hash().unwrap()
+    );
+    assert_ne!(a.composition_hash().unwrap(), b.composition_hash().unwrap());
+    for invalid in ["", "endpoint-secret", "123", &"z".repeat(64)] {
+        assert!(fixture.plan_with_host_facts(Some(invalid)).is_err());
+    }
 }

--- a/docs/SOLUTION_INSTALLATION_SERVICE.md
+++ b/docs/SOLUTION_INSTALLATION_SERVICE.md
@@ -1,0 +1,69 @@
+# Solution configuration and disabled installation
+
+The enterprise onboarding service now connects the existing signed PackManager,
+protected customer state and installation journal to native disabled agent
+templates and paused routines. It requires a current synchronized hosted policy,
+an unexpired verified identity with `hosted.admin`, and matching organization,
+workspace and deployment. Admin operation permission does not imply source read
+permission. No account, organization, invitation, source or secret is created.
+
+The existing ConfigStore's **managed layer or startup CLI overrides** must contain
+`solution_installation`, with `schema_version: 1`, a `policy` using the existing
+solution Constraints schema, and a `models` map. Project, global and runtime
+overlays cannot supply or widen this section. The managed configuration file and
+startup arguments remain operator-controlled host files.
+
+Each model entry contains `provider_id`, `model_id`, `credential_ref` (an existing
+reference, never a key value), and optional `allow_test_provider: false`. The
+concrete ProviderRegistry adapter supplies network locality and an opaque route
+digest. A custom HTTP provider named `local` is still a network provider. Unknown
+adapters are unavailable to this installer. Local Echo requires explicit opt-in
+and only demonstrates mechanics; it is not a production language model. Concrete
+credential-generation enforcement and dispatch binding remain activation work.
+
+`profile-ref:<org-id>` refers to the current hosted organization. Enabled source
+bindings expose `data-ref:<binding-id>` only with an active same-tenant connector,
+prompt-context permission and the caller's current native read grant. Projects
+come from those authorized source records. A private memory binding may name only
+the verified caller; this does not grant access to other users' notes. Capability
+connector and secret references with no implemented trusted adapter fail closed.
+
+Three POST endpoints extend `/enterprise/onboarding-plans/solutions`:
+
+- `/preview`: `{pack_selector, configuration}` resolves a draft without creating
+  the state database or native resources. It returns the plan and composition
+  digest, with `activation_required: true` and `solution_ready: false`.
+- `/configuration`: `{request: {pack_selector, configuration}, expected_version}`
+  saves through the existing protected generation/digest compare-and-swap store.
+- `/stage`: `{pack_selector, scope, config_version, reviewed_composition,
+  expected_generation}` begins/resumes the existing durable staging journal and
+  materializes only disabled native agent templates and paused routines.
+
+The composition binds current host settings, concrete provider routes, authorized
+source records and connector metadata. Changing a source destination/revision
+while retaining its ID invalidates the preview. Every journal transition reloads
+the signed pack, authorization and protected configuration. Native claims have no
+timeout takeover: their stable IDs reconcile exact existing content. Repeated
+apply observes completed receipts from actual files; missing or edited resources
+produce a conflict instead of being recreated. This reconciliation is safe only
+for these idempotent native adapters, not arbitrary external effects. Routine
+storage retains its existing one-AppState-writer-per-host constraint.
+
+Agent staging narrows the token ceiling and sets the reviewed default model.
+Routines remain paused with the customer's timezone; staging does not enable
+schedules or execute models. Unsupported component kinds, tools and external
+effects are rejected. Native resources cannot be activated through generic APIs.
+
+Remaining work includes actionable aggregation of all missing prerequisites,
+configuration/progress read routes, UI/CLI flows, preference/preset composition,
+routine-to-agent invocation, current credential and model dispatch enforcement,
+shared atomic budgets, explicit activation, upgrades/uninstall reference guards,
+source-backed product behavior and clean-host recovery. The existing memory
+facility readiness flag does not establish live KMS health or full solution
+readiness. This slice must not close TAN-834, TAN-831 or the overall system goal.
+
+Regression coverage includes route identity rejection, concrete provider locality,
+host-rebinding rejection in SQLite/PostgreSQL journal transitions, and signed-pack
+service tests for nonmutating preview, source grants, revocation, partial failure,
+concurrent retry, native restart and manual deletion. CI is the execution evidence;
+writing these tests alone is not a pass.


### PR DESCRIPTION
Customer configuration and durable staging previously required callers to supply trusted inputs manually. This connects enterprise onboarding endpoints to current hosted identity/grants, operator-managed settings, signed PackManager artifacts, protected configuration and the existing installation journal. Staging creates disabled native agent templates and paused routines. Repeat apply validates actual disk receipts and preserves manual conflicts or missing resources.

The reviewed composition binds concrete provider routes and current source/connector records. Rebinding an ID invalidates the preview. Actual adapters determine network locality, including custom HTTP providers named local. Project/global/runtime overlays cannot widen installation policy. Each journal transition reauthorizes and resolves current configuration, pack and host facts.

Exact signed head 0512a2f965d6f23d2867f700ea325ff5f29f5c87 passed all six workflows. Solution Contract 34011406983 includes three signed-pack service integration cases, HTTP identity, eight actual SQLite/PostgreSQL journal tests, six protected customer tests, encrypted transfer, native barriers, 22 PackManager/service tests, pure contracts, provider-locality and PostgreSQL clippy. Engine 34011407018 passed, including 5,190 workspace tests (7 skipped). Security Assurance 34011406982 passed Linux release 101427824070, engine container 101431504771 and aggregate 101431740219. Hosted-policy, ACME governance and email workflows also passed. Ready for review; no local Cargo available.

Stacks on published dependency assembly 61c6ed3a06449ccea15ab84bf5640ca56dc01fb5, composed from separately reviewable policy, keys, memory, customer state, journal, signed-pack and native staging candidates. Assembly uses signed local dependency merges; no remote PR was merged. These tests validate the combined candidate.

Remaining: actionable prerequisite aggregation and progress/read UI/CLI; actual credential/model compatibility and shared spend dispatch; preferences/presets; routine-to-agent invocation; explicit activation and a useful source-backed answer; upgrades/uninstall; clean-host recovery and full customer/privacy acceptance. Local Echo is diagnostic only. Routine storage retains one AppState writer per host. No whole-issue completion or solution readiness is claimed. See docs/SOLUTION_INSTALLATION_SERVICE.md. Keep TAN-834 and the system goal open; do not merge automatically.