### PR TITLE
feat(solutions): charge physical provider attempts against durable budgets (TAN-831)

### DIFF
--- a/crates/tandem-providers/src/attempt_accounting.rs
+++ b/crates/tandem-providers/src/attempt_accounting.rs
@@ -1,0 +1,362 @@
+//! Optional trusted admission at actual adapter sends. This is deliberately
+//! separate from repeatable policy revalidation and never refunds on Drop.
+
+use std::{future::Future, sync::Arc};
+
+use anyhow::{ensure, Context};
+use futures::future::BoxFuture;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProviderProtocol {
+    ChatCompletions,
+    Responses,
+    Anthropic,
+    Cohere,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProviderAttempt {
+    pub provider_id: String,
+    pub model_id: String,
+    pub protocol: ProviderProtocol,
+    pub endpoint_sha256: String,
+    pub credential_sha256: String,
+    pub payload_sha256: String,
+    pub request_bytes: usize,
+    pub maximum_output_tokens: u32,
+    pub streaming: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfirmedProviderUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProviderAttemptOutcome {
+    Usage(ConfirmedProviderUsage),
+    /// Authority changed while durable admission was pending. The adapter has
+    /// not called send; this is the only automatic zero-charge reconciliation.
+    NotDispatched,
+}
+
+#[derive(Clone)]
+pub struct ProviderAttemptReceipt {
+    confirm:
+        Arc<dyn Fn(ProviderAttemptOutcome) -> BoxFuture<'static, anyhow::Result<()>> + Send + Sync>,
+}
+
+impl ProviderAttemptReceipt {
+    pub fn new<F, Fut>(confirm: F) -> Self
+    where
+        F: Fn(ProviderAttemptOutcome) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        Self {
+            confirm: Arc::new(move |usage| Box::pin(confirm(usage))),
+        }
+    }
+
+    pub(crate) async fn confirm(&self, usage: ConfirmedProviderUsage) -> anyhow::Result<()> {
+        (self.confirm)(ProviderAttemptOutcome::Usage(usage)).await
+    }
+}
+
+#[derive(Clone)]
+pub struct ProviderAttemptPolicy {
+    max_output_tokens: u32,
+    max_request_bytes: usize,
+    admit: Arc<
+        dyn Fn(ProviderAttempt) -> BoxFuture<'static, anyhow::Result<ProviderAttemptReceipt>>
+            + Send
+            + Sync,
+    >,
+}
+
+tokio::task_local! {
+    static ATTEMPT_POLICY: ProviderAttemptPolicy;
+}
+
+impl ProviderAttemptPolicy {
+    /// Host/runtime-owned caps and admission callback, never deserialized from
+    /// a browser request. Callback success must represent one durable new claim.
+    pub fn new<F, Fut>(
+        max_output_tokens: u32,
+        max_request_bytes: usize,
+        admit: F,
+    ) -> anyhow::Result<Self>
+    where
+        F: Fn(ProviderAttempt) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = anyhow::Result<ProviderAttemptReceipt>> + Send + 'static,
+    {
+        ensure!(
+            max_output_tokens > 0 && max_request_bytes > 0,
+            "provider request limits must be finite and positive"
+        );
+        Ok(Self {
+            max_output_tokens,
+            max_request_bytes,
+            admit: Arc::new(move |attempt| Box::pin(admit(attempt))),
+        })
+    }
+
+    pub fn scope<F: Future>(self, future: F) -> impl Future<Output = F::Output> {
+        ATTEMPT_POLICY.scope(self, Box::pin(future))
+    }
+}
+
+pub(crate) fn ensure_supported(provider: &dyn crate::Provider) -> anyhow::Result<()> {
+    ensure!(
+        ATTEMPT_POLICY.try_with(|_| ()).is_err() || provider.supports_attempt_accounting(),
+        "provider does not support bounded attempt accounting"
+    );
+    Ok(())
+}
+
+fn output_field(protocol: ProviderProtocol) -> &'static str {
+    match protocol {
+        ProviderProtocol::Responses => "max_output_tokens",
+        _ => "max_tokens",
+    }
+}
+
+pub(crate) fn bound_request(body: &mut Value, protocol: ProviderProtocol) -> anyhow::Result<()> {
+    let Ok(policy) = ATTEMPT_POLICY.try_with(Clone::clone) else {
+        return Ok(());
+    };
+    let field = output_field(protocol);
+    let limit = match body.get(field) {
+        None => u64::from(policy.max_output_tokens),
+        Some(value) => value
+            .as_u64()
+            .filter(|value| *value > 0)
+            .context("invalid provider output token limit")?
+            .min(u64::from(policy.max_output_tokens)),
+    };
+    body[field] = Value::from(limit);
+    Ok(())
+}
+
+fn digest(parts: &[&[u8]]) -> String {
+    let mut digest = Sha256::new();
+    for part in parts {
+        digest.update((part.len() as u64).to_be_bytes());
+        digest.update(part);
+    }
+    format!("{:x}", digest.finalize())
+}
+
+pub(crate) async fn before_send(
+    request: &reqwest::RequestBuilder,
+    provider_id: &str,
+    model_id: &str,
+    protocol: ProviderProtocol,
+) -> anyhow::Result<Option<ProviderAttemptReceipt>> {
+    let Ok(policy) = ATTEMPT_POLICY.try_with(Clone::clone) else {
+        return Ok(None);
+    };
+    // Inspect the bytes and headers of the already-built request, after auth
+    // overrides and sampling. Neither raw prompt nor key leaves this boundary.
+    let built = request
+        .try_clone()
+        .context("uninspectable provider request")?
+        .build()?;
+    let bytes = built
+        .body()
+        .and_then(|body| body.as_bytes())
+        .context("unbounded provider request body")?;
+    ensure!(
+        bytes.len() <= policy.max_request_bytes,
+        "provider request exceeds reviewed byte limit"
+    );
+    let body: Value = serde_json::from_slice(bytes)?;
+    ensure!(
+        body.get("model").and_then(Value::as_str) == Some(model_id),
+        "provider model binding changed"
+    );
+    let maximum_output_tokens = body
+        .get(output_field(protocol))
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .filter(|value| *value > 0)
+        .context("provider output is not bounded")?;
+    ensure!(
+        maximum_output_tokens <= policy.max_output_tokens,
+        "provider output exceeds reviewed limit"
+    );
+    let headers = built.headers();
+    let authorization = headers
+        .get("authorization")
+        .map(|value| value.as_bytes())
+        .unwrap_or_default();
+    let api_key = headers
+        .get("x-api-key")
+        .map(|value| value.as_bytes())
+        .unwrap_or_default();
+    let account = headers
+        .get("chatgpt-account-id")
+        .map(|value| value.as_bytes())
+        .unwrap_or_default();
+    let attempt = ProviderAttempt {
+        provider_id: provider_id.into(),
+        model_id: model_id.into(),
+        protocol,
+        endpoint_sha256: digest(&[b"provider-endpoint-v1", built.url().as_str().as_bytes()]),
+        credential_sha256: digest(&[b"provider-credential-v1", authorization, api_key, account]),
+        payload_sha256: digest(&[b"provider-payload-v1", bytes]),
+        request_bytes: bytes.len(),
+        maximum_output_tokens,
+        streaming: body.get("stream").and_then(Value::as_bool).unwrap_or(false),
+    };
+    let receipt = (policy.admit)(attempt).await?;
+    if let Err(error) = crate::dispatch_authority::revalidate().await {
+        (receipt.confirm)(ProviderAttemptOutcome::NotDispatched).await?;
+        return Err(error);
+    }
+    Ok(Some(receipt))
+}
+
+/// Legacy telemetry parsers use missing=>zero defaults; billing must not. Missing,
+/// malformed or overflowing counters leave the attempt unresolved, never free.
+pub(crate) fn confirmed_usage(
+    value: &Value,
+    protocol: ProviderProtocol,
+) -> Option<ConfirmedProviderUsage> {
+    let usage = value.get("usage")?;
+    if let Some(extra) = usage.get("server_tool_use") {
+        let fields = extra.as_object()?;
+        if fields
+            .values()
+            .any(|value| !value.is_null() && value.as_u64() != Some(0))
+        {
+            return None;
+        }
+    }
+    let (input, output) = match protocol {
+        ProviderProtocol::ChatCompletions => {
+            (usage.get("prompt_tokens")?, usage.get("completion_tokens")?)
+        }
+        ProviderProtocol::Cohere => {
+            let billed = usage.get("billed_units")?;
+            (billed.get("input_tokens")?, billed.get("output_tokens")?)
+        }
+        _ => (usage.get("input_tokens")?, usage.get("output_tokens")?),
+    };
+    let mut input_tokens = input.as_u64()?;
+    let output_tokens = output.as_u64()?;
+    if protocol == ProviderProtocol::Anthropic {
+        for field in ["cache_creation_input_tokens", "cache_read_input_tokens"] {
+            if let Some(value) = usage.get(field) {
+                input_tokens = input_tokens.checked_add(value.as_u64()?)?;
+            }
+        }
+    }
+    let sum = input_tokens.checked_add(output_tokens)?;
+    let total_tokens = if protocol == ProviderProtocol::Cohere {
+        let billed = usage.get("billed_units")?.as_object()?;
+        // Non-token billing requires its own approved tariff and receipt type.
+        if billed.iter().any(|(name, value)| {
+            !matches!(name.as_str(), "input_tokens" | "output_tokens")
+                && !value.is_null()
+                && value.as_u64() != Some(0)
+        }) {
+            return None;
+        }
+        let tokens = usage.get("tokens")?;
+        tokens
+            .get("input_tokens")?
+            .as_u64()?
+            .checked_add(tokens.get("output_tokens")?.as_u64()?)?
+            .max(sum)
+    } else {
+        match usage.get("total_tokens") {
+            None => sum,
+            Some(total) => total.as_u64().filter(|total| *total >= sum)?,
+        }
+    };
+    Some(ConfirmedProviderUsage {
+        input_tokens,
+        output_tokens,
+        total_tokens,
+    })
+}
+
+#[derive(Default)]
+pub(crate) struct StreamingUsage {
+    latest: Option<ConfirmedProviderUsage>,
+    high_water: Option<ConfirmedProviderUsage>,
+    conflicting: bool,
+}
+
+impl StreamingUsage {
+    pub(crate) fn observe(&mut self, value: &Value, protocol: ProviderProtocol) {
+        if value.get("usage").is_none_or(Value::is_null) {
+            return;
+        }
+        let next = confirmed_usage(value, protocol);
+        if let (Some(previous), Some(next)) = (&self.high_water, &next) {
+            self.conflicting |= next.input_tokens < previous.input_tokens
+                || next.output_tokens < previous.output_tokens
+                || next.total_tokens < previous.total_tokens;
+        }
+        if next.is_some() {
+            self.high_water = next.clone();
+        }
+        self.latest = next;
+    }
+
+    pub(crate) async fn confirm(
+        &mut self,
+        receipt: &Option<ProviderAttemptReceipt>,
+    ) -> anyhow::Result<()> {
+        if !self.conflicting {
+            if let (Some(receipt), Some(usage)) = (receipt, self.latest.take()) {
+                receipt.confirm(usage).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) async fn confirm_responses_sse(
+    receipt: &Option<ProviderAttemptReceipt>,
+    text: &str,
+) -> anyhow::Result<()> {
+    if let Some(receipt) = receipt {
+        let mut terminal = None;
+        for line in text.lines() {
+            let Some(data) = line.strip_prefix("data: ") else {
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<Value>(data) else {
+                continue;
+            };
+            if value.get("type").and_then(Value::as_str) == Some("response.completed") {
+                let usage = confirmed_usage(&value["response"], ProviderProtocol::Responses);
+                if let Some(previous) = &terminal {
+                    ensure!(previous == &usage, "conflicting provider usage receipts");
+                }
+                terminal = Some(usage);
+            }
+        }
+        if let Some(Some(usage)) = terminal {
+            receipt.confirm(usage).await?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) async fn confirm_json(
+    receipt: &Option<ProviderAttemptReceipt>,
+    value: &Value,
+    protocol: ProviderProtocol,
+) -> anyhow::Result<()> {
+    if let (Some(receipt), Some(usage)) = (receipt, confirmed_usage(value, protocol)) {
+        receipt.confirm(usage).await?;
+    }
+    Ok(())
+}

--- a/crates/tandem-providers/src/attempt_accounting.rs
+++ b/crates/tandem-providers/src/attempt_accounting.rs
@@ -275,7 +275,9 @@ pub(crate) fn confirmed_usage(
     } else {
         match usage.get("total_tokens") {
             None => sum,
-            Some(total) => total.as_u64().filter(|total| *total >= sum)?,
+            // A larger total contains tokens with no supported input/output
+            // tariff classification. Do not release their reserved cost.
+            Some(total) => total.as_u64().filter(|total| *total == sum)?,
         }
     };
     Some(ConfirmedProviderUsage {

--- a/crates/tandem-providers/src/attempt_accounting_tests.rs
+++ b/crates/tandem-providers/src/attempt_accounting_tests.rs
@@ -1,0 +1,297 @@
+#[cfg(test)]
+mod attempt_accounting_tests {
+    use super::provider_attempt_tests::{compatible, reply, responses};
+    use super::*;
+
+    fn recording_policy(
+        attempts: Arc<Mutex<Vec<ProviderAttempt>>>,
+        outcomes: Arc<Mutex<Vec<(usize, ProviderAttemptOutcome)>>>,
+        limit: usize,
+    ) -> ProviderAttemptPolicy {
+        ProviderAttemptPolicy::new(10, 4096, move |attempt| {
+            let mut captured = attempts.lock().unwrap();
+            let index = captured.len();
+            captured.push(attempt);
+            let outcomes = outcomes.clone();
+            async move {
+                anyhow::ensure!(index < limit, "synthetic attempt budget exhausted");
+                Ok(ProviderAttemptReceipt::new(move |outcome| {
+                    outcomes.lock().unwrap().push((index, outcome));
+                    async { Ok(()) }
+                }))
+            }
+        })
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn attempt_accounting_bounds_actual_complete_and_records_confirmed_usage() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let provider = compatible(format!("http://{}", listener.local_addr().unwrap()));
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let (_, _, body) = read_single_http_request(&mut socket).await;
+            let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(body["max_tokens"], 10);
+            reply(&mut socket, "200 OK", r#"{"choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}"#).await;
+        });
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let policy = recording_policy(attempts.clone(), outcomes.clone(), 1);
+        let output = PROVIDER_PRIVATE_ENDPOINTS_ALLOWED
+            .scope(
+                true,
+                policy.scope(provider.complete("synthetic private prompt", None)),
+            )
+            .await
+            .unwrap();
+        assert_eq!(output, "ok");
+        tokio::time::timeout(Duration::from_secs(3), server)
+            .await
+            .unwrap()
+            .unwrap();
+        let attempts = attempts.lock().unwrap();
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].maximum_output_tokens, 10);
+        assert!(!format!("{:?}", attempts[0]).contains("synthetic private prompt"));
+        assert_eq!(
+            *outcomes.lock().unwrap(),
+            vec![(
+                0,
+                ProviderAttemptOutcome::Usage(ConfirmedProviderUsage {
+                    input_tokens: 2,
+                    output_tokens: 3,
+                    total_tokens: 5
+                })
+            )]
+        );
+    }
+
+    async fn stream_case(drop_after_first: bool) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let provider = compatible(format!("http://{}", listener.local_addr().unwrap()));
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            read_single_http_request(&mut socket).await;
+            reply(&mut socket, "200 OK", concat!(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n",
+                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+                "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":3}}\n\n",
+                "data: [DONE]\n\n"
+            )).await;
+        });
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let policy = recording_policy(attempts.clone(), outcomes.clone(), 1);
+        // Receipt observation must work after the task-local policy future ends.
+        let mut stream = PROVIDER_PRIVATE_ENDPOINTS_ALLOWED
+            .scope(
+                true,
+                policy.scope(provider.stream(
+                    vec![ChatMessage {
+                        role: "user".into(),
+                        content: "synthetic".into(),
+                        attachments: Vec::new(),
+                    }],
+                    None,
+                    ToolMode::None,
+                    None,
+                    SamplingParams::default(),
+                    CancellationToken::new(),
+                )),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            stream.next().await.unwrap().unwrap(),
+            StreamChunk::TextDelta(_)
+        ));
+        if !drop_after_first {
+            while let Some(chunk) = stream.next().await {
+                chunk.unwrap();
+            }
+        }
+        drop(stream);
+        tokio::time::timeout(Duration::from_secs(3), server)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(attempts.lock().unwrap().len(), 1);
+        assert_eq!(
+            outcomes.lock().unwrap().len(),
+            usize::from(!drop_after_first)
+        );
+    }
+
+    #[tokio::test]
+    async fn attempt_accounting_receipt_survives_stream_policy_scope_end() {
+        stream_case(false).await;
+    }
+
+    #[tokio::test]
+    async fn attempt_accounting_dropped_stream_never_refunds_unknown_usage() {
+        stream_case(true).await;
+    }
+
+    #[tokio::test]
+    async fn attempt_accounting_fallback_requires_another_admission() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let provider = responses(format!("http://{}", listener.local_addr().unwrap()));
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let (_, _, body) = read_single_http_request(&mut socket).await;
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&body).unwrap()["max_output_tokens"],
+                10
+            );
+            reply(
+                &mut socket,
+                "400 Bad Request",
+                r#"{"detail":"Stream must be set to true"}"#,
+            )
+            .await;
+            listener
+        });
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let error = recording_policy(attempts.clone(), outcomes.clone(), 1)
+            .scope(provider.complete("synthetic", None))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("budget exhausted"));
+        let listener = tokio::time::timeout(Duration::from_secs(3), server)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err()
+        );
+        assert_eq!(attempts.lock().unwrap().len(), 2);
+        assert!(!attempts.lock().unwrap()[0].streaming);
+        assert!(attempts.lock().unwrap()[1].streaming);
+        assert!(
+            outcomes.lock().unwrap().is_empty(),
+            "HTTP error is not proof of zero charge"
+        );
+    }
+
+    #[tokio::test]
+    async fn attempt_accounting_revoked_after_admission_confirms_not_dispatched() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let provider = responses(format!("http://{}", listener.local_addr().unwrap()));
+        let revoked = Arc::new(AtomicBool::new(false));
+        let check = revoked.clone();
+        let authority = ProviderDispatchAuthority::new(move || {
+            let check = check.clone();
+            async move {
+                anyhow::ensure!(!check.load(Ordering::SeqCst), "revoked during admission");
+                Ok(())
+            }
+        });
+        let outcomes = Arc::new(Mutex::new(Vec::new()));
+        let captured = outcomes.clone();
+        let policy = ProviderAttemptPolicy::new(10, 4096, move |_| {
+            revoked.store(true, Ordering::SeqCst);
+            let captured = captured.clone();
+            async move {
+                Ok(ProviderAttemptReceipt::new(move |outcome| {
+                    captured.lock().unwrap().push(outcome);
+                    async { Ok(()) }
+                }))
+            }
+        })
+        .unwrap();
+        let error = authority
+            .scope(policy.scope(provider.complete("synthetic", None)))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("revoked"));
+        assert_eq!(
+            *outcomes.lock().unwrap(),
+            vec![ProviderAttemptOutcome::NotDispatched]
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn attempt_accounting_unknown_adapter_is_rejected_before_legacy_dispatch() {
+        let registry = ProviderRegistry::new(AppConfig::default());
+        let policy = ProviderAttemptPolicy::new(10, 100, |_| async {
+            panic!("unaccounted adapter cannot reach admission")
+        })
+        .unwrap();
+        assert!(policy
+            .scope(registry.complete_for_provider(Some("local"), "synthetic", None))
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("does not support"));
+        assert!(registry
+            .complete_for_provider(Some("local"), "synthetic", None)
+            .await
+            .is_ok());
+    }
+
+    #[test]
+    fn attempt_accounting_missing_overflowing_or_extra_billable_units_stay_unknown() {
+        use attempt_accounting::confirmed_usage;
+        for value in [
+            json!({}),
+            json!({"usage":{}}),
+            json!({"usage":{"prompt_tokens":0}}),
+            json!({"usage":{"prompt_tokens":u64::MAX,"completion_tokens":1}}),
+            json!({"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":1}}),
+        ] {
+            assert!(confirmed_usage(&value, ProviderProtocol::ChatCompletions).is_none());
+        }
+        assert_eq!(
+            confirmed_usage(
+                &json!({"usage":{"input_tokens":2,"cache_creation_input_tokens":4,
+            "cache_read_input_tokens":5,"output_tokens":3}}),
+                ProviderProtocol::Anthropic
+            )
+            .unwrap()
+            .total_tokens,
+            14
+        );
+        let cohere = json!({"usage":{"billed_units":{"input_tokens":2,"output_tokens":3},
+            "tokens":{"input_tokens":7,"output_tokens":4}}});
+        let usage = confirmed_usage(&cohere, ProviderProtocol::Cohere).unwrap();
+        assert_eq!(
+            (usage.input_tokens, usage.output_tokens, usage.total_tokens),
+            (2, 3, 11)
+        );
+        let mut extra = cohere;
+        extra["usage"]["billed_units"]["search_units"] = json!(1);
+        assert!(confirmed_usage(&extra, ProviderProtocol::Cohere).is_none());
+    }
+
+    #[tokio::test]
+    async fn attempt_accounting_stream_cannot_settle_incomplete_or_decreasing_usage() {
+        for ending in [
+            json!({"usage": {}}),
+            json!({"usage": {"prompt_tokens": 1, "completion_tokens": 1}}),
+        ] {
+            let outcomes = Arc::new(Mutex::new(Vec::new()));
+            let captured = outcomes.clone();
+            let receipt = Some(ProviderAttemptReceipt::new(move |outcome| {
+                captured.lock().unwrap().push(outcome);
+                async { Ok(()) }
+            }));
+            let mut usage = attempt_accounting::StreamingUsage::default();
+            usage.observe(
+                &json!({"usage": {"prompt_tokens": 2, "completion_tokens": 3}}),
+                ProviderProtocol::ChatCompletions,
+            );
+            usage.observe(&ending, ProviderProtocol::ChatCompletions);
+            usage.confirm(&receipt).await.unwrap();
+            assert!(outcomes.lock().unwrap().is_empty());
+        }
+    }
+}

--- a/crates/tandem-providers/src/attempt_accounting_tests.rs
+++ b/crates/tandem-providers/src/attempt_accounting_tests.rs
@@ -247,6 +247,7 @@ mod attempt_accounting_tests {
             json!({"usage":{"prompt_tokens":0}}),
             json!({"usage":{"prompt_tokens":u64::MAX,"completion_tokens":1}}),
             json!({"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":1}}),
+            json!({"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":100}}),
         ] {
             assert!(confirmed_usage(&value, ProviderProtocol::ChatCompletions).is_none());
         }

--- a/crates/tandem-providers/src/lib.rs
+++ b/crates/tandem-providers/src/lib.rs
@@ -11,3 +11,8 @@ include!("lib_parts/part01.rs");
 include!("lib_parts/part02.rs");
 include!("lib_parts/part03.rs");
 include!("lib_parts/part04.rs");
+mod attempt_accounting;
+pub use attempt_accounting::{
+    ConfirmedProviderUsage, ProviderAttempt, ProviderAttemptOutcome, ProviderAttemptPolicy,
+    ProviderAttemptReceipt, ProviderProtocol,
+};

--- a/crates/tandem-providers/src/lib_parts/part01.rs
+++ b/crates/tandem-providers/src/lib_parts/part01.rs
@@ -838,6 +838,9 @@ pub struct TokenUsage {
 }
 #[async_trait]
 pub trait Provider: Send + Sync {
+    /// Only adapters with admission on every actual send may run in a budget scope.
+    fn supports_attempt_accounting(&self) -> bool { false }
+
     /// Unknown adapters remain usable by legacy callers, but cannot be
     /// approved for solution installation until they describe their route.
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
@@ -1166,6 +1169,7 @@ impl ProviderRegistry {
         model_id: Option<&str>,
     ) -> anyhow::Result<String> {
         let provider = self.select_provider(provider_id).await?;
+        attempt_accounting::ensure_supported(provider.as_ref())?;
         let resolved_provider_id = provider.info().id;
         let auth_override = self
             .auth_override_for_provider(resolved_provider_id.as_str())
@@ -1225,6 +1229,7 @@ impl ProviderRegistry {
         model_id: Option<&str>,
     ) -> anyhow::Result<ResolvedProviderRoute> {
         let provider = self.select_provider(provider_id).await?;
+        attempt_accounting::ensure_supported(provider.as_ref())?;
         Ok(ResolvedProviderRoute {
             provider_id: provider.info().id,
             model_id: model_id.map(str::to_string),
@@ -1307,6 +1312,7 @@ impl ProviderRegistry {
         cancel: CancellationToken,
     ) -> anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<StreamChunk>> + Send>>> {
         let provider = self.select_provider(provider_id).await?;
+        attempt_accounting::ensure_supported(provider.as_ref())?;
         let resolved_provider_id = provider.info().id;
         let auth_override = self
             .auth_override_for_provider(resolved_provider_id.as_str())

--- a/crates/tandem-providers/src/lib_parts/part02.rs
+++ b/crates/tandem-providers/src/lib_parts/part02.rs
@@ -1,5 +1,6 @@
 #[async_trait]
 impl Provider for OpenAICompatibleProvider {
+    fn supports_attempt_accounting(&self) -> bool { true }
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
         Some(ProviderInstallationMetadata::network(&self.id, &self.base_url))
     }
@@ -23,17 +24,20 @@ impl Provider for OpenAICompatibleProvider {
             .unwrap_or(self.default_model.as_str());
         let url = format!("{}/chat/completions", self.base_url);
         let target = resolve_provider_request_target(&url, &self.id).await?;
+        let mut accepted_receipt = None;
         let mut response_opt = None;
         let mut last_send_err: Option<reqwest::Error> = None;
         let mut last_error: Option<anyhow::Error> = None;
         let mut max_tokens = provider_max_tokens_for(&self.id);
         for attempt in 0..3 {
-            let mut req = target.client.post(target.url.clone()).json(&json!({
+            let mut body = json!({
                 "model": model,
                 "messages": [{"role":"user","content": prompt}],
                 "stream": false,
                 "max_tokens": max_tokens,
-            }));
+            });
+            attempt_accounting::bound_request(&mut body, ProviderProtocol::ChatCompletions)?;
+            let mut req = target.client.post(target.url.clone()).json(&body);
             if self.id == "openrouter" {
                 req = req
                     .header("HTTP-Referer", "https://tandem.ac")
@@ -44,6 +48,7 @@ impl Provider for OpenAICompatibleProvider {
             }
 
             dispatch_authority::revalidate().await?;
+            let attempt_receipt = attempt_accounting::before_send(&req, &self.id, model, ProviderProtocol::ChatCompletions).await?;
             match req.send().await {
                 Ok(resp) => {
                     let status = resp.status();
@@ -62,6 +67,7 @@ impl Provider for OpenAICompatibleProvider {
                         last_error = Some(openai_response_error(status, &text));
                         break;
                     }
+                    accepted_receipt = attempt_receipt;
                     response_opt = Some(resp);
                     break;
                 }
@@ -100,6 +106,7 @@ impl Provider for OpenAICompatibleProvider {
             );
         };
         let value = read_provider_response_json_limited(response).await?;
+        attempt_accounting::confirm_json(&accepted_receipt, &value, ProviderProtocol::ChatCompletions).await?;
 
         if let Some(detail) = extract_openai_error(&value) {
             anyhow::bail!(detail);
@@ -179,6 +186,7 @@ impl Provider for OpenAICompatibleProvider {
             body["tool_choice"] = json!(openai_tool_choice(&tool_mode));
         }
         apply_openai_chat_sampling(&mut body, &self.id, model, sampling);
+        attempt_accounting::bound_request(&mut body, ProviderProtocol::ChatCompletions)?;
         // A `max_tokens` override changes `body["max_tokens"]`; keep the local
         // value (used by the OpenRouter affordability retry below) in sync so
         // the "can only afford N" filter compares against the requested cap.
@@ -186,6 +194,7 @@ impl Provider for OpenAICompatibleProvider {
             max_tokens = requested as u32;
         }
 
+        let mut accepted_receipt = None;
         let mut resp_opt = None;
         let mut last_send_err: Option<reqwest::Error> = None;
         let mut last_error: Option<anyhow::Error> = None;
@@ -202,6 +211,7 @@ impl Provider for OpenAICompatibleProvider {
             }
 
             dispatch_authority::revalidate().await?;
+            let attempt_receipt = attempt_accounting::before_send(&req, &self.id, model, ProviderProtocol::ChatCompletions).await?;
             match req.send().await {
                 Ok(resp) => {
                     let status = resp.status();
@@ -231,6 +241,7 @@ impl Provider for OpenAICompatibleProvider {
                         last_error = Some(openai_response_error(status, &text));
                         break;
                     }
+                    accepted_receipt = attempt_receipt;
                     resp_opt = Some(resp);
                     break;
                 }
@@ -299,6 +310,7 @@ impl Provider for OpenAICompatibleProvider {
             // BEFORE [DONE].  Defer the Done yield to [DONE] so we always capture it.
             let mut pending_finish_reason: Option<String> = None;
             let mut pending_usage: Option<TokenUsage> = None;
+            let mut confirmed_accounting_usage = attempt_accounting::StreamingUsage::default();
             while let Some(chunk) = bytes.next().await {
                 if cancel.is_cancelled() {
                     yield StreamChunk::Done {
@@ -320,6 +332,7 @@ impl Provider for OpenAICompatibleProvider {
                         }
                         let payload = line.trim_start_matches("data: ").trim();
                         if payload == "[DONE]" {
+                            confirmed_accounting_usage.confirm(&accepted_receipt).await?;
                             let finish_reason = pending_finish_reason
                                 .take()
                                 .unwrap_or_else(|| "stop".to_string());
@@ -340,6 +353,7 @@ impl Provider for OpenAICompatibleProvider {
 
                         // Capture usage from any chunk — the usage-only trailing chunk
                         // (choices:[]) arrives before [DONE] when include_usage is set.
+                        confirmed_accounting_usage.observe(&value, ProviderProtocol::ChatCompletions);
                         if let Some(u) = extract_usage(&value) {
                             pending_usage = Some(u);
                         }
@@ -405,6 +419,9 @@ impl Provider for OpenAICompatibleProvider {
             }
             // Stream ended without [DONE] — flush any pending finish.
             if let Some(reason) = pending_finish_reason.take() {
+                if !cancel.is_cancelled() {
+                    confirmed_accounting_usage.confirm(&accepted_receipt).await?;
+                }
                 yield StreamChunk::Done {
                     finish_reason: reason,
                     usage: pending_usage.take(),
@@ -479,6 +496,7 @@ fn codex_supported_models(context_window: usize) -> Vec<ModelInfo> {
 
 #[async_trait]
 impl Provider for OpenAIResponsesProvider {
+    fn supports_attempt_accounting(&self) -> bool { true }
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
         Some(ProviderInstallationMetadata::network(&self.id, &self.base_url))
     }
@@ -547,9 +565,11 @@ impl Provider for OpenAIResponsesProvider {
             body["include"] = json!(["reasoning.encrypted_content"]);
         }
 
+        let mut accepted_receipt = None;
         let mut response_opt = None;
         let mut last_send_err: Option<reqwest::Error> = None;
         let mut last_error: Option<anyhow::Error> = None;
+        attempt_accounting::bound_request(&mut body, ProviderProtocol::Responses)?;
         for attempt in 0..3 {
             let mut req = self.client.post(url.clone()).json(&body);
             if let Some(api_key) = &self.api_key {
@@ -557,6 +577,7 @@ impl Provider for OpenAIResponsesProvider {
             }
 
             dispatch_authority::revalidate().await?;
+            let attempt_receipt = attempt_accounting::before_send(&req, &self.id, model, ProviderProtocol::Responses).await?;
             match req.send().await {
                 Ok(resp) => {
                     let status = resp.status();
@@ -570,6 +591,7 @@ impl Provider for OpenAIResponsesProvider {
                         last_error = Some(openai_response_error(status, &text));
                         break;
                     }
+                    accepted_receipt = attempt_receipt;
                     response_opt = Some(resp);
                     break;
                 }
@@ -609,6 +631,7 @@ impl Provider for OpenAIResponsesProvider {
         };
 
         let value = read_provider_response_json_limited(response).await?;
+        attempt_accounting::confirm_json(&accepted_receipt, &value, ProviderProtocol::Responses).await?;
         if let Some(detail) = extract_openai_error(&value) {
             anyhow::bail!(detail);
         }
@@ -717,9 +740,11 @@ impl Provider for OpenAIResponsesProvider {
             ProviderAuthOverride::Bearer(token) => Some(token.as_str()),
         };
 
+        let mut accepted_receipt = None;
         let mut resp_opt = None;
         let mut last_send_err: Option<reqwest::Error> = None;
         let mut last_error: Option<anyhow::Error> = None;
+        attempt_accounting::bound_request(&mut body, ProviderProtocol::Responses)?;
         for attempt in 0..3 {
             let mut req = self.client.post(url.clone()).json(&body);
             if let Some(api_key) = runtime_bearer {
@@ -727,6 +752,7 @@ impl Provider for OpenAIResponsesProvider {
             }
 
             dispatch_authority::revalidate().await?;
+            let attempt_receipt = attempt_accounting::before_send(&req, &self.id, model, ProviderProtocol::Responses).await?;
             match req.send().await {
                 Ok(resp) => {
                     let status = resp.status();
@@ -737,6 +763,7 @@ impl Provider for OpenAIResponsesProvider {
                         last_error = Some(openai_response_error(status, &text));
                         break;
                     }
+                    accepted_receipt = attempt_receipt;
                     resp_opt = Some(resp);
                     break;
                 }
@@ -1102,6 +1129,7 @@ impl Provider for OpenAIResponsesProvider {
                                     finish_reason = "toolUse".to_string();
                                 }
                                 if !saw_completion {
+                                    attempt_accounting::confirm_json(&accepted_receipt, &value["response"], ProviderProtocol::Responses).await?;
                                     if let Some(output) = response.get("output").and_then(|v| v.as_array()) {
                                         for (index, item_value) in output.iter().enumerate() {
                                             let Some(item) = item_value.as_object() else {
@@ -1274,11 +1302,13 @@ impl OpenAIResponsesProvider {
             body["include"] = json!(["reasoning.encrypted_content"]);
         }
 
+        attempt_accounting::bound_request(&mut body, ProviderProtocol::Responses)?;
         let mut req = self.client.post(url).json(&body);
         if let Some(api_key) = &self.api_key {
             req = req.bearer_auth(api_key);
         }
         dispatch_authority::revalidate().await?;
+        let attempt_receipt = attempt_accounting::before_send(&req, &self.id, model, ProviderProtocol::Responses).await?;
         let resp = req.send().await?;
         let status = resp.status();
         if !status.is_success() {
@@ -1288,6 +1318,7 @@ impl OpenAIResponsesProvider {
             return Err(openai_response_error(status, &text));
         }
         let sse_text = read_provider_response_text_limited(resp).await?;
+        attempt_accounting::confirm_responses_sse(&attempt_receipt, &sse_text).await?;
         parse_openai_responses_sse_text(&sse_text)
     }
 }
@@ -1355,6 +1386,7 @@ struct CohereProvider {
 
 #[async_trait]
 impl Provider for AnthropicProvider {
+    fn supports_attempt_accounting(&self) -> bool { true }
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
         Some(ProviderInstallationMetadata::network("anthropic", "https://api.anthropic.com/v1/messages"))
     }
@@ -1376,20 +1408,23 @@ impl Provider for AnthropicProvider {
             .map(str::trim)
             .filter(|m| !m.is_empty())
             .unwrap_or(self.default_model.as_str());
-        let mut req = self
-            .client
+        let mut body = json!({
+            "model": model,
+            "max_tokens": 1024,
+            "messages": [{"role":"user","content": prompt}],
+        });
+        attempt_accounting::bound_request(&mut body, ProviderProtocol::Anthropic)?;
+        let mut req = self.client
             .post("https://api.anthropic.com/v1/messages")
             .header("anthropic-version", "2023-06-01")
-            .json(&json!({
-                "model": model,
-                "max_tokens": 1024,
-                "messages": [{"role":"user","content": prompt}],
-            }));
+            .json(&body);
         if let Some(key) = &self.api_key {
             req = req.header("x-api-key", key);
         }
         dispatch_authority::revalidate().await?;
+        let attempt_receipt = attempt_accounting::before_send(&req, "anthropic", model, ProviderProtocol::Anthropic).await?;
         let value = read_provider_response_json_limited(req.send().await?).await?;
+        attempt_accounting::confirm_json(&attempt_receipt, &value, ProviderProtocol::Anthropic).await?;
         let text = value["content"][0]["text"]
             .as_str()
             .unwrap_or("No completion content.")
@@ -1420,6 +1455,7 @@ impl Provider for AnthropicProvider {
                 .collect::<Vec<_>>(),
         });
         apply_anthropic_sampling(&mut body, model, sampling);
+        attempt_accounting::bound_request(&mut body, ProviderProtocol::Anthropic)?;
         let mut req = self
             .client
             .post("https://api.anthropic.com/v1/messages")
@@ -1430,10 +1466,13 @@ impl Provider for AnthropicProvider {
         }
 
         dispatch_authority::revalidate().await?;
+        let attempt_receipt = attempt_accounting::before_send(&req, "anthropic", model, ProviderProtocol::Anthropic).await?;
         let resp = req.send().await?;
         let mut bytes = resp.bytes_stream();
         let stream = try_stream! {
             let mut buffer = String::new();
+            let mut confirmed_usage = serde_json::json!({"usage": {}});
+            let mut confirmed_accounting_usage = attempt_accounting::StreamingUsage::default();
             while let Some(chunk) = bytes.next().await {
                 if cancel.is_cancelled() {
                     yield StreamChunk::Done {
@@ -1464,6 +1503,18 @@ impl Provider for AnthropicProvider {
                             continue;
                         };
                         match value.get("type").and_then(|v| v.as_str()).unwrap_or_default() {
+                            "message_start" => {
+                                if let Some(usage) = value.get("message").and_then(|message| message.get("usage")).and_then(|usage| usage.as_object()) {
+                                    confirmed_usage["usage"] = serde_json::Value::Object(usage.clone());
+                                }
+                            }
+                            "message_delta" => {
+                                if let Some(usage) = value.get("usage").and_then(|usage| usage.as_object()) {
+                                    let merged = confirmed_usage["usage"].as_object_mut().expect("usage accumulator object");
+                                    merged.extend(usage.clone());
+                                    confirmed_accounting_usage.observe(&confirmed_usage, ProviderProtocol::Anthropic);
+                                }
+                            }
                             "content_block_delta" => {
                                 if let Some(delta) = value.get("delta").and_then(|v| v.get("text")).and_then(|v| v.as_str()) {
                                     yield StreamChunk::TextDelta(delta.to_string());
@@ -1473,6 +1524,7 @@ impl Provider for AnthropicProvider {
                                 }
                             }
                             "message_stop" => {
+                                confirmed_accounting_usage.confirm(&attempt_receipt).await?;
                                 yield StreamChunk::Done {
                                     finish_reason: "stop".to_string(),
                                     usage: None,
@@ -1490,6 +1542,7 @@ impl Provider for AnthropicProvider {
 
 #[async_trait]
 impl Provider for CohereProvider {
+    fn supports_attempt_accounting(&self) -> bool { true }
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
         Some(ProviderInstallationMetadata::network("cohere", &self.base_url))
     }
@@ -1513,18 +1566,19 @@ impl Provider for CohereProvider {
             .unwrap_or(self.default_model.as_str());
         let target =
             resolve_provider_request_target(&format!("{}/chat", self.base_url), "cohere").await?;
-        let mut req = target
-            .client
-            .post(target.url)
-            .json(&json!({
-                "model": model,
-                "messages": [{"role":"user","content": prompt}],
-            }));
+        let mut body = json!({
+            "model": model,
+            "messages": [{"role":"user","content": prompt}],
+        });
+        attempt_accounting::bound_request(&mut body, ProviderProtocol::Cohere)?;
+        let mut req = target.client.post(target.url).json(&body);
         if let Some(key) = &self.api_key {
             req = req.bearer_auth(key);
         }
         dispatch_authority::revalidate().await?;
+        let attempt_receipt = attempt_accounting::before_send(&req, "cohere", model, ProviderProtocol::Cohere).await?;
         let value = read_provider_response_json_limited(req.send().await?).await?;
+        attempt_accounting::confirm_json(&attempt_receipt, &value, ProviderProtocol::Cohere).await?;
         let text = value["message"]["content"][0]["text"]
             .as_str()
             .or_else(|| value["text"].as_str())

--- a/crates/tandem-providers/src/lib_parts/part04.rs
+++ b/crates/tandem-providers/src/lib_parts/part04.rs
@@ -3,6 +3,7 @@ mod tests {
     use super::*;
     include!("../hosted_policy_tests.rs");
     include!("../provider_attempt_tests.rs");
+    include!("../attempt_accounting_tests.rs");
     use futures::StreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;

--- a/crates/tandem-providers/src/provider_attempt_tests.rs
+++ b/crates/tandem-providers/src/provider_attempt_tests.rs
@@ -2,7 +2,7 @@
 mod provider_attempt_tests {
     use super::*;
 
-    fn responses(base_url: String) -> OpenAIResponsesProvider {
+    pub(super) fn responses(base_url: String) -> OpenAIResponsesProvider {
         OpenAIResponsesProvider {
             id: "openai-codex".into(),
             name: "Synthetic Responses".into(),
@@ -14,7 +14,7 @@ mod provider_attempt_tests {
         }
     }
 
-    fn compatible(base_url: String) -> OpenAICompatibleProvider {
+    pub(super) fn compatible(base_url: String) -> OpenAICompatibleProvider {
         OpenAICompatibleProvider {
             id: "ollama".into(),
             name: "Synthetic local transport".into(),
@@ -62,7 +62,7 @@ mod provider_attempt_tests {
         })
     }
 
-    async fn reply(socket: &mut tokio::net::TcpStream, status: &str, body: &str) {
+    pub(super) async fn reply(socket: &mut tokio::net::TcpStream, status: &str, body: &str) {
         let response = format!(
             "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
             body.len()

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -21,6 +21,7 @@ mod goal_control;
 mod goal_lifecycle;
 mod migration;
 pub(crate) mod protected_records;
+mod provider_attempt_budget;
 mod runtime_records;
 pub(crate) mod solution_budget_records;
 mod solution_budgets;
@@ -36,9 +37,11 @@ pub use goal_lifecycle::{GoalEventRow, GoalPauseOutcome, GoalResumeOutcome, Star
 pub use migration::{
     LegacyImportContext, LegacyRuntimeMigrationPaths, LegacyRuntimeMigrationReport,
 };
+pub use provider_attempt_budget::{ApprovedModelPrice, ApprovedSolutionProviderCharge};
 pub use solution_budgets::{
-    SolutionBudgetInput, SolutionBudgetReservationResult, SolutionChargeIntent, SolutionChargeKind,
-    SolutionChargeReservation, SolutionChargeStatus, SolutionRunBudget,
+    SolutionBudgetInput, SolutionBudgetReservationResult, SolutionChargeCostBasis,
+    SolutionChargeIntent, SolutionChargeKind, SolutionChargeReservation, SolutionChargeStatus,
+    SolutionRunBudget,
 };
 pub use solution_installations::{
     SolutionComponentProgress, SolutionInstallation, SolutionInstallationInput,

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget.rs
@@ -1,0 +1,242 @@
+//! Connect actual adapter attempts to the existing protected budget store.
+//! The runtime must supply current authorized binding/root facts; this module
+//! never treats a customer document or a provider callback as that authority.
+
+use std::{future::Future, sync::Arc};
+
+use anyhow::{ensure, Context};
+use tandem_providers::{
+    ProviderAttempt, ProviderAttemptOutcome, ProviderAttemptPolicy, ProviderAttemptReceipt,
+    ProviderProtocol,
+};
+use tandem_solutions::CustomerScope;
+use tandem_types::VerifiedTenantContext;
+
+use super::{
+    OrchestrationStateStore, SolutionBudgetInput, SolutionChargeCostBasis, SolutionChargeIntent,
+    SolutionChargeKind, SolutionRunBudget,
+};
+
+/// Current host-approved upper rates in integer micro-USD per million tokens.
+/// Input rates must cover every supported input category, including cache writes
+/// and reads. These are accounting ceilings, not a provider invoice/guarantee.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApprovedModelPrice {
+    pub input_microusd_per_million: u64,
+    pub output_microusd_per_million: u64,
+    pub request_microusd: u64,
+    pub valid_until_ms: u64,
+}
+
+impl ApprovedModelPrice {
+    pub fn cost(&self, input: u64, output: u64) -> anyhow::Result<u64> {
+        fn tokens(count: u64, rate: u64) -> anyhow::Result<u64> {
+            let rounded = u128::from(count)
+                .checked_mul(u128::from(rate))
+                .and_then(|value| value.checked_add(999_999))
+                .context("model price overflow")?
+                / 1_000_000;
+            u64::try_from(rounded).context("model price overflow")
+        }
+        let input_cost = tokens(input, self.input_microusd_per_million)?;
+        let output_cost = tokens(output, self.output_microusd_per_million)?;
+        self.request_microusd
+            .checked_add(input_cost)
+            .and_then(|value| value.checked_add(output_cost))
+            .context("model price overflow")
+    }
+}
+
+/// Produced by a trusted current model/root authorization callback, never HTTP
+/// deserialization. The caller must validate activation/current account binding,
+/// source/data-class policy and real root lineage before returning this value.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ApprovedSolutionProviderCharge {
+    pub verified: VerifiedTenantContext,
+    pub scope: CustomerScope,
+    pub composition_sha256: String,
+    pub configuration: super::CustomerConfigVersion,
+    pub installation_generation: u64,
+    pub model_class: String,
+    pub binding: tandem_solutions::LockedModelBinding,
+    pub root_run_id: String,
+    pub kind: SolutionChargeKind,
+    /// Reviewed model/account/price revision, not an arbitrary request ID.
+    pub route_revision: String,
+    pub provider_id: String,
+    pub model_id: String,
+    pub protocol: ProviderProtocol,
+    pub endpoint_sha256: String,
+    pub credential_sha256: String,
+    /// Must be a supported host bound, never guessed from prompt byte length.
+    pub maximum_input_tokens: u64,
+    pub maximum_output_tokens: u32,
+    pub run_budget: SolutionRunBudget,
+    /// Missing prices block; zero must be an explicit approved value.
+    pub price: Option<ApprovedModelPrice>,
+}
+
+impl OrchestrationStateStore {
+    /// Build an optional scope around the existing provider registry dispatch.
+    /// The callback runs again for each physical adapter attempt. It must verify
+    /// current facts independently; the scope is not an installation capability.
+    pub fn solution_provider_attempt_policy<F, Fut, Clock>(
+        &self,
+        maximum_output_tokens: u32,
+        maximum_request_bytes: usize,
+        authorize: F,
+        clock: Clock,
+    ) -> anyhow::Result<ProviderAttemptPolicy>
+    where
+        F: Fn(ProviderAttempt) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = anyhow::Result<ApprovedSolutionProviderCharge>> + Send + 'static,
+        Clock: Fn() -> u64 + Send + Sync + 'static,
+    {
+        let store = self.clone();
+        let authorize = Arc::new(authorize);
+        let clock = Arc::new(clock);
+        ProviderAttemptPolicy::new(
+            maximum_output_tokens,
+            maximum_request_bytes,
+            move |attempt| {
+                let store = store.clone();
+                let authorize = authorize.clone();
+                let clock = clock.clone();
+                async move {
+                    let approval = authorize(attempt.clone()).await?;
+                    ensure!(
+                        attempt.provider_id == approval.provider_id
+                            && attempt.model_id == approval.model_id
+                            && attempt.protocol == approval.protocol
+                            && attempt.endpoint_sha256 == approval.endpoint_sha256
+                            && attempt.credential_sha256 == approval.credential_sha256,
+                        "provider attempt differs from current approved model/account route"
+                    );
+                    ensure!(
+                        approval.binding.binding.provider == approval.provider_id
+                            && approval.binding.binding.model == approval.model_id,
+                        "provider route does not match the reviewed solution model binding"
+                    );
+                    ensure!(
+                        attempt.maximum_output_tokens <= approval.maximum_output_tokens,
+                        "provider attempt exceeds current output policy"
+                    );
+                    let now_ms = clock();
+                    let price = approval
+                        .price
+                        .clone()
+                        .context("model price unknown; dispatch blocked")?;
+                    ensure!(
+                        now_ms <= price.valid_until_ms,
+                        "model price expired; review current binding"
+                    );
+                    let maximum_tokens = approval
+                        .maximum_input_tokens
+                        .checked_add(u64::from(attempt.maximum_output_tokens))
+                        .context("model token bound overflow")?;
+                    let maximum_cost = price.cost(
+                        approval.maximum_input_tokens,
+                        u64::from(attempt.maximum_output_tokens),
+                    )?;
+                    let intent = SolutionChargeIntent {
+                        reservation_id: uuid::Uuid::new_v4().to_string(),
+                        root_run_id: approval.root_run_id.clone(),
+                        kind: approval.kind.clone(),
+                        route_revision: approval.route_revision.clone(),
+                        maximum_tokens,
+                        maximum_cost_microusd: Some(maximum_cost),
+                        run_budget: approval.run_budget.clone(),
+                    };
+                    let admission_store = store.clone();
+                    let reviewed = approval.clone();
+                    let ticket = crate::encrypted_file_store::spawn_protected_blocking(move || {
+                        let (result, ticket) = admission_store.reserve_runtime_solution_charge(
+                            SolutionBudgetInput {
+                                verified: &approval.verified,
+                                scope: &approval.scope,
+                                composition_sha256: &approval.composition_sha256,
+                                now_ms,
+                            },
+                            intent,
+                            super::solution_budgets::RuntimeSolutionModel {
+                                configuration: approval.configuration,
+                                installation_generation: approval.installation_generation,
+                                model_class: approval.model_class,
+                                binding: approval.binding,
+                            },
+                        )?;
+                        ensure!(
+                            result.newly_reserved,
+                            "provider attempt already exists; reconcile instead of sending"
+                        );
+                        Ok::<_, anyhow::Error>(ticket)
+                    })
+                    .await??;
+                    let ticket = Arc::new(ticket);
+                    // Reservation can wait for another database writer. Recheck
+                    // current model/account/root authorization after it completes.
+                    // No send has happened, so this denial may reconcile at zero.
+                    let rechecked = async {
+                        let current = authorize(attempt).await?;
+                        ensure!(
+                            current == reviewed,
+                            "model or runtime authority changed during budget admission"
+                        );
+                        tandem_solutions::validate_customer_config_scope(
+                            &current.verified,
+                            &current.scope,
+                            clock(),
+                        )?;
+                        ensure!(
+                            clock() <= price.valid_until_ms,
+                            "model price expired during budget admission"
+                        );
+                        Ok::<_, anyhow::Error>(())
+                    }
+                    .await;
+                    if let Err(error) = rechecked {
+                        let refund_store = store.clone();
+                        let refund_ticket = ticket.clone();
+                        let now_ms = clock();
+                        crate::encrypted_file_store::spawn_protected_blocking(move || {
+                            refund_store.settle_runtime_solution_charge(
+                                &refund_ticket,
+                                now_ms,
+                                0,
+                                0,
+                                SolutionChargeCostBasis::Confirmed,
+                            )
+                        })
+                        .await??;
+                        return Err(error);
+                    }
+                    Ok(ProviderAttemptReceipt::new(move |outcome| {
+                        let store = store.clone();
+                        let ticket = ticket.clone();
+                        let price = price.clone();
+                        let now_ms = clock();
+                        async move {
+                            let (tokens, cost, basis) = match outcome {
+                                ProviderAttemptOutcome::NotDispatched => {
+                                    (0, 0, SolutionChargeCostBasis::Confirmed)
+                                }
+                                ProviderAttemptOutcome::Usage(usage) => (
+                                    usage.total_tokens,
+                                    price.cost(usage.input_tokens, usage.output_tokens)?,
+                                    SolutionChargeCostBasis::ApprovedUpperBound,
+                                ),
+                            };
+                            crate::encrypted_file_store::spawn_protected_blocking(move || {
+                                store.settle_runtime_solution_charge(
+                                    &ticket, now_ms, tokens, cost, basis,
+                                )
+                            })
+                            .await??;
+                            Ok(())
+                        }
+                    }))
+                }
+            },
+        )
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
@@ -197,25 +197,34 @@ async fn reply(socket: &mut tokio::net::TcpStream, with_usage: bool) {
     socket.shutdown().await.unwrap();
 }
 
-fn account(
+async fn account_row(
+    store: &OrchestrationStateStore,
+    fixture: &BudgetFixture,
+    key: &str,
+) -> Option<serde_json::Value> {
+    let store = store.clone();
+    let tenant = fixture.installation.customer.context.tenant_context.clone();
+    let scope = fixture.installation.customer.config.scope.clone();
+    let key = key.to_string();
+    crate::encrypted_file_store::spawn_protected_blocking(move || {
+        store.with_connection(|connection| {
+            crate::stateful_runtime::orchestration_store::solution_budget_records::load::<
+                serde_json::Value,
+            >(connection, &tenant, &scope, &key)
+        })
+    })
+    .await
+    .unwrap()
+    .unwrap()
+    .map(|(_, value)| value)
+}
+
+async fn account(
     store: &OrchestrationStateStore,
     fixture: &BudgetFixture,
     key: &str,
 ) -> serde_json::Value {
-    store
-        .with_connection(|connection| {
-            crate::stateful_runtime::orchestration_store::solution_budget_records::load::<
-                serde_json::Value,
-            >(
-                connection,
-                &fixture.installation.customer.context.tenant_context,
-                &fixture.installation.customer.config.scope,
-                key,
-            )
-        })
-        .unwrap()
-        .unwrap()
-        .1
+    account_row(store, fixture, key).await.unwrap()
 }
 
 #[test]
@@ -250,13 +259,13 @@ fn solution_budget_provider_actual_sends_share_the_durable_ceiling() {
             }
             let error = complete(&registry, policy.clone()).await.unwrap_err();
             assert!(error.to_string().contains("budget"));
-            assert_eq!(account(store, &fixture, "global")["outstanding"], 1);
+            assert_eq!(account(store, &fixture, "global").await["outstanding"], 1);
             release.send(()).unwrap();
             assert_eq!(first.await.unwrap(), "ok");
             assert_eq!(complete(&registry, policy).await.unwrap(), "ok");
             tokio::time::timeout(std::time::Duration::from_secs(3), server).await.unwrap().unwrap();
-            assert_eq!(account(store, &fixture, "global")["outstanding"], 0);
-            let root = account(store, &fixture, &format!("root:{}", sha256(b"actual-root")));
+            assert_eq!(account(store, &fixture, "global").await["outstanding"], 0);
+            let root = account(store, &fixture, &format!("root:{}", sha256(b"actual-root"))).await;
             assert_eq!(root["requests"], 2, "repeated policy checks must not double-charge");
             assert_eq!(root["committed_cost"], 10);
         });
@@ -282,7 +291,13 @@ fn solution_budget_provider_missing_usage_survives_reopen_and_blocks_overspend()
                 });
                 let policy = policy(store, approved, Arc::new(AtomicU64::new(1500)));
                 assert_eq!(complete(&registry, policy.clone()).await.unwrap(), "ok");
-                store.initialize().unwrap();
+                let reopened = store.clone();
+                crate::encrypted_file_store::spawn_protected_blocking(move || {
+                    reopened.initialize()
+                })
+                .await
+                .unwrap()
+                .unwrap();
                 assert!(complete(&registry, policy)
                     .await
                     .unwrap_err()
@@ -298,7 +313,7 @@ fn solution_budget_provider_missing_usage_survives_reopen_and_blocks_overspend()
                 )
                 .await
                 .is_err());
-                assert_eq!(account(store, &fixture, "global")["outstanding"], 1);
+                assert_eq!(account(store, &fixture, "global").await["outstanding"], 1);
             });
         })
     });
@@ -330,9 +345,9 @@ fn solution_budget_provider_confirmed_receipt_settles_after_user_assertion_expir
                     complete(&registry, policy).await.is_err(),
                     "old assertion cannot authorize another send"
                 );
-                assert_eq!(account(store, &fixture, "global")["outstanding"], 0);
+                assert_eq!(account(store, &fixture, "global").await["outstanding"], 0);
                 assert_eq!(
-                    account(store, &fixture, &format!("root:{}", sha256(b"actual-root")))
+                    account(store, &fixture, &format!("root:{}", sha256(b"actual-root"))).await
                         ["committed_cost"],
                     5
                 );
@@ -383,8 +398,9 @@ fn solution_budget_provider_rechecks_binding_after_reservation_without_sending()
                     .to_string()
                     .contains("changed during"));
                 assert_eq!(checks.load(Ordering::SeqCst), 2);
-                assert_eq!(account(store, &fixture, "global")["outstanding"], 0);
-                let root = account(store, &fixture, &format!("root:{}", sha256(b"actual-root")));
+                assert_eq!(account(store, &fixture, "global").await["outstanding"], 0);
+                let root =
+                    account(store, &fixture, &format!("root:{}", sha256(b"actual-root"))).await;
                 assert_eq!(root["committed_cost"], 0);
                 assert_eq!(root["requests"], 1);
                 assert!(tokio::time::timeout(
@@ -425,16 +441,7 @@ fn solution_budget_provider_rejects_stale_model_and_unknown_price_before_network
                 )
                 .await
                 .is_err());
-                let global = store
-                    .with_connection(|connection| {
-                        super::super::solution_budget_records::load::<serde_json::Value>(
-                            connection,
-                            &approved.verified.tenant_context,
-                            &approved.scope,
-                            "global",
-                        )
-                    })
-                    .unwrap();
+                let global = account_row(store, &fixture, "global").await;
                 assert!(
                     global.is_none(),
                     "rejected admission must not consume budget"

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
@@ -1,0 +1,462 @@
+use super::*;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use tandem_providers::{
+    AppConfig, ProviderAttempt, ProviderAuthRecovery, ProviderConfig, ProviderRegistry,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+fn network_fixture(store: &OrchestrationStateStore, name: &str) -> BudgetFixture {
+    let mut installation = InstallationFixture::new("a");
+    installation.customer.config.scope.instance_id = name.into();
+    for policy in [
+        &mut installation.customer.blueprint.constraints,
+        &mut installation.customer.config.constraints,
+    ] {
+        policy.allowed_providers = ["ollama".into()].into();
+        policy.allow_network_egress = true;
+        policy.max_daily_cost_microusd = 50;
+        policy.max_tokens_per_run = 100;
+        policy.max_concurrent_runs = 4;
+    }
+    let model = installation.models.get_mut("local.fixture").unwrap();
+    model.provider = "ollama".into();
+    model.uses_network = true;
+    let (config, digest) = installation.seed(store);
+    store
+        .transition_solution_installation(
+            installation.input(&config, &digest),
+            None,
+            SolutionInstallationTransition::Begin,
+        )
+        .unwrap();
+    BudgetFixture {
+        installation,
+        digest,
+    }
+}
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn registry(address: std::net::SocketAddr) -> ProviderRegistry {
+    ProviderRegistry::new(AppConfig {
+        providers: [(
+            "ollama".into(),
+            ProviderConfig {
+                url: Some(format!("http://{address}/v1")),
+                api_key: None,
+                default_model: Some("synthetic-model".into()),
+            },
+        )]
+        .into(),
+        default_provider: Some("ollama".into()),
+    })
+}
+
+fn approval(
+    fixture: &BudgetFixture,
+    store: &OrchestrationStateStore,
+) -> ApprovedSolutionProviderCharge {
+    let installed = store
+        .solution_installation(
+            &fixture.installation.customer.context,
+            &fixture.installation.customer.config.scope,
+            1500,
+        )
+        .unwrap()
+        .unwrap();
+    ApprovedSolutionProviderCharge {
+        verified: fixture.installation.customer.context.clone(),
+        scope: fixture.installation.customer.config.scope.clone(),
+        composition_sha256: fixture.digest.clone(),
+        configuration: installed.config_version,
+        installation_generation: installed.generation,
+        model_class: "economy".into(),
+        binding: installed.plan.models["economy"].clone(),
+        root_run_id: "actual-root".into(),
+        kind: SolutionChargeKind::Model,
+        route_revision: sha256(b"synthetic-approved-account-model-price"),
+        provider_id: "ollama".into(),
+        model_id: "synthetic-model".into(),
+        protocol: tandem_providers::ProviderProtocol::ChatCompletions,
+        endpoint_sha256: String::new(),
+        credential_sha256: String::new(),
+        maximum_input_tokens: 20,
+        maximum_output_tokens: 10,
+        run_budget: SolutionRunBudget {
+            max_tokens: 100,
+            max_cost_microusd: 50,
+            max_requests: 4,
+        },
+        price: Some(ApprovedModelPrice {
+            input_microusd_per_million: 1_000_000,
+            output_microusd_per_million: 1_000_000,
+            request_microusd: 0,
+            valid_until_ms: 10_000,
+        }),
+    }
+}
+
+fn current(
+    approved: &ApprovedSolutionProviderCharge,
+    attempt: ProviderAttempt,
+) -> ApprovedSolutionProviderCharge {
+    let mut result = approved.clone();
+    // Synthetic trusted binding callback. Real activation must obtain these
+    // facts from its current host/account registry, not echo browser input.
+    result.endpoint_sha256 = attempt.endpoint_sha256;
+    result.credential_sha256 = attempt.credential_sha256;
+    result
+}
+
+fn policy(
+    store: &OrchestrationStateStore,
+    approved: ApprovedSolutionProviderCharge,
+    clock: Arc<AtomicU64>,
+) -> tandem_providers::ProviderAttemptPolicy {
+    store
+        .solution_provider_attempt_policy(
+            10,
+            4096,
+            move |attempt| {
+                let approved = current(&approved, attempt);
+                async move { Ok(approved) }
+            },
+            move || clock.load(Ordering::SeqCst),
+        )
+        .unwrap()
+}
+
+async fn complete(
+    registry: &ProviderRegistry,
+    policy: tandem_providers::ProviderAttemptPolicy,
+) -> anyhow::Result<String> {
+    registry
+        .scope_tenant_provider_auth_with_recovery(
+            tandem_types::TenantContext::explicit(
+                "org-a",
+                "workspace-a",
+                Some("deployment-a".into()),
+            ),
+            ProviderAuthRecovery::new(|_| async { Ok(false) }),
+            true,
+            policy.scope(registry.complete_for_provider(Some("ollama"), "synthetic request", None)),
+        )
+        .await
+}
+
+async fn request(socket: &mut tokio::net::TcpStream) -> serde_json::Value {
+    let mut bytes = Vec::new();
+    let header_end = loop {
+        let mut chunk = [0; 2048];
+        let n = socket.read(&mut chunk).await.unwrap();
+        assert!(n > 0);
+        bytes.extend_from_slice(&chunk[..n]);
+        if let Some(index) = bytes.windows(4).position(|value| value == b"\r\n\r\n") {
+            break index + 4;
+        }
+    };
+    let headers = String::from_utf8(bytes[..header_end].to_vec()).unwrap();
+    let len: usize = headers
+        .lines()
+        .find_map(|line| {
+            line.to_ascii_lowercase()
+                .strip_prefix("content-length:")
+                .map(|value| value.trim().parse().unwrap())
+        })
+        .unwrap();
+    while bytes.len() - header_end < len {
+        let mut chunk = [0; 2048];
+        let n = socket.read(&mut chunk).await.unwrap();
+        assert!(n > 0);
+        bytes.extend_from_slice(&chunk[..n]);
+    }
+    serde_json::from_slice(&bytes[header_end..header_end + len]).unwrap()
+}
+
+async fn reply(socket: &mut tokio::net::TcpStream, with_usage: bool) {
+    let body = if with_usage {
+        r#"{"choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}"#
+    } else {
+        r#"{"choices":[{"message":{"content":"ok"}}],"usage":{}}"#
+    };
+    socket
+        .write_all(
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .as_bytes(),
+        )
+        .await
+        .unwrap();
+    socket.shutdown().await.unwrap();
+}
+
+fn account(
+    store: &OrchestrationStateStore,
+    fixture: &BudgetFixture,
+    key: &str,
+) -> serde_json::Value {
+    store
+        .with_connection(|connection| {
+            crate::stateful_runtime::orchestration_store::solution_budget_records::load::<
+                serde_json::Value,
+            >(
+                connection,
+                &fixture.installation.customer.context.tenant_context,
+                &fixture.installation.customer.config.scope,
+                key,
+            )
+        })
+        .unwrap()
+        .unwrap()
+        .1
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_actual_sends_share_the_durable_ceiling() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = network_fixture(store, "provider-ceiling");
+            let approved = approval(&fixture, store);
+            runtime().block_on(async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let registry = registry(listener.local_addr().unwrap());
+            let (arrived, waiting) = tokio::sync::oneshot::channel();
+            let (release, released) = tokio::sync::oneshot::channel();
+            let server = tokio::spawn(async move {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                assert_eq!(request(&mut socket).await["max_tokens"], 10);
+                arrived.send(()).unwrap();
+                released.await.unwrap();
+                reply(&mut socket, true).await;
+                let (mut socket, _) = listener.accept().await.unwrap();
+                request(&mut socket).await;
+                reply(&mut socket, true).await;
+            });
+            let clock = Arc::new(AtomicU64::new(1500));
+            let policy = policy(store, approved, clock);
+            let first = complete(&registry, policy.clone());
+            tokio::pin!(first);
+            tokio::select! {
+                result = &mut first => panic!("first request completed before release: {result:?}"),
+                result = waiting => result.unwrap(),
+            }
+            let error = complete(&registry, policy.clone()).await.unwrap_err();
+            assert!(error.to_string().contains("budget"));
+            assert_eq!(account(store, &fixture, "global")["outstanding"], 1);
+            release.send(()).unwrap();
+            assert_eq!(first.await.unwrap(), "ok");
+            assert_eq!(complete(&registry, policy).await.unwrap(), "ok");
+            tokio::time::timeout(std::time::Duration::from_secs(3), server).await.unwrap().unwrap();
+            assert_eq!(account(store, &fixture, "global")["outstanding"], 0);
+            let root = account(store, &fixture, &format!("root:{}", sha256(b"actual-root")));
+            assert_eq!(root["requests"], 2, "repeated policy checks must not double-charge");
+            assert_eq!(root["committed_cost"], 10);
+        });
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_missing_usage_survives_reopen_and_blocks_overspend() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = network_fixture(store, "provider-unknown");
+            let approved = approval(&fixture, store);
+            runtime().block_on(async {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let registry = registry(listener.local_addr().unwrap());
+                let server = tokio::spawn(async move {
+                    let (mut socket, _) = listener.accept().await.unwrap();
+                    request(&mut socket).await;
+                    reply(&mut socket, false).await;
+                    listener
+                });
+                let policy = policy(store, approved, Arc::new(AtomicU64::new(1500)));
+                assert_eq!(complete(&registry, policy.clone()).await.unwrap(), "ok");
+                store.initialize().unwrap();
+                assert!(complete(&registry, policy)
+                    .await
+                    .unwrap_err()
+                    .to_string()
+                    .contains("budget"));
+                let listener = tokio::time::timeout(std::time::Duration::from_secs(3), server)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert!(tokio::time::timeout(
+                    std::time::Duration::from_millis(50),
+                    listener.accept()
+                )
+                .await
+                .is_err());
+                assert_eq!(account(store, &fixture, "global")["outstanding"], 1);
+            });
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_confirmed_receipt_settles_after_user_assertion_expires() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = network_fixture(store, "provider-expiry");
+            let approved = approval(&fixture, store);
+            let expiry = approved.verified.expires_at_ms;
+            runtime().block_on(async {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let registry = registry(listener.local_addr().unwrap());
+                let clock = Arc::new(AtomicU64::new(1500));
+                let tick = clock.clone();
+                let server = tokio::spawn(async move {
+                    let (mut socket, _) = listener.accept().await.unwrap();
+                    request(&mut socket).await;
+                    tick.store(expiry + 1, Ordering::SeqCst);
+                    reply(&mut socket, true).await;
+                    listener
+                });
+                let policy = policy(store, approved, clock);
+                assert_eq!(complete(&registry, policy.clone()).await.unwrap(), "ok");
+                assert!(
+                    complete(&registry, policy).await.is_err(),
+                    "old assertion cannot authorize another send"
+                );
+                assert_eq!(account(store, &fixture, "global")["outstanding"], 0);
+                assert_eq!(
+                    account(store, &fixture, &format!("root:{}", sha256(b"actual-root")))
+                        ["committed_cost"],
+                    5
+                );
+                let listener = tokio::time::timeout(std::time::Duration::from_secs(3), server)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert!(tokio::time::timeout(
+                    std::time::Duration::from_millis(50),
+                    listener.accept()
+                )
+                .await
+                .is_err());
+            });
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_rechecks_binding_after_reservation_without_sending() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = network_fixture(store, "provider-stale");
+            let approved = approval(&fixture, store);
+            runtime().block_on(async {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let registry = registry(listener.local_addr().unwrap());
+                let checks = Arc::new(AtomicUsize::new(0));
+                let count = checks.clone();
+                let policy = store
+                    .solution_provider_attempt_policy(
+                        10,
+                        4096,
+                        move |attempt| {
+                            let mut approved = current(&approved, attempt);
+                            if count.fetch_add(1, Ordering::SeqCst) > 0 {
+                                approved.route_revision = sha256(b"changed-account-generation");
+                            }
+                            async move { Ok(approved) }
+                        },
+                        || 1500,
+                    )
+                    .unwrap();
+                assert!(complete(&registry, policy)
+                    .await
+                    .unwrap_err()
+                    .to_string()
+                    .contains("changed during"));
+                assert_eq!(checks.load(Ordering::SeqCst), 2);
+                assert_eq!(account(store, &fixture, "global")["outstanding"], 0);
+                let root = account(store, &fixture, &format!("root:{}", sha256(b"actual-root")));
+                assert_eq!(root["committed_cost"], 0);
+                assert_eq!(root["requests"], 1);
+                assert!(tokio::time::timeout(
+                    std::time::Duration::from_millis(50),
+                    listener.accept()
+                )
+                .await
+                .is_err());
+            });
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_rejects_stale_model_and_unknown_price_before_network() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = network_fixture(store, "provider-invalid");
+            let approved = approval(&fixture, store);
+            runtime().block_on(async {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let registry = registry(listener.local_addr().unwrap());
+                for variant in 0..4 {
+                    let mut invalid = approved.clone();
+                    match variant {
+                        0 => invalid.installation_generation += 1,
+                        1 => invalid.binding.binding_id = "different-approved-binding".into(),
+                        2 => invalid.price = None,
+                        _ => invalid.price.as_mut().unwrap().valid_until_ms = 1499,
+                    }
+                    let policy = policy(store, invalid, Arc::new(AtomicU64::new(1500)));
+                    assert!(complete(&registry, policy).await.is_err());
+                }
+                assert!(tokio::time::timeout(
+                    std::time::Duration::from_millis(50),
+                    listener.accept()
+                )
+                .await
+                .is_err());
+                let global = store
+                    .with_connection(|connection| {
+                        super::super::solution_budget_records::load::<serde_json::Value>(
+                            connection,
+                            &approved.verified.tenant_context,
+                            &approved.scope,
+                            "global",
+                        )
+                    })
+                    .unwrap();
+                assert!(
+                    global.is_none(),
+                    "rejected admission must not consume budget"
+                );
+            });
+        })
+    });
+}
+
+#[test]
+fn solution_budget_provider_price_ceilings_round_up_and_reject_overflow() {
+    let mut price = ApprovedModelPrice {
+        input_microusd_per_million: 1,
+        output_microusd_per_million: 1,
+        request_microusd: 3,
+        valid_until_ms: 2000,
+    };
+    assert_eq!(price.cost(1, 1).unwrap(), 5);
+    assert_eq!(price.cost(0, 0).unwrap(), 3);
+    price.input_microusd_per_million = u64::MAX;
+    assert!(price.cost(u64::MAX, 0).is_err());
+    price.input_microusd_per_million = 0;
+    price.request_microusd = u64::MAX;
+    assert!(price.cost(0, 1).is_err());
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budget_tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use std::sync::{Arc, Barrier};
 
+#[path = "provider_attempt_budget_tests.rs"]
+mod provider_tests;
+
 struct BudgetFixture {
     installation: InstallationFixture,
     digest: String,
@@ -303,7 +306,8 @@ fn solution_budget_unknown_price_overrun_and_foreign_scope_fail_closed() {
                 SolutionChargeStatus::Settled {
                     tokens: 2,
                     cost_microusd: 10,
-                    overrun: false
+                    overrun: false,
+                    cost_basis: SolutionChargeCostBasis::Confirmed
                 }
             );
         })

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
@@ -62,7 +62,19 @@ pub enum SolutionChargeStatus {
         tokens: u64,
         cost_microusd: u64,
         overrun: bool,
+        #[serde(default)]
+        cost_basis: SolutionChargeCostBasis,
     },
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SolutionChargeCostBasis {
+    #[default]
+    Confirmed,
+    /// Confirmed token usage valued at the approved conservative input/output
+    /// rates. This is not a provider invoice or a hard billing guarantee.
+    ApprovedUpperBound,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,6 +91,23 @@ pub struct SolutionBudgetReservationResult {
     pub reservation: SolutionChargeReservation,
     /// False means observe/reconcile the existing attempt; do not dispatch.
     pub newly_reserved: bool,
+}
+
+/// A nonserializable settlement capability minted only after a current, scoped
+/// reservation succeeds. It authorizes accounting for that attempt, never a new
+/// dispatch, and remains usable when the initiating user assertion expires.
+pub(crate) struct RuntimeSolutionCharge {
+    verified: VerifiedTenantContext,
+    scope: CustomerScope,
+    composition_sha256: String,
+    intent: SolutionChargeIntent,
+}
+
+pub(crate) struct RuntimeSolutionModel {
+    pub configuration: super::CustomerConfigVersion,
+    pub installation_generation: u64,
+    pub model_class: String,
+    pub binding: tandem_solutions::LockedModelBinding,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -115,10 +144,57 @@ fn key(prefix: &str, value: &str) -> String {
 }
 
 impl OrchestrationStateStore {
+    pub(crate) fn reserve_runtime_solution_charge(
+        &self,
+        input: SolutionBudgetInput<'_>,
+        intent: SolutionChargeIntent,
+        model: RuntimeSolutionModel,
+    ) -> anyhow::Result<(SolutionBudgetReservationResult, RuntimeSolutionCharge)> {
+        let ticket = RuntimeSolutionCharge {
+            verified: input.verified.clone(),
+            scope: input.scope.clone(),
+            composition_sha256: input.composition_sha256.into(),
+            intent: intent.clone(),
+        };
+        let reservation = self.reserve_solution_charge_inner(input, intent, Some(&model))?;
+        Ok((reservation, ticket))
+    }
+
+    pub(crate) fn settle_runtime_solution_charge(
+        &self,
+        ticket: &RuntimeSolutionCharge,
+        now_ms: u64,
+        actual_tokens: u64,
+        actual_cost_microusd: u64,
+        cost_basis: SolutionChargeCostBasis,
+    ) -> anyhow::Result<SolutionChargeReservation> {
+        self.settle_admitted_solution_charge(
+            SolutionBudgetInput {
+                verified: &ticket.verified,
+                scope: &ticket.scope,
+                composition_sha256: &ticket.composition_sha256,
+                now_ms,
+            },
+            &ticket.intent,
+            actual_tokens,
+            actual_cost_microusd,
+            cost_basis,
+        )
+    }
+
     pub fn reserve_solution_charge(
         &self,
         input: SolutionBudgetInput<'_>,
         intent: SolutionChargeIntent,
+    ) -> anyhow::Result<SolutionBudgetReservationResult> {
+        self.reserve_solution_charge_inner(input, intent, None)
+    }
+
+    fn reserve_solution_charge_inner(
+        &self,
+        input: SolutionBudgetInput<'_>,
+        intent: SolutionChargeIntent,
+        model: Option<&RuntimeSolutionModel>,
     ) -> anyhow::Result<SolutionBudgetReservationResult> {
         validate_customer_config_scope(input.verified, input.scope, input.now_ms)?;
         reference(&intent.reservation_id)?;
@@ -145,6 +221,14 @@ impl OrchestrationStateStore {
             let installation =
                 solution_installations::load(&transaction, input.verified, input.scope)?
                     .context("solution installation missing")?;
+            if let Some(model) = model {
+                ensure!(
+                    installation.generation == model.installation_generation
+                        && installation.config_version == model.configuration
+                        && installation.plan.models.get(&model.model_class) == Some(&model.binding),
+                    "reviewed runtime model or installation generation changed"
+                );
+            }
             ensure!(
                 installation.composition_sha256 == input.composition_sha256,
                 "solution composition changed before budget reservation"
@@ -297,6 +381,23 @@ impl OrchestrationStateStore {
         actual_cost_microusd: u64,
     ) -> anyhow::Result<SolutionChargeReservation> {
         validate_customer_config_scope(input.verified, input.scope, input.now_ms)?;
+        self.settle_admitted_solution_charge(
+            input,
+            intent,
+            actual_tokens,
+            actual_cost_microusd,
+            SolutionChargeCostBasis::Confirmed,
+        )
+    }
+
+    fn settle_admitted_solution_charge(
+        &self,
+        input: SolutionBudgetInput<'_>,
+        intent: &SolutionChargeIntent,
+        actual_tokens: u64,
+        actual_cost_microusd: u64,
+        cost_basis: SolutionChargeCostBasis,
+    ) -> anyhow::Result<SolutionChargeReservation> {
         let tenant = &input.verified.tenant_context;
         self.with_connection(|connection| {
             let transaction =
@@ -323,6 +424,7 @@ impl OrchestrationStateStore {
                 tokens: actual_tokens,
                 cost_microusd: actual_cost_microusd,
                 overrun,
+                cost_basis,
             };
             if reservation.status != SolutionChargeStatus::Reserved {
                 ensure!(

--- a/docs/PROVIDER_ATTEMPT_BUDGET.md
+++ b/docs/PROVIDER_ATTEMPT_BUDGET.md
@@ -1,0 +1,74 @@
+# Durable provider attempt accounting
+
+`ProviderAttemptPolicy` scopes the existing provider registry. Each of the eight
+concrete adapter send sites obtains a new admission after constructing its final
+request. Transport retries, authentication recovery and Responses completion's
+streaming fallback therefore consume separate reservations. Repeatable
+`ProviderDispatchAuthority` checks remain separate from accounting.
+
+The optional scope clamps the adapter's output token field and limits serialized
+request bytes. Admission receives the actual provider/model/protocol and hashes
+of the endpoint, credential headers and payload, without raw keys or prompts.
+Unsupported adapters fail before dispatch while a policy is present. Unscoped
+legacy dispatch keeps its existing behavior. Redirects are already disabled by
+the provider-authority dependency.
+
+`OrchestrationStateStore::solution_provider_attempt_policy` connects these sends
+to the protected solution budget ledger. Its trusted callback must resolve the
+current authorized model, account, price and root-run facts. The reservation
+transaction verifies the stored installation generation, protected customer
+configuration version and locked model binding. One atomic reservation checks
+solution/day/root cost, tokens, outstanding requests and finite attempt limits.
+The callback runs again after reservation; dispatch authority also revalidates
+before the adapter sends. A denial before send can settle at confirmed zero.
+
+Every physical attempt receives a server-generated ID. Missing or malformed
+usage, transport errors, interrupted streams, cancellation and process failure
+leave the reservation held. There is no timeout refund or retry takeover. The
+existing encrypted records and backend transfer preserve those holds. A private,
+nonserializable settlement capability permits reconciliation of an incurred
+request after its initiating assertion expires; it cannot authorize another send.
+
+Confirmed token counts are valued using current host-approved upper rates in
+integer micro-USD. Settlement records `approved_upper_bound`, distinct from
+`confirmed` costs supplied to the original ledger API. Missing/expired prices
+block admission. Input rates must cover all permitted categories, including
+cache writes and reads. Prices and input-token ceilings must come from reviewed
+host/model facts; prompt bytes and adapter context-window defaults are not proof
+of a billing bound. Overflow fails closed. An observed overrun retains the
+existing global admission halt.
+
+Usage parsers require complete unsigned counters. Anthropic input includes cache
+creation/read tokens; streaming deltas merge cumulative counters. Cohere uses
+billed token units for rate calculations and actual token usage for token limits.
+Unpriced non-token units remain unresolved. Incomplete or decreasing cumulative
+stream receipts cannot release held funds. These contracts follow the
+[Claude streaming](https://platform.claude.com/docs/en/build-with-claude/streaming),
+[Claude caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
+and [Cohere chat](https://docs.cohere.com/v2/reference/chat) interfaces. They do not
+establish a provider invoice or guarantee future vendor billing behavior.
+
+## Verification
+
+The full `tandem-providers` library suite includes local HTTP tests for actual
+output caps, confirmed usage, receipts after scope exit, dropped streams,
+separate fallback admission and revocation between reservation and send.
+Codec tests cover missing, overflowing and inconsistent usage.
+
+The existing `solution_budget_` suite runs on SQLite and PostgreSQL. Its provider
+cases use actual local HTTP requests and the protected ledger to exercise
+concurrent admission, unknown usage across reopen, settlement after assertion
+expiry, and changed authorization before send. Synthetic approval callbacks
+isolate accounting behavior; they do not prove a production account resolver.
+
+## Remaining integration
+
+This scope is not yet installed by a production Company Brain activation/run
+entry point. Current account-generation resolution, model/tool/modality support,
+data-class destination policy, independently authorized user sources/private
+memory, root lineage, approved input bounds and prices still need that trusted
+runtime factory. Embeddings, transcription and tool charges need their own
+physical-attempt adapters. Operator reconciliation, retention and external
+rollback anchors remain separate work. Activation, product UI/CLI, live-provider,
+two-user privacy and clean-host acceptance remain open. Do not infer completion
+of TAN-831, TAN-834 or the full system from this accounting foundation.


### PR DESCRIPTION
Provider retries and Responses streaming fallback can send multiple physical requests for one logical completion. This slice connects each actual adapter send to the existing protected solution ledger, with bounded output, current model/configuration checks and a fresh reservation per attempt. Repeatable authorization checks do not double-charge. Missing usage, interrupted streams and transport errors keep their reservations held across reopen; proven denial before send reconciles at zero. A private settlement capability can reconcile an incurred receipt after its initiating assertion expires without authorizing another request.

All eight adapter send sites participate when the trusted optional scope is installed. Strict token receipts are priced with reviewed upper rates and explicitly recorded as approved_upper_bound, distinct from confirmed monetary charges. Unknown/expired prices and unsupported adapters fail closed. Existing unscoped dispatch behavior is preserved.

Validation: exact signed head6360e10df3fe366250e6b164f7cde34b491879ce passed Solution Contract34016717646 (storage101441670313) and Hosted policy34016717650 (job101441680485). The full provider suite ran72 tests, all passed. The real SQLite/PostgreSQL suite ran13 budget cases including the five new HTTP/ledger cases and price rounding/overflow, plus encrypted backend transfer, native/service/HTTP integration and PostgreSQL/SQLite clippy. Engine34016717754 passed all jobs; workspace101442424120:5,216 passed,7 skipped. ACME and Email also passed. Security34016717654 passed enterprise release101441699072, engine container101445978585 and aggregate101446279416. All six current workflows passed; exact-head guard marked this PR ready for review. No merge. The initial PostgreSQL test-driver panic was corrected using the existing protected blocking helper, and the current backend rerun passed. Local Rustfmt/diff checks passed; no local Cargo.

Dependencies: local integration base213f4e9fa98d24069cd3fb637f593c00afd5e887 assembles #1945 at26fc4ca528025f4bb87f7e61b05fde08e468254b and #1946 atbd18f203d02dac19764fbe7f56adb6d2a7ccec10, both on #1944. No remote PR has been merged. All commits after the service base carry DCO sign-offs.

Remaining: production activation/run entry point and trusted current account-generation/model/price/data-class/root-lineage factory; independently authorized user sources/private memory; embeddings/transcription/tool adapters; reconciliation UI and external rollback anchors. Synthetic test approvals prove accounting, not a live account resolver or vendor billing guarantee. Full Company Brain recovery, privacy and clean-host acceptance remain open. See docs/PROVIDER_ATTEMPT_BUDGET.md. Do not merge automatically or mark TAN-831/TAN-834 Done.