### PR TITLE
feat(solutions): reserve shared budgets and reconcile durable charge attempts (TAN-831)

### DIFF
--- a/.github/workflows/solution-contract.yml
+++ b/.github/workflows/solution-contract.yml
@@ -84,6 +84,8 @@ jobs:
         run: cargo test -p tandem-server --locked --features storage-postgres stateful_runtime::orchestration_store::transfer --lib -- --test-threads=1
       - name: Verify durable solution staging on both backends
         run: cargo test -p tandem-server --locked --features storage-postgres solution_installation_ --lib -- --test-threads=1
+      - name: Verify atomic shared budgets and crash reconciliation on both backends
+        run: cargo test -p tandem-server --locked --features storage-postgres solution_budget_ --lib -- --test-threads=1
       - name: Verify native disabled agent staging and reconciliation
         run: cargo test -p tandem-server --locked --features storage-postgres agent_teams::solution_templates --lib
       - name: Verify native routine staging and execution barriers

--- a/crates/tandem-server/src/http/workflow_planner_transport.rs
+++ b/crates/tandem-server/src/http/workflow_planner_transport.rs
@@ -693,6 +693,7 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial]
+    #[serial_test::serial(data_boundary_env)]
     async fn planner_transport_isolates_hosted_codex_auth_from_local_and_other_tenants() {
         let state = crate::test_support::test_state().await;
         let tenant_a = TenantContext::explicit("planner-org-a", "planner-workspace-a", None);

--- a/crates/tandem-server/src/stateful_runtime/backend/postgres.rs
+++ b/crates/tandem-server/src/stateful_runtime/backend/postgres.rs
@@ -569,6 +569,15 @@ pub(crate) fn initialize_schema(connection: &mut Connection) -> anyhow::Result<(
         transaction.commit()?;
         version = 7;
     }
+    if version == 7 {
+        let transaction =
+            connection.transaction_with_behavior(super::TransactionBehavior::Immediate)?;
+        transaction.execute_batch(
+            crate::stateful_runtime::orchestration_store::solution_budget_records::SCHEMA_V8,
+        )?;
+        transaction.commit()?;
+        version = 8;
+    }
     if version != crate::stateful_runtime::orchestration_store::SCHEMA_VERSION {
         bail!(
             "unsupported orchestration store schema version {version}; expected {}",

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -22,6 +22,8 @@ mod goal_lifecycle;
 mod migration;
 pub(crate) mod protected_records;
 mod runtime_records;
+pub(crate) mod solution_budget_records;
+mod solution_budgets;
 pub(crate) mod solution_installations;
 mod transfer;
 mod transition;
@@ -33,6 +35,10 @@ pub use goal_control::{GoalCancellationResult, GoalControlOutcome};
 pub use goal_lifecycle::{GoalEventRow, GoalPauseOutcome, GoalResumeOutcome, StartGoalOutcome};
 pub use migration::{
     LegacyImportContext, LegacyRuntimeMigrationPaths, LegacyRuntimeMigrationReport,
+};
+pub use solution_budgets::{
+    SolutionBudgetInput, SolutionBudgetReservationResult, SolutionChargeIntent, SolutionChargeKind,
+    SolutionChargeReservation, SolutionChargeStatus, SolutionRunBudget,
 };
 pub use solution_installations::{
     SolutionComponentProgress, SolutionInstallation, SolutionInstallationInput,
@@ -47,7 +53,7 @@ pub use transition::{
     WorkflowCompletionResult,
 };
 
-pub(crate) const SCHEMA_VERSION: i64 = 7;
+pub(crate) const SCHEMA_VERSION: i64 = 8;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrchestrationStorePaths {
@@ -1217,6 +1223,10 @@ fn initialize_schema(connection: &mut rusqlite::Connection) -> anyhow::Result<()
     if version == 6 {
         solution_installations::migrate_sqlite(connection)?;
         version = 7;
+    }
+    if version == 7 {
+        solution_budget_records::migrate_sqlite(connection)?;
+        version = 8;
     }
     if version != SCHEMA_VERSION {
         bail!(

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/customer_config_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/customer_config_tests.rs
@@ -340,6 +340,8 @@ fn customer_config_schema_upgrade_keeps_existing_runtime_records() {
         store.with_connection(|connection| {
             connection.execute_batch("DROP TABLE solution_installation_versions;
                 DROP TABLE solution_installations;
+                DROP TABLE solution_budget_records;
+                DROP TABLE solution_budget_versions;
                 DROP TABLE solution_customer_config_versions;
                 DROP TABLE solution_customer_configs;
                 UPDATE schema_metadata SET schema_version=5;

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budget_records.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budget_records.rs
@@ -1,0 +1,150 @@
+//! Protected budget records share the orchestration writer transaction and
+//! transfer machinery. Version history detects deleting/rolling back only a
+//! current row; off-host rollback detection still requires recovery anchors.
+
+use anyhow::ensure;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tandem_solutions::{canonical_json, sha256, CustomerScope};
+use tandem_types::TenantContext;
+
+use super::protected_records;
+use crate::stateful_runtime::backend::{params, Executor, OptionalExtension};
+
+#[derive(Serialize, Deserialize)]
+struct Record<T> {
+    instance_id: String,
+    key: String,
+    generation: u64,
+    value: T,
+}
+
+fn id(scope: &CustomerScope, key: &str, generation: u64) -> anyhow::Result<String> {
+    Ok(format!(
+        "{}:{generation}",
+        sha256(&canonical_json(&(&scope.instance_id, key))?)
+    ))
+}
+
+pub(super) fn load<T: DeserializeOwned>(
+    executor: &impl Executor,
+    tenant: &TenantContext,
+    scope: &CustomerScope,
+    key: &str,
+) -> anyhow::Result<Option<(u64, T)>> {
+    let row = executor.query_row(
+        "SELECT generation,record_json FROM solution_budget_records
+         WHERE org_id=?1 AND workspace_id=?2 AND deployment_id=?3 AND instance_id=?4 AND record_key=?5",
+        params![scope.org_id,scope.workspace_id,scope.deployment_id,scope.instance_id,key],
+        |row| Ok((row.get::<_, u64>(0)?, row.get::<_, String>(1)?)),
+    ).optional()?;
+    let maximum: Option<u64> = executor.query_row(
+        "SELECT MAX(generation) FROM solution_budget_versions
+         WHERE org_id=?1 AND workspace_id=?2 AND deployment_id=?3 AND instance_id=?4 AND record_key=?5",
+        params![scope.org_id,scope.workspace_id,scope.deployment_id,scope.instance_id,key],
+        |row| row.get(0),
+    )?;
+    ensure!(
+        row.as_ref().map(|(generation, _)| *generation) == maximum,
+        "solution budget current record missing or rolled back"
+    );
+    let Some((generation, raw)) = row else {
+        return Ok(None);
+    };
+    let record: Record<T> = protected_records::decode(
+        tenant,
+        "solution-budget",
+        &id(scope, key, generation)?,
+        &raw,
+    )?;
+    ensure!(
+        record.instance_id == scope.instance_id
+            && record.key == key
+            && record.generation == generation,
+        "solution budget persisted binding mismatch"
+    );
+    Ok(Some((generation, record.value)))
+}
+
+pub(super) fn save<T: Serialize>(
+    executor: &impl Executor,
+    tenant: &TenantContext,
+    scope: &CustomerScope,
+    key: &str,
+    previous: u64,
+    value: T,
+) -> anyhow::Result<()> {
+    let generation = previous
+        .checked_add(1)
+        .filter(|value| *value <= i64::MAX as u64)
+        .ok_or_else(|| anyhow::anyhow!("solution budget generation exhausted"))?;
+    let raw = protected_records::encode(
+        tenant,
+        "solution-budget",
+        &id(scope, key, generation)?,
+        &Record {
+            instance_id: scope.instance_id.clone(),
+            key: key.into(),
+            generation,
+            value,
+        },
+    )?;
+    let changed = if previous == 0 {
+        executor.execute(
+            "INSERT INTO solution_budget_records
+            (org_id,workspace_id,deployment_id,instance_id,record_key,generation,record_json)
+            VALUES (?1,?2,?3,?4,?5,?6,?7) ON CONFLICT DO NOTHING",
+            params![
+                scope.org_id,
+                scope.workspace_id,
+                scope.deployment_id,
+                scope.instance_id,
+                key,
+                generation,
+                raw
+            ],
+        )?
+    } else {
+        executor.execute("UPDATE solution_budget_records SET generation=?6,record_json=?7
+            WHERE org_id=?1 AND workspace_id=?2 AND deployment_id=?3 AND instance_id=?4 AND record_key=?5 AND generation=?8",
+            params![scope.org_id,scope.workspace_id,scope.deployment_id,scope.instance_id,key,generation,raw,previous])?
+    };
+    ensure!(changed == 1, "solution budget changed concurrently");
+    executor.execute(
+        "INSERT INTO solution_budget_versions
+        (org_id,workspace_id,deployment_id,instance_id,record_key,generation,record_json)
+        VALUES (?1,?2,?3,?4,?5,?6,?7)",
+        params![
+            scope.org_id,
+            scope.workspace_id,
+            scope.deployment_id,
+            scope.instance_id,
+            key,
+            generation,
+            raw
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) const SCHEMA_V8: &str = "
+CREATE TABLE solution_budget_records (
+ org_id TEXT NOT NULL,workspace_id TEXT NOT NULL,deployment_id TEXT NOT NULL,instance_id TEXT NOT NULL,
+ record_key TEXT NOT NULL,generation BIGINT NOT NULL CHECK (generation>0),record_json TEXT NOT NULL,
+ PRIMARY KEY (org_id,workspace_id,deployment_id,instance_id,record_key)
+);
+CREATE TABLE solution_budget_versions (
+ org_id TEXT NOT NULL,workspace_id TEXT NOT NULL,deployment_id TEXT NOT NULL,instance_id TEXT NOT NULL,
+ record_key TEXT NOT NULL,generation BIGINT NOT NULL CHECK (generation>0),record_json TEXT NOT NULL,
+ PRIMARY KEY (org_id,workspace_id,deployment_id,instance_id,record_key,generation)
+);
+UPDATE schema_metadata SET schema_version=8;
+";
+
+#[cfg(feature = "storage-sqlite")]
+pub(super) fn migrate_sqlite(connection: &mut rusqlite::Connection) -> anyhow::Result<()> {
+    let transaction =
+        connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    transaction.execute_batch(SCHEMA_V8)?;
+    transaction.commit()?;
+    Ok(())
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budget_tests.rs
@@ -407,6 +407,51 @@ pub(crate) struct TransferBudget {
     reserved: SolutionChargeIntent,
 }
 
+#[test]
+#[serial]
+fn solution_budget_rechecks_configuration_generation_but_can_settle_existing_charge() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = BudgetFixture::new(store, "a", "config-change", 2);
+            let charge = BudgetFixture::charge("already-dispatched", "root", 30, 10);
+            store
+                .reserve_solution_charge(fixture.input(1500), charge.clone())
+                .unwrap();
+            let customer = &fixture.installation.customer;
+            let original = store
+                .customer_configuration(&customer.context, &customer.config.scope, 1500)
+                .unwrap()
+                .unwrap();
+            let mut edited = customer.config.clone();
+            edited.timezone = "UTC".into();
+            let changed = customer
+                .save(store, &edited, Some(&original.version))
+                .unwrap();
+            assert!(store
+                .reserve_solution_charge(
+                    fixture.input(1500),
+                    BudgetFixture::charge("stale", "root", 30, 10)
+                )
+                .is_err());
+            // Billing receipts still settle old attempts after configuration changes.
+            store
+                .settle_solution_charge(fixture.input(1500), &charge, 5, 20)
+                .unwrap();
+            let restored = customer
+                .save(store, &customer.config, Some(&changed.version))
+                .unwrap();
+            assert_eq!(restored.version.sha256, original.version.sha256);
+            assert_ne!(restored.version.generation, original.version.generation);
+            assert!(store
+                .reserve_solution_charge(
+                    fixture.input(1500),
+                    BudgetFixture::charge("stale-after-aba", "root", 30, 10)
+                )
+                .is_err());
+        })
+    });
+}
+
 #[cfg(feature = "storage-postgres")]
 pub(crate) fn seed_budget_for_transfer(store: &OrchestrationStateStore) -> TransferBudget {
     encrypted(|| {

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budget_tests.rs
@@ -1,0 +1,447 @@
+use super::*;
+use std::sync::{Arc, Barrier};
+
+struct BudgetFixture {
+    installation: InstallationFixture,
+    digest: String,
+}
+
+impl BudgetFixture {
+    fn new(
+        store: &OrchestrationStateStore,
+        customer: &str,
+        instance: &str,
+        concurrency: u32,
+    ) -> Self {
+        let mut installation = InstallationFixture::new(customer);
+        installation.customer.config.scope.instance_id = instance.into();
+        installation.customer.context.expires_at_ms = 10 * 86_400_000;
+        for policy in [
+            &mut installation.customer.blueprint.constraints,
+            &mut installation.customer.config.constraints,
+        ] {
+            policy.max_daily_cost_microusd = 100;
+            policy.max_tokens_per_run = 100;
+            policy.max_concurrent_runs = concurrency;
+        }
+        let (config, digest) = installation.seed(store);
+        store
+            .transition_solution_installation(
+                installation.input(&config, &digest),
+                None,
+                SolutionInstallationTransition::Begin,
+            )
+            .unwrap();
+        Self {
+            installation,
+            digest,
+        }
+    }
+
+    fn input(&self, now_ms: u64) -> SolutionBudgetInput<'_> {
+        SolutionBudgetInput {
+            verified: &self.installation.customer.context,
+            scope: &self.installation.customer.config.scope,
+            composition_sha256: &self.digest,
+            now_ms,
+        }
+    }
+
+    fn charge(id: &str, root: &str, cost: u64, tokens: u64) -> SolutionChargeIntent {
+        SolutionChargeIntent {
+            reservation_id: id.into(),
+            root_run_id: root.into(),
+            kind: SolutionChargeKind::Model,
+            route_revision: sha256(b"current-host-approved-model-and-price"),
+            maximum_tokens: tokens,
+            maximum_cost_microusd: Some(cost),
+            run_budget: SolutionRunBudget {
+                max_cost_microusd: 100,
+                max_tokens: 100,
+                max_requests: 4,
+            },
+        }
+    }
+}
+
+fn encrypted<T>(operation: impl FnOnce() -> T) -> T {
+    futures::executor::block_on(crate::encrypted_file_store::with_test_crypto_provider(
+        tandem_memory::MemoryCryptoProvider::local_key([0x73; 32]),
+        None,
+        async { operation() },
+    ))
+}
+
+#[test]
+#[serial]
+fn solution_budget_concurrent_workers_reserve_one_shared_ceiling() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = BudgetFixture::new(store, "a", "concurrent", 16);
+            let barrier = Arc::new(Barrier::new(8));
+            let results = std::thread::scope(|scope| {
+                let threads: Vec<_> = (0..8)
+                    .map(|index| {
+                        let barrier = barrier.clone();
+                        let fixture = &fixture;
+                        scope.spawn(move || {
+                            encrypted(|| {
+                                barrier.wait();
+                                store.reserve_solution_charge(
+                                    fixture.input(1500),
+                                    BudgetFixture::charge(
+                                        &format!("attempt-{index}"),
+                                        &format!("root-{index}"),
+                                        60,
+                                        10,
+                                    ),
+                                )
+                            })
+                        })
+                    })
+                    .collect();
+                threads
+                    .into_iter()
+                    .map(|thread| thread.join().unwrap())
+                    .collect::<Vec<_>>()
+            });
+            assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+            let winning = results
+                .into_iter()
+                .find_map(Result::ok)
+                .unwrap()
+                .reservation;
+            assert!(
+                !store
+                    .reserve_solution_charge(fixture.input(1500), winning.intent.clone())
+                    .unwrap()
+                    .newly_reserved
+            );
+            let settled = store
+                .settle_solution_charge(fixture.input(1501), &winning.intent, 5, 30)
+                .unwrap();
+            assert_eq!(
+                store
+                    .settle_solution_charge(fixture.input(1501), &winning.intent, 5, 30)
+                    .unwrap(),
+                settled
+            );
+            assert!(store
+                .settle_solution_charge(fixture.input(1501), &winning.intent, 0, 0)
+                .is_err());
+            assert!(store
+                .reserve_solution_charge(
+                    fixture.input(1501),
+                    BudgetFixture::charge("too-much", "new-root", 71, 1)
+                )
+                .is_err());
+            assert!(
+                store
+                    .reserve_solution_charge(
+                        fixture.input(1501),
+                        BudgetFixture::charge("remaining", "new-root", 70, 1)
+                    )
+                    .unwrap()
+                    .newly_reserved
+            );
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_children_retries_and_free_requests_share_root_limits() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = BudgetFixture::new(store, "a", "root-budget", 4);
+            let mut parent = BudgetFixture::charge("parent-attempt", "root", 0, 60);
+            parent.run_budget.max_requests = 2;
+            store
+                .reserve_solution_charge(fixture.input(1500), parent.clone())
+                .unwrap();
+            store
+                .settle_solution_charge(fixture.input(1500), &parent, 60, 0)
+                .unwrap();
+            let mut child = BudgetFixture::charge("child-retry", "root", 0, 41);
+            child.kind = SolutionChargeKind::Retry;
+            assert!(store
+                .reserve_solution_charge(fixture.input(1500), child.clone())
+                .is_err());
+            child.maximum_tokens = 40;
+            // A child asking for higher ceilings cannot widen the root's limits.
+            child.run_budget.max_tokens = 999;
+            child.run_budget.max_requests = 99;
+            store
+                .reserve_solution_charge(fixture.input(1500), child.clone())
+                .unwrap();
+            store
+                .settle_solution_charge(fixture.input(1500), &child, 20, 0)
+                .unwrap();
+            assert!(store
+                .reserve_solution_charge(
+                    fixture.input(1500),
+                    BudgetFixture::charge("third", "root", 0, 0)
+                )
+                .is_err());
+            let mut altered = parent;
+            altered.route_revision = sha256(b"another-route");
+            assert!(store
+                .reserve_solution_charge(fixture.input(1500), altered)
+                .is_err());
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_unknown_attempt_survives_midnight_and_restart_without_timeout_refund() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = BudgetFixture::new(store, "a", "uncertain", 1);
+            let first = BudgetFixture::charge("interrupted", "root", 80, 50);
+            store
+                .reserve_solution_charge(fixture.input(1500), first.clone())
+                .unwrap();
+            store.initialize().unwrap();
+            let tomorrow = 86_400_001;
+            assert!(store
+                .reserve_solution_charge(
+                    fixture.input(tomorrow),
+                    BudgetFixture::charge("next", "next-root", 1, 1)
+                )
+                .is_err());
+            assert!(
+                !store
+                    .reserve_solution_charge(fixture.input(tomorrow), first.clone())
+                    .unwrap()
+                    .newly_reserved
+            );
+            // Only a confirmed adapter result can release the outstanding charge.
+            store
+                .settle_solution_charge(fixture.input(tomorrow), &first, 40, 70)
+                .unwrap();
+            assert!(store
+                .reserve_solution_charge(
+                    fixture.input(1500),
+                    BudgetFixture::charge("clock-rollback", "next-root", 1, 1)
+                )
+                .is_err());
+            assert!(
+                store
+                    .reserve_solution_charge(
+                        fixture.input(tomorrow),
+                        BudgetFixture::charge("next", "next-root", 100, 1)
+                    )
+                    .unwrap()
+                    .newly_reserved
+            );
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_unknown_price_overrun_and_foreign_scope_fail_closed() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let a = BudgetFixture::new(store, "a", "same-id", 2);
+            let b = BudgetFixture::new(store, "b", "same-id", 2);
+            let mut unknown = BudgetFixture::charge("unknown", "root", 0, 1);
+            unknown.maximum_cost_microusd = None;
+            assert!(store
+                .reserve_solution_charge(a.input(1500), unknown)
+                .is_err());
+            let charge = BudgetFixture::charge("same-attempt", "root", 30, 10);
+            let a_reserved = store
+                .reserve_solution_charge(a.input(1500), charge.clone())
+                .unwrap();
+            assert!(
+                store
+                    .reserve_solution_charge(b.input(1500), charge.clone())
+                    .unwrap()
+                    .newly_reserved
+            );
+            let foreign = SolutionBudgetInput {
+                scope: b.input(1500).scope,
+                ..a.input(1500)
+            };
+            assert!(store
+                .settle_solution_charge(foreign, &charge, 10, 30)
+                .is_err());
+            let overrun = store
+                .settle_solution_charge(a.input(1500), &charge, 10, 120)
+                .unwrap();
+            assert!(matches!(
+                overrun.status,
+                SolutionChargeStatus::Settled {
+                    overrun: true,
+                    cost_microusd: 120,
+                    ..
+                }
+            ));
+            assert!(store
+                .reserve_solution_charge(
+                    a.input(86_400_001),
+                    BudgetFixture::charge("new-day", "root-b", 0, 0)
+                )
+                .is_err());
+            assert_eq!(
+                store
+                    .settle_solution_charge(a.input(1500), &charge, 10, 120)
+                    .unwrap(),
+                overrun
+            );
+            assert_eq!(
+                a_reserved.reservation.status,
+                SolutionChargeStatus::Reserved
+            );
+            assert_eq!(
+                store
+                    .settle_solution_charge(b.input(1500), &charge, 2, 10)
+                    .unwrap()
+                    .status,
+                SolutionChargeStatus::Settled {
+                    tokens: 2,
+                    cost_microusd: 10,
+                    overrun: false
+                }
+            );
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_partial_record_rollback_and_missing_heads_are_detected() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = BudgetFixture::new(store, "a", "corruption", 2);
+            let charge = BudgetFixture::charge("first", "root", 60, 20);
+            store
+                .reserve_solution_charge(fixture.input(1500), charge.clone())
+                .unwrap();
+            store
+                .settle_solution_charge(fixture.input(1500), &charge, 20, 40)
+                .unwrap();
+            store.with_connection(|connection| {
+            let ciphertext: String = connection.query_row("SELECT record_json FROM solution_budget_versions WHERE record_key='global' AND generation=1", [], |row| row.get(0))?;
+            assert!(crate::encrypted_file_store::is_encrypted_payload(&ciphertext));
+            connection.execute("UPDATE solution_budget_records SET generation=1,record_json=?1 WHERE record_key='global'", params![ciphertext])?;
+            Ok(())
+        }).unwrap();
+            assert!(store
+                .reserve_solution_charge(
+                    fixture.input(1500),
+                    BudgetFixture::charge("new", "root", 60, 20)
+                )
+                .is_err());
+            store
+                .with_connection(|connection| {
+                    connection.execute(
+                        "DELETE FROM solution_budget_records WHERE record_key='global'",
+                        [],
+                    )?;
+                    Ok(())
+                })
+                .unwrap();
+            assert!(store
+                .reserve_solution_charge(
+                    fixture.input(1500),
+                    BudgetFixture::charge("new", "root", 60, 20)
+                )
+                .is_err());
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_v7_upgrade_is_atomic_and_preserves_existing_installation() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = BudgetFixture::new(store, "a", "upgrade", 2);
+            let installation = fixture.installation.read(store);
+            store
+                .with_connection(|connection| {
+                    connection.execute_batch(
+                        "DROP TABLE solution_budget_records; DROP TABLE solution_budget_versions;
+                UPDATE schema_metadata SET schema_version=7;
+                CREATE TABLE solution_budget_versions (broken TEXT);",
+                    )?;
+                    Ok(())
+                })
+                .unwrap();
+            assert!(store.initialize().is_err());
+            store
+                .with_connection(|connection| {
+                    let version: i64 = connection.query_row(
+                        "SELECT schema_version FROM schema_metadata",
+                        [],
+                        |row| row.get(0),
+                    )?;
+                    assert_eq!(version, 7);
+                    connection.execute_batch("DROP TABLE solution_budget_versions;")?;
+                    Ok(())
+                })
+                .unwrap();
+            // If the failed migration partially created the current table, this
+            // retry fails. Both schema version and DDL must roll back together.
+            store.initialize().unwrap();
+            assert_eq!(fixture.installation.read(store), installation);
+            assert!(
+                store
+                    .reserve_solution_charge(
+                        fixture.input(1500),
+                        BudgetFixture::charge("after-upgrade", "root", 30, 10)
+                    )
+                    .unwrap()
+                    .newly_reserved
+            );
+        })
+    });
+}
+
+#[cfg(feature = "storage-postgres")]
+pub(crate) struct TransferBudget {
+    fixture: BudgetFixture,
+    reserved: SolutionChargeIntent,
+}
+
+#[cfg(feature = "storage-postgres")]
+pub(crate) fn seed_budget_for_transfer(store: &OrchestrationStateStore) -> TransferBudget {
+    encrypted(|| {
+        let fixture = BudgetFixture::new(store, "b", "budget-transfer", 2);
+        let first = BudgetFixture::charge("finished", "root-a", 60, 20);
+        store
+            .reserve_solution_charge(fixture.input(1500), first.clone())
+            .unwrap();
+        store
+            .settle_solution_charge(fixture.input(1500), &first, 10, 40)
+            .unwrap();
+        let reserved = BudgetFixture::charge("interrupted", "root-b", 60, 20);
+        store
+            .reserve_solution_charge(fixture.input(1500), reserved.clone())
+            .unwrap();
+        TransferBudget { fixture, reserved }
+    })
+}
+
+#[cfg(feature = "storage-postgres")]
+pub(crate) fn assert_budget_after_transfer(
+    store: &OrchestrationStateStore,
+    saved: &TransferBudget,
+) {
+    encrypted(|| {
+        let repeated = store
+            .reserve_solution_charge(saved.fixture.input(1500), saved.reserved.clone())
+            .unwrap();
+        assert!(!repeated.newly_reserved);
+        assert_eq!(repeated.reservation.status, SolutionChargeStatus::Reserved);
+        assert!(store
+            .reserve_solution_charge(
+                saved.fixture.input(1500),
+                BudgetFixture::charge("overspend", "third-root", 1, 1)
+            )
+            .is_err());
+    })
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 use tandem_solutions::{sha256, validate_customer_config_scope, CustomerScope};
 use tandem_types::VerifiedTenantContext;
 
-use super::{solution_budget_records as records, solution_installations, OrchestrationStateStore};
+use super::{
+    customer_configs, solution_budget_records as records, solution_installations,
+    OrchestrationStateStore,
+};
 use crate::stateful_runtime::backend::TransactionBehavior;
 
 const DAY_MS: u64 = 86_400_000;
@@ -145,6 +148,13 @@ impl OrchestrationStateStore {
             ensure!(
                 installation.composition_sha256 == input.composition_sha256,
                 "solution composition changed before budget reservation"
+            );
+            let configuration = customer_configs::load(&transaction, tenant, input.scope)?
+                .context("solution customer configuration missing")?;
+            ensure!(
+                configuration.version == installation.config_version
+                    && configuration.blueprint_sha256 == installation.plan.blueprint_sha256,
+                "solution configuration changed before budget reservation"
             );
             let policy = &installation.plan.constraints;
             let reservation_key = key("attempt", &intent.reservation_id);

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
@@ -1,0 +1,386 @@
+//! Atomic accounting, not dispatch authority. The existing authorized runtime
+//! must resolve current model/price limits and an authoritative root run before
+//! calling this store. A duplicate reservation never authorizes a second send.
+
+use anyhow::{ensure, Context};
+use serde::{Deserialize, Serialize};
+use tandem_solutions::{sha256, validate_customer_config_scope, CustomerScope};
+use tandem_types::VerifiedTenantContext;
+
+use super::{solution_budget_records as records, solution_installations, OrchestrationStateStore};
+use crate::stateful_runtime::backend::TransactionBehavior;
+
+const DAY_MS: u64 = 86_400_000;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SolutionChargeKind {
+    Model,
+    Retry,
+    Escalation,
+    Embedding,
+    Transcription,
+    Tool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SolutionRunBudget {
+    pub max_tokens: u64,
+    pub max_cost_microusd: u64,
+    pub max_requests: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SolutionChargeIntent {
+    /// One immutable physical attempt ID. Every retry uses another ID.
+    pub reservation_id: String,
+    /// Children inherit their runtime-owned root, never choose a fresh budget.
+    pub root_run_id: String,
+    pub kind: SolutionChargeKind,
+    pub route_revision: String,
+    pub maximum_tokens: u64,
+    /// None means unknown pricing; it is never interpreted as free.
+    pub maximum_cost_microusd: Option<u64>,
+    pub run_budget: SolutionRunBudget,
+}
+
+pub struct SolutionBudgetInput<'a> {
+    pub verified: &'a VerifiedTenantContext,
+    pub scope: &'a CustomerScope,
+    pub composition_sha256: &'a str,
+    pub now_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SolutionChargeStatus {
+    Reserved,
+    Settled {
+        tokens: u64,
+        cost_microusd: u64,
+        overrun: bool,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SolutionChargeReservation {
+    pub intent: SolutionChargeIntent,
+    pub composition_sha256: String,
+    pub period_start_ms: u64,
+    pub created_at_ms: u64,
+    pub status: SolutionChargeStatus,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SolutionBudgetReservationResult {
+    pub reservation: SolutionChargeReservation,
+    /// False means observe/reconcile the existing attempt; do not dispatch.
+    pub newly_reserved: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct Account {
+    committed_tokens: u64,
+    reserved_tokens: u64,
+    committed_cost: u64,
+    reserved_cost: u64,
+    outstanding: u64,
+    requests: u64,
+    last_observed_ms: u64,
+    overrun: bool,
+    root_limits: Option<SolutionRunBudget>,
+}
+
+fn sum(left: u64, right: u64) -> anyhow::Result<u64> {
+    left.checked_add(right)
+        .context("solution budget amount overflow")
+}
+
+fn reference(value: &str) -> anyhow::Result<()> {
+    ensure!(
+        !value.is_empty()
+            && value.len() <= 256
+            && value.trim() == value
+            && !value.chars().any(char::is_control),
+        "invalid solution charge identity"
+    );
+    Ok(())
+}
+
+fn key(prefix: &str, value: &str) -> String {
+    format!("{prefix}:{}", sha256(value.as_bytes()))
+}
+
+impl OrchestrationStateStore {
+    pub fn reserve_solution_charge(
+        &self,
+        input: SolutionBudgetInput<'_>,
+        intent: SolutionChargeIntent,
+    ) -> anyhow::Result<SolutionBudgetReservationResult> {
+        validate_customer_config_scope(input.verified, input.scope, input.now_ms)?;
+        reference(&intent.reservation_id)?;
+        reference(&intent.root_run_id)?;
+        ensure!(
+            intent.route_revision.len() == 64
+                && intent
+                    .route_revision
+                    .bytes()
+                    .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)),
+            "invalid reviewed charge route"
+        );
+        let cost = intent
+            .maximum_cost_microusd
+            .context("solution budget price unknown; dispatch blocked")?;
+        ensure!(
+            intent.run_budget.max_requests > 0,
+            "solution run request budget exhausted"
+        );
+        let tenant = &input.verified.tenant_context;
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let installation =
+                solution_installations::load(&transaction, input.verified, input.scope)?
+                    .context("solution installation missing")?;
+            ensure!(
+                installation.composition_sha256 == input.composition_sha256,
+                "solution composition changed before budget reservation"
+            );
+            let policy = &installation.plan.constraints;
+            let reservation_key = key("attempt", &intent.reservation_id);
+            let existing = records::load::<SolutionChargeReservation>(
+                &transaction,
+                tenant,
+                input.scope,
+                &reservation_key,
+            )?;
+            let (global_generation, mut global) =
+                records::load::<Account>(&transaction, tenant, input.scope, "global")?
+                    .unwrap_or_default();
+            ensure!(
+                !global.overrun,
+                "solution budget overrun requires reconciliation"
+            );
+            ensure!(
+                input.now_ms >= global.last_observed_ms,
+                "solution budget clock moved backwards"
+            );
+            if let Some((_, reservation)) = existing {
+                ensure!(
+                    reservation.intent == intent
+                        && reservation.composition_sha256 == input.composition_sha256,
+                    "solution charge ID already belongs to another intent"
+                );
+                transaction.commit()?;
+                return Ok(SolutionBudgetReservationResult {
+                    reservation,
+                    newly_reserved: false,
+                });
+            }
+            let day = input.now_ms / DAY_MS * DAY_MS;
+            let day_key = format!("day:{day}");
+            let root_key = key("root", &intent.root_run_id);
+            let (day_generation, mut daily) =
+                records::load::<Account>(&transaction, tenant, input.scope, &day_key)?
+                    .unwrap_or_default();
+            let (root_generation, mut root) =
+                records::load::<Account>(&transaction, tenant, input.scope, &root_key)?
+                    .unwrap_or_default();
+            let mut limits = intent.run_budget.clone();
+            limits.max_tokens = limits.max_tokens.min(policy.max_tokens_per_run);
+            limits.max_cost_microusd = limits.max_cost_microusd.min(policy.max_daily_cost_microusd);
+            if let Some(previous) = &root.root_limits {
+                limits.max_tokens = limits.max_tokens.min(previous.max_tokens);
+                limits.max_cost_microusd = limits.max_cost_microusd.min(previous.max_cost_microusd);
+                limits.max_requests = limits.max_requests.min(previous.max_requests);
+            }
+            ensure!(
+                global.outstanding < u64::from(policy.max_concurrent_runs),
+                "solution concurrent request budget exhausted"
+            );
+            ensure!(
+                sum(sum(daily.committed_cost, daily.reserved_cost)?, cost)?
+                    <= policy.max_daily_cost_microusd,
+                "solution daily cost budget exhausted"
+            );
+            ensure!(
+                sum(sum(root.committed_cost, root.reserved_cost)?, cost)?
+                    <= limits.max_cost_microusd,
+                "solution root run cost budget exhausted"
+            );
+            ensure!(
+                sum(
+                    sum(root.committed_tokens, root.reserved_tokens)?,
+                    intent.maximum_tokens
+                )? <= limits.max_tokens,
+                "solution root run token budget exhausted"
+            );
+            ensure!(
+                root.requests < u64::from(limits.max_requests),
+                "solution root run request budget exhausted"
+            );
+            root.root_limits = Some(limits);
+            for account in [&mut daily, &mut root] {
+                account.reserved_tokens = sum(account.reserved_tokens, intent.maximum_tokens)?;
+                account.reserved_cost = sum(account.reserved_cost, cost)?;
+                account.outstanding = sum(account.outstanding, 1)?;
+                account.requests = sum(account.requests, 1)?;
+            }
+            global.outstanding = sum(global.outstanding, 1)?;
+            global.last_observed_ms = input.now_ms;
+            let reservation = SolutionChargeReservation {
+                intent: intent.clone(),
+                composition_sha256: input.composition_sha256.into(),
+                period_start_ms: day,
+                created_at_ms: input.now_ms,
+                status: SolutionChargeStatus::Reserved,
+            };
+            records::save(
+                &transaction,
+                tenant,
+                input.scope,
+                "global",
+                global_generation,
+                global,
+            )?;
+            records::save(
+                &transaction,
+                tenant,
+                input.scope,
+                &day_key,
+                day_generation,
+                daily,
+            )?;
+            records::save(
+                &transaction,
+                tenant,
+                input.scope,
+                &root_key,
+                root_generation,
+                root,
+            )?;
+            records::save(
+                &transaction,
+                tenant,
+                input.scope,
+                &reservation_key,
+                0,
+                &reservation,
+            )?;
+            transaction.commit()?;
+            Ok(SolutionBudgetReservationResult {
+                reservation,
+                newly_reserved: true,
+            })
+        })
+    }
+
+    /// Only a trusted adapter with a confirmed result may settle an attempt.
+    /// An unknown outcome remains reserved, including across midnight/restart.
+    /// Reconciliation can record an actual overrun; it must not erase it to
+    /// pretend that an estimated price was a provider-side billing guarantee.
+    pub fn settle_solution_charge(
+        &self,
+        input: SolutionBudgetInput<'_>,
+        intent: &SolutionChargeIntent,
+        actual_tokens: u64,
+        actual_cost_microusd: u64,
+    ) -> anyhow::Result<SolutionChargeReservation> {
+        validate_customer_config_scope(input.verified, input.scope, input.now_ms)?;
+        let tenant = &input.verified.tenant_context;
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let reservation_key = key("attempt", &intent.reservation_id);
+            let (generation, mut reservation) = records::load::<SolutionChargeReservation>(
+                &transaction,
+                tenant,
+                input.scope,
+                &reservation_key,
+            )?
+            .context("solution charge reservation missing")?;
+            ensure!(
+                reservation.intent == *intent
+                    && reservation.composition_sha256 == input.composition_sha256,
+                "solution charge settlement intent mismatch"
+            );
+            let maximum_cost = intent
+                .maximum_cost_microusd
+                .context("reservation maximum cost missing")?;
+            let overrun =
+                actual_tokens > intent.maximum_tokens || actual_cost_microusd > maximum_cost;
+            let settled = SolutionChargeStatus::Settled {
+                tokens: actual_tokens,
+                cost_microusd: actual_cost_microusd,
+                overrun,
+            };
+            if reservation.status != SolutionChargeStatus::Reserved {
+                ensure!(
+                    reservation.status == settled,
+                    "solution charge already settled differently"
+                );
+                transaction.commit()?;
+                return Ok(reservation);
+            }
+            let (global_generation, mut global) =
+                records::load::<Account>(&transaction, tenant, input.scope, "global")?
+                    .context("solution global budget missing")?;
+            global.outstanding = global
+                .outstanding
+                .checked_sub(1)
+                .context("solution budget outstanding underflow")?;
+            global.overrun |= overrun;
+            global.last_observed_ms = global.last_observed_ms.max(input.now_ms);
+            for account_key in [
+                format!("day:{}", reservation.period_start_ms),
+                key("root", &intent.root_run_id),
+            ] {
+                let (account_generation, mut account) =
+                    records::load::<Account>(&transaction, tenant, input.scope, &account_key)?
+                        .context("solution charge account missing")?;
+                account.reserved_tokens = account
+                    .reserved_tokens
+                    .checked_sub(intent.maximum_tokens)
+                    .context("solution token reservation underflow")?;
+                account.reserved_cost = account
+                    .reserved_cost
+                    .checked_sub(maximum_cost)
+                    .context("solution cost reservation underflow")?;
+                account.outstanding = account
+                    .outstanding
+                    .checked_sub(1)
+                    .context("solution outstanding reservation underflow")?;
+                account.committed_tokens = sum(account.committed_tokens, actual_tokens)?;
+                account.committed_cost = sum(account.committed_cost, actual_cost_microusd)?;
+                account.overrun |= overrun;
+                records::save(
+                    &transaction,
+                    tenant,
+                    input.scope,
+                    &account_key,
+                    account_generation,
+                    account,
+                )?;
+            }
+            reservation.status = settled;
+            records::save(
+                &transaction,
+                tenant,
+                input.scope,
+                "global",
+                global_generation,
+                global,
+            )?;
+            records::save(
+                &transaction,
+                tenant,
+                input.scope,
+                &reservation_key,
+                generation,
+                &reservation,
+            )?;
+            transaction.commit()?;
+            Ok(reservation)
+        })
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installation_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installation_tests.rs
@@ -11,6 +11,9 @@ use super::customer_config_tests::Fixture;
 use super::*;
 use crate::stateful_runtime::backend::{params, Executor, ExecutorRaw};
 
+#[path = "solution_budget_tests.rs"]
+pub(super) mod budget_tests;
+
 #[derive(Clone)]
 struct InstallationFixture {
     customer: Fixture,
@@ -64,8 +67,8 @@ pub(super) fn assert_protected_installation_after_transfer(
             store
                 .with_connection(|connection| {
                     let count: i64 = connection.query_row(
-                        "SELECT COUNT(*) FROM solution_installation_versions WHERE org_id='org-b'",
-                        [],
+                        "SELECT COUNT(*) FROM solution_installation_versions WHERE org_id='org-b' AND instance_id=?1",
+                        [&expected.plan.instance_id],
                         |row| row.get(0),
                     )?;
                     assert_eq!(count, 2);
@@ -540,7 +543,9 @@ fn solution_installation_schema_upgrade_preserves_configuration() {
             .with_connection(|connection| {
                 connection.execute_batch(
                     "DROP TABLE solution_installation_versions;
-                DROP TABLE solution_installations; UPDATE schema_metadata SET schema_version=6;",
+                DROP TABLE solution_installations;
+                DROP TABLE solution_budget_records; DROP TABLE solution_budget_versions;
+                UPDATE schema_metadata SET schema_version=6;",
                 )?;
                 Ok(())
             })

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installations.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_installations.rs
@@ -90,7 +90,7 @@ pub enum SolutionInstallationTransition<'a> {
     },
 }
 
-fn load(
+pub(super) fn load(
     executor: &impl Executor,
     context: &VerifiedTenantContext,
     scope: &CustomerScope,

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/transfer.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/transfer.rs
@@ -1014,6 +1014,10 @@ mod tests {
             super::super::solution_installation_tests::seed_protected_installation_for_transfer(
                 &source,
             );
+        let budget =
+            super::super::solution_installation_tests::budget_tests::seed_budget_for_transfer(
+                &source,
+            );
 
         let request = StatefulBackendMigrationRequest {
             source_paths: source_paths.clone(),
@@ -1069,6 +1073,10 @@ mod tests {
         super::super::solution_installation_tests::assert_protected_installation_after_transfer(
             &round_trip,
             &installation,
+        );
+        super::super::solution_installation_tests::budget_tests::assert_budget_after_transfer(
+            &round_trip,
+            &budget,
         );
         round_trip
             .with_connection(|connection| {

--- a/docs/SOLUTION_BUDGET_ACCOUNTING.md
+++ b/docs/SOLUTION_BUDGET_ACCOUNTING.md
@@ -11,6 +11,10 @@ A trusted runtime caller supplies a verified tenant context, installation scope,
 current composition, an authoritative root run, a unique physical-attempt ID,
 reviewed route revision, bounded token/cost reservation and finite root-run
 limits. None of these approval inputs come from a browser, pack or model output.
+Admission also compares the current protected customer configuration generation
+and digest with the installation, in the same transaction. Saving a changed
+configuration blocks the old installation even after an A-to-B-to-A edit. Existing
+charge receipts can still settle after a configuration change.
 The store loads the current installation and intersects limits with its reviewed
 token, concurrency and daily cost ceilings. A root's limits can narrow but cannot
 grow during retries, escalation or child execution.

--- a/docs/SOLUTION_BUDGET_ACCOUNTING.md
+++ b/docs/SOLUTION_BUDGET_ACCOUNTING.md
@@ -1,0 +1,60 @@
+# Shared solution budget accounting
+
+Solution budgets now reserve and reconcile charges through the existing
+OrchestrationStateStore. SQLite's immediate transaction and PostgreSQL's existing
+schema-scoped writer lock update the whole accounting operation atomically.
+Schema version 8 adds protected current records and immutable version history;
+the existing backend transfer copies both. This is accounting infrastructure:
+it does not activate a solution or grant permission to send a provider request.
+
+A trusted runtime caller supplies a verified tenant context, installation scope,
+current composition, an authoritative root run, a unique physical-attempt ID,
+reviewed route revision, bounded token/cost reservation and finite root-run
+limits. None of these approval inputs come from a browser, pack or model output.
+The store loads the current installation and intersects limits with its reviewed
+token, concurrency and daily cost ceilings. A root's limits can narrow but cannot
+grow during retries, escalation or child execution.
+
+Each admission updates three accounts in one transaction: the solution's global
+outstanding count, its UTC-day cost account, and its root-run account. The global
+outstanding limit conservatively applies the configured concurrent-run ceiling
+to physical requests, including requests within one root. Children must inherit
+the runtime's root identifier. Model, retry, escalation, embedding, transcription
+and tool charges use the same accounting operation; their actual adapters still
+need to call it before dispatch.
+
+Money uses integer micro-USD. Unknown pricing blocks admission, rather than being
+treated as free. Estimates must bound the intended request; rates are deployment
+inputs, not hardcoded vendor prices. A duplicate attempt returns
+`newly_reserved: false` and must be observed/reconciled, never sent again. A changed
+intent cannot reuse that ID. Failed admission cannot partially consume counters.
+
+There is no timeout refund. After an unknown transport result or crash, cost and
+concurrency stay reserved even across midnight. A confirmed adapter receipt may
+settle once; an exact repeat is idempotent and conflicting settlements fail.
+Confirmed non-dispatch can settle at zero. Actual usage above the reservation is
+recorded honestly and halts further admissions, including on the next day, until
+an operator reconciliation protocol handles the overrun. That protocol is not
+implemented in this slice. An old reservation settles against its original UTC
+day. The global clock high-water mark rejects backwards-time admission.
+
+Protected record identity includes the tenant, installation, record key and
+generation. History detects deleting or rolling back only a current row. A full
+database snapshot rollback still needs the system's external recovery anchors;
+local version history alone does not prove off-host anti-rollback protection.
+Retention must preserve unsettled attempts and consumed root-run accounting;
+automatic pruning is intentionally absent.
+
+Regression tests use real SQLite and PostgreSQL transactions for simultaneous
+workers, root/child token and request limits, duplicate receipts, changed routes,
+unknown price, cross-tenant scopes, overruns, midnight/clock rollback, current-row
+deletion/rollback and atomic v7 migration. The existing encrypted backend round
+trip now carries a settled charge and an interrupted reservation, and verifies
+that the restored budget cannot spend the reserved remainder again.
+
+TAN-831 remains open. Required next work includes binding current credentials and
+model profiles to actual provider dispatch, proving output/retry bounds for each
+supported adapter, routing/modality/region/retention checks, finite escalation,
+usage reconciliation and telemetry, explicit activation, budget-blocked runtime
+state and UI/doctor evidence. These storage tests alone cannot prove that every
+provider/tool charge is routed through this accounting boundary.


### PR DESCRIPTION
Existing agent budgets count estimated usage after a call in memory. Add atomic pre-dispatch accounting to the existing OrchestrationStateStore: one transaction reserves the shared UTC-day cost, global outstanding-request count and root-run token/cost/request ceilings. Child/retry/escalation charges share the authoritative root; subsequent calls cannot widen its limits. Unknown pricing blocks admission. Money uses integer micro-USD.

A duplicate physical-attempt ID returns newly_reserved=false and never grants another send. Unknown outcomes retain cost and concurrency across restart and midnight until a confirmed result reconciles once. Conflicting settlements fail; actual overruns are recorded and halt further admission rather than pretending estimates guarantee provider billing. Schema8 adds protected current records and immutable history, including detection of current-row deletion/rollback. Whole-snapshot anti-rollback still requires external recovery anchors.

Seven new real SQLite/PostgreSQL regression tests cover simultaneous workers, root/child/retry limits, idempotent reconciliation, unknown cost, cross-tenant scope, overruns, midnight/clock rollback, protected-record rollback and atomic v7 migration. The existing encrypted backend round trip now includes both settled usage and an interrupted reservation and checks that restored state cannot spend the remainder again. The current configuration generation is checked in the same reservation transaction: changing configuration and restoring identical contents invalidates the old installation, while incurred charges can still settle. Exact signed head26fc4ca528025f4bb87f7e61b05fde08e468254b passed all six current workflows. Solution34014604299/storage101436111195 includes seven real-backend budget cases, encrypted transfer, native/service/HTTP checks and PostgreSQL clippy. Engine34014604297/workspace101436681289: 5,197 passed, 7 skipped. Hosted34014604323, ACME34014604340, Email34014604295 and Security34014604308 (enterprise release, engine container and aggregate) passed. The previous head exposed a concurrent DLP environment test race; the auth-isolation fixture now also uses the existing data_boundary_env serial lock while retaining its original lock. Exact-head guard marked this PR ready for review; no merge. Local Rustfmt and diff checks passed. No local Cargo.

Stacks on #1944 at 0512a2f965d6f23d2867f700ea325ff5f29f5c87. Current signed head: 26fc4ca528025f4bb87f7e61b05fde08e468254b. No remote PR merge. This is accounting infrastructure, not activation or dispatch authority. Trusted runtime integration must resolve actual model/credential/price bounds, inherit real root IDs, reserve before every billable attempt and settle from confirmed receipts. Provider/tool/embedding adapters, finite routing/escalation, modality/region/retention checks, budget-blocked UI/doctor state and full product/recovery acceptance remain. Overrun reconciliation and safe retention also remain. Do not close TAN-831 or merge automatically. See docs/SOLUTION_BUDGET_ACCOUNTING.md.