### PR TITLE
fix(providers): recheck current authority before adapter retries and fallback (TAN-834)

### DIFF
--- a/.github/workflows/hosted-policy.yml
+++ b/.github/workflows/hosted-policy.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           cache-profile: hosted-policy
           components: rustfmt
+      - name: Verify provider retry revocation and request isolation
+        run: cargo test -p tandem-providers --lib
       - name: Validate hosted policy contract
         run: cargo test -p tandem-enterprise-contract hosted_policy --lib
       - name: Verify global memory sharing and conservative schema upgrade
@@ -51,7 +53,5 @@ jobs:
         run: cargo test -p tandem-enterprise-server hosted_policy --lib
       - name: Verify native organization registry HTTP compatibility
         run: cargo test -p tandem-enterprise-server --test enterprise_http enterprise_org_unit
-      - name: Verify provider retry revocation and request isolation
-        run: cargo test -p tandem-providers --lib
       - name: Verify MCP revocation after readiness and before network dispatch
         run: cargo test -p tandem-runtime mcp --lib

--- a/crates/tandem-providers/src/dispatch_authority.rs
+++ b/crates/tandem-providers/src/dispatch_authority.rs
@@ -1,5 +1,6 @@
 //! Mutable request authority is checked after credential resolution and again
-//! after authentication recovery. It is never cached in a provider permit.
+//! after authentication recovery and before each adapter send, including retries.
+//! It is never cached in a provider permit.
 use std::future::Future;
 use std::sync::Arc;
 
@@ -39,4 +40,13 @@ pub(crate) async fn revalidate() -> anyhow::Result<()> {
         (authority.check)().await?;
     }
     Ok(())
+}
+
+/// Redirects would dispatch another request inside reqwest without an async
+/// authority check. Provider endpoints must be configured to their final URL.
+pub(crate) fn provider_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("provider HTTP client initialization failed")
 }

--- a/crates/tandem-providers/src/lib_parts/part01.rs
+++ b/crates/tandem-providers/src/lib_parts/part01.rs
@@ -1533,7 +1533,7 @@ fn build_providers(config: &AppConfig) -> Vec<Arc<dyn Provider>> {
                 .default_model
                 .clone()
                 .unwrap_or_else(|| "claude-sonnet-4-6".to_string()),
-            client: Client::new(),
+            client: dispatch_authority::provider_client(),
         }));
     }
     if let Some(cohere) = config.providers.get("cohere") {
@@ -1676,7 +1676,7 @@ fn add_openai_responses_provider(
                 context_window,
             }]
         },
-        client: Client::new(),
+        client: dispatch_authority::provider_client(),
     }));
 }
 

--- a/crates/tandem-providers/src/lib_parts/part02.rs
+++ b/crates/tandem-providers/src/lib_parts/part02.rs
@@ -43,6 +43,7 @@ impl Provider for OpenAICompatibleProvider {
                 req = req.bearer_auth(api_key);
             }
 
+            dispatch_authority::revalidate().await?;
             match req.send().await {
                 Ok(resp) => {
                     let status = resp.status();
@@ -200,6 +201,7 @@ impl Provider for OpenAICompatibleProvider {
                 req = req.bearer_auth(api_key);
             }
 
+            dispatch_authority::revalidate().await?;
             match req.send().await {
                 Ok(resp) => {
                     let status = resp.status();
@@ -554,6 +556,7 @@ impl Provider for OpenAIResponsesProvider {
                 req = req.bearer_auth(api_key);
             }
 
+            dispatch_authority::revalidate().await?;
             match req.send().await {
                 Ok(resp) => {
                     let status = resp.status();
@@ -723,6 +726,7 @@ impl Provider for OpenAIResponsesProvider {
                 req = req.bearer_auth(api_key);
             }
 
+            dispatch_authority::revalidate().await?;
             match req.send().await {
                 Ok(resp) => {
                     let status = resp.status();
@@ -1274,6 +1278,7 @@ impl OpenAIResponsesProvider {
         if let Some(api_key) = &self.api_key {
             req = req.bearer_auth(api_key);
         }
+        dispatch_authority::revalidate().await?;
         let resp = req.send().await?;
         let status = resp.status();
         if !status.is_success() {
@@ -1383,6 +1388,7 @@ impl Provider for AnthropicProvider {
         if let Some(key) = &self.api_key {
             req = req.header("x-api-key", key);
         }
+        dispatch_authority::revalidate().await?;
         let value = read_provider_response_json_limited(req.send().await?).await?;
         let text = value["content"][0]["text"]
             .as_str()
@@ -1423,6 +1429,7 @@ impl Provider for AnthropicProvider {
             req = req.header("x-api-key", key);
         }
 
+        dispatch_authority::revalidate().await?;
         let resp = req.send().await?;
         let mut bytes = resp.bytes_stream();
         let stream = try_stream! {
@@ -1516,6 +1523,7 @@ impl Provider for CohereProvider {
         if let Some(key) = &self.api_key {
             req = req.bearer_auth(key);
         }
+        dispatch_authority::revalidate().await?;
         let value = read_provider_response_json_limited(req.send().await?).await?;
         let text = value["message"]["content"][0]["text"]
             .as_str()

--- a/crates/tandem-providers/src/lib_parts/part04.rs
+++ b/crates/tandem-providers/src/lib_parts/part04.rs
@@ -2,6 +2,7 @@
 mod tests {
     use super::*;
     include!("../hosted_policy_tests.rs");
+    include!("../provider_attempt_tests.rs");
     use futures::StreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;

--- a/crates/tandem-providers/src/provider_attempt_tests.rs
+++ b/crates/tandem-providers/src/provider_attempt_tests.rs
@@ -1,0 +1,257 @@
+#[cfg(test)]
+mod provider_attempt_tests {
+    use super::*;
+
+    fn responses(base_url: String) -> OpenAIResponsesProvider {
+        OpenAIResponsesProvider {
+            id: "openai-codex".into(),
+            name: "Synthetic Responses".into(),
+            base_url,
+            api_key: None,
+            default_model: "synthetic-model".into(),
+            models: Vec::new(),
+            client: dispatch_authority::provider_client(),
+        }
+    }
+
+    fn compatible(base_url: String) -> OpenAICompatibleProvider {
+        OpenAICompatibleProvider {
+            id: "ollama".into(),
+            name: "Synthetic local transport".into(),
+            base_url,
+            api_key: None,
+            default_model: "synthetic-model".into(),
+        }
+    }
+
+    async fn invoke(provider: &dyn Provider, streaming: bool) -> anyhow::Result<String> {
+        if streaming {
+            let mut stream = provider
+                .stream(
+                    vec![ChatMessage {
+                        role: "user".into(),
+                        content: "synthetic request".into(),
+                        attachments: Vec::new(),
+                    }],
+                    None,
+                    ToolMode::None,
+                    None,
+                    SamplingParams::default(),
+                    CancellationToken::new(),
+                )
+                .await?;
+            while let Some(chunk) = stream.next().await {
+                chunk?;
+            }
+            Ok(String::new())
+        } else {
+            provider.complete("synthetic request", None).await
+        }
+    }
+
+    fn membership_guard(revoked: Arc<AtomicBool>) -> ProviderDispatchAuthority {
+        ProviderDispatchAuthority::new(move || {
+            let revoked = revoked.clone();
+            async move {
+                anyhow::ensure!(
+                    !revoked.load(Ordering::SeqCst),
+                    "synthetic membership revoked"
+                );
+                Ok(())
+            }
+        })
+    }
+
+    async fn reply(socket: &mut tokio::net::TcpStream, status: &str, body: &str) {
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+        socket.shutdown().await.unwrap();
+    }
+
+    async fn fallback_case(revoke: bool) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let provider = responses(format!("http://{}", listener.local_addr().unwrap()));
+        let revoked = Arc::new(AtomicBool::new(false));
+        let authority = membership_guard(revoked.clone());
+        let requests = Arc::new(AtomicUsize::new(0));
+        let observed = requests.clone();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let first = read_single_http_request(&mut socket).await;
+            observed.fetch_add(1, Ordering::SeqCst);
+            assert!(first.2.contains("\"stream\":false"));
+            revoked.store(revoke, Ordering::SeqCst);
+            reply(
+                &mut socket,
+                "400 Bad Request",
+                r#"{"detail":"Stream must be set to true"}"#,
+            )
+            .await;
+            if !revoke {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let second = read_single_http_request(&mut socket).await;
+                observed.fetch_add(1, Ordering::SeqCst);
+                assert!(second.2.contains("\"stream\":true"));
+                reply(
+                    &mut socket,
+                    "200 OK",
+                    "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Recovered\"}\n\ndata: [DONE]\n\n",
+                )
+                .await;
+            }
+            // Keep the listener alive until the caller finishes, so an extra
+            // request cannot be disguised as connection-refused retry behavior.
+            listener
+        });
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            authority.scope(provider.complete("synthetic request", None)),
+        )
+        .await
+        .expect("fallback must finish without another unauthorized send");
+        let listener = server.await.unwrap();
+        if revoke {
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("membership revoked"));
+            assert_eq!(requests.load(Ordering::SeqCst), 1);
+        } else {
+            assert_eq!(result.unwrap(), "Recovered");
+            assert_eq!(requests.load(Ordering::SeqCst), 2);
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn hosted_policy_adapter_fallback_rechecks_revoked_membership() {
+        fallback_case(true).await;
+    }
+
+    #[tokio::test]
+    async fn hosted_policy_adapter_fallback_preserves_permitted_requests() {
+        fallback_case(false).await;
+    }
+
+    #[tokio::test]
+    async fn hosted_policy_adapter_transport_retries_recheck_authority() {
+        // Refused local connections enter each real adapter's retry loop.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+        let providers: Vec<Box<dyn Provider>> =
+            vec![Box::new(compatible(url.clone())), Box::new(responses(url))];
+        for provider in providers {
+            for streaming in [false, true] {
+                let checks = Arc::new(AtomicUsize::new(0));
+                let count = checks.clone();
+                let authority = ProviderDispatchAuthority::new(move || {
+                    let count = count.clone();
+                    async move {
+                        anyhow::ensure!(
+                            count.fetch_add(1, Ordering::SeqCst) == 0,
+                            "synthetic membership revoked before retry"
+                        );
+                        Ok(())
+                    }
+                });
+                let result = tokio::time::timeout(
+                    Duration::from_secs(5),
+                    PROVIDER_PRIVATE_ENDPOINTS_ALLOWED
+                        .scope(true, authority.scope(invoke(provider.as_ref(), streaming))),
+                )
+                .await
+                .expect("retry check must terminate");
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("membership revoked"));
+                assert_eq!(checks.load(Ordering::SeqCst), 2);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn hosted_policy_adapter_denial_prevents_first_network_request() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let providers: Vec<Box<dyn Provider>> = vec![
+            Box::new(compatible(url.clone())),
+            Box::new(responses(url.clone())),
+            // A local proxy prevents any accidental Internet call if the
+            // Anthropic send barrier regresses, including its fixed HTTPS URL.
+            Box::new(AnthropicProvider {
+                api_key: None,
+                default_model: "synthetic-model".into(),
+                client: Client::builder()
+                    .proxy(reqwest::Proxy::all(&url).unwrap())
+                    .build()
+                    .unwrap(),
+            }),
+        ];
+        for provider in providers {
+            for streaming in [false, true] {
+                let authority = membership_guard(Arc::new(AtomicBool::new(true)));
+                let result = tokio::time::timeout(
+                    Duration::from_secs(3),
+                    PROVIDER_PRIVATE_ENDPOINTS_ALLOWED
+                        .scope(true, authority.scope(invoke(provider.as_ref(), streaming))),
+                )
+                .await
+                .expect("denied request must terminate before transport");
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("membership revoked"));
+            }
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn hosted_policy_adapter_redirect_cannot_bypass_dispatch_boundary() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut config = cfg(&["openai-codex"], Some("openai-codex"), false);
+        config.providers.get_mut("openai-codex").unwrap().base_url = Some(format!("http://{addr}"));
+        let registry = ProviderRegistry::new(config);
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            read_single_http_request(&mut socket).await;
+            socket
+                .write_all(
+                    format!("HTTP/1.1 307 Temporary Redirect\r\nLocation: http://{addr}/redirected\r\nContent-Length: 0\r\nConnection: close\r\n\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            socket.shutdown().await.unwrap();
+            listener
+        });
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            membership_guard(Arc::new(AtomicBool::new(false))).scope(
+                registry.complete_for_provider(Some("openai-codex"), "synthetic request", None),
+            ),
+        )
+        .await
+        .expect("redirect must return without following Location");
+        assert!(result.is_err());
+        let listener = server.await.unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+}

--- a/crates/tandem-providers/src/provider_attempt_tests.rs
+++ b/crates/tandem-providers/src/provider_attempt_tests.rs
@@ -224,7 +224,7 @@ mod provider_attempt_tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let mut config = cfg(&["openai-codex"], Some("openai-codex"), false);
-        config.providers.get_mut("openai-codex").unwrap().base_url = Some(format!("http://{addr}"));
+        config.providers.get_mut("openai-codex").unwrap().url = Some(format!("http://{addr}"));
         let registry = ProviderRegistry::new(config);
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();

--- a/crates/tandem-providers/src/provider_attempt_tests.rs
+++ b/crates/tandem-providers/src/provider_attempt_tests.rs
@@ -112,7 +112,10 @@ mod provider_attempt_tests {
         )
         .await
         .expect("fallback must finish without another unauthorized send");
-        let listener = server.await.unwrap();
+        let listener = tokio::time::timeout(Duration::from_secs(3), server)
+            .await
+            .expect("synthetic fallback server must finish")
+            .unwrap();
         if revoke {
             assert!(result
                 .unwrap_err()
@@ -223,9 +226,16 @@ mod provider_attempt_tests {
     async fn hosted_policy_adapter_redirect_cannot_bypass_dispatch_boundary() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let mut config = cfg(&["openai-codex"], Some("openai-codex"), false);
-        config.providers.get_mut("openai-codex").unwrap().url = Some(format!("http://{addr}"));
-        let registry = ProviderRegistry::new(config);
+        // The production Codex constructor deliberately ignores configured URL
+        // overrides. Use the existing fixture replacement with the production
+        // client factory, never a config field that could reach the Internet.
+        let registry = ProviderRegistry::new(cfg(&[], None, false));
+        registry
+            .replace_for_test(
+                vec![Arc::new(responses(format!("http://{addr}")))],
+                Some("openai-codex".into()),
+            )
+            .await;
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
             read_single_http_request(&mut socket).await;
@@ -247,7 +257,10 @@ mod provider_attempt_tests {
         .await
         .expect("redirect must return without following Location");
         assert!(result.is_err());
-        let listener = server.await.unwrap();
+        let listener = tokio::time::timeout(Duration::from_secs(3), server)
+            .await
+            .expect("synthetic redirect server must finish")
+            .unwrap();
         assert!(
             tokio::time::timeout(Duration::from_millis(50), listener.accept())
                 .await

--- a/docs/PROVIDER_ATTEMPT_AUTHORITY.md
+++ b/docs/PROVIDER_ATTEMPT_AUTHORITY.md
@@ -1,0 +1,30 @@
+# Provider attempt authority
+
+Hosted membership and policy can change after a provider call starts. The existing
+`ProviderDispatchAuthority` now revalidates immediately before each of the eight
+adapter HTTP send sites, as well as the existing registry and authentication
+recovery checks. This covers connection/timeout retries, OpenRouter affordability
+and tool-choice retries, and Responses completion-to-streaming fallback.
+
+Production Responses and Anthropic clients disable automatic HTTP redirects,
+matching the existing hardened compatible/Cohere clients. Configure a provider's
+final endpoint URL: a redirect must not create an additional content-bearing
+request within the HTTP client without a new authority check. This intentionally
+changes behavior for endpoints that previously depended on redirects.
+
+Unscoped standalone dispatch retains the existing no-authority behavior. Current
+allowed requests, OAuth recovery, exact-payload data-boundary permits and bounded
+adapter retries retain their existing paths. A policy denial propagates as its
+original error and is not treated as an authentication refresh opportunity.
+
+Five new tests use synthetic local HTTP connections: revocation before a Responses
+streaming fallback, the corresponding allowed fallback, all four adapter transport
+retry loops, denied first sends through compatible/Responses/Anthropic adapters,
+and redirect rejection through the production registry. Existing provider tests
+cover unscoped fallback, authentication recovery and concurrent authority isolation.
+
+This is an authorization barrier, not budget admission. A guard may be called
+multiple times for one request; it must not charge once per check. Durable budget
+reservation/reconciliation must bind actual attempts separately. This change also
+does not cancel a request already sent, revoke a provider-side job, or prove full
+Company Brain product, multi-user privacy or clean-host recovery acceptance.


### PR DESCRIPTION
A provider can retry a failed request or switch Responses completion to streaming after hosted membership or policy has changed. Registry checks previously authorized the adapter invocation, while its later sends reused that old decision. Revalidate the existing ProviderDispatchAuthority immediately before all eight concrete adapter send sites, including all four transport loops and the separate streamed-completion fallback.

Responses and Anthropic production clients also disable automatic redirects, matching compatible/Cohere clients: redirects otherwise create another request inside reqwest without a new asynchronous authority check. Operators must configure the final provider URL. Existing exact-payload egress permits and authentication recovery remain in place; unscoped calls retain the existing no-authority behavior.

Five new local HTTP tests cover revoked fallback, permitted fallback, all four real connection-failure retry loops, first-send denial for compatible/Responses/Anthropic, and redirect rejection through the production registry. Existing provider tests cover legacy fallback, credential recovery and concurrent scope isolation. The existing hosted-policy workflow runs the same full provider suite earlier so these failures surface before broader server checks. Exact signed head bd18f203d02dac19764fbe7f56adb6d2a7ccec10 passed the full cargo test -p tandem-providers --lib step in current Hosted policy 34013826444/job101434121357, including all five new cases and existing compatibility regressions. Rustfmt/diff checks passed; one independent source review found no concrete production bypass or unintended regression. All five current workflows passed: Hosted policy, Solution Contract, Engine CI, Email Approval Demo and Security Assurance including enterprise release and engine container. Engine workspace job101434744390 ran 5,195 tests: all passed, 7 skipped. Exact-head guard marked this PR ready for review; no merge. The initial redirect fixture incorrectly assumed Codex honors configured URL overrides; it now uses the existing test provider replacement with the production client factory and bounded mock-server joins. No local Cargo is available.

This is a narrow follow-up to current runtime revocation, stacked on #1944 at 0512a2f965d6f23d2867f700ea325ff5f29f5c87. No remote PR merge. It does not reserve budgets, cancel already-dispatched work, or complete TAN-834, TAN-831 or full Company Brain acceptance. A policy guard may execute multiple times per request and must not double-charge; actual spend admission/reconciliation remains separate work. See docs/PROVIDER_ATTEMPT_AUTHORITY.md. Do not merge automatically.