### PR TITLE
feat(providers): resolve current tenant model and credential bindings (TAN-831)

### DIFF
--- a/crates/tandem-providers/src/attempt_accounting.rs
+++ b/crates/tandem-providers/src/attempt_accounting.rs
@@ -8,7 +8,8 @@ use futures::future::BoxFuture;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ProviderProtocol {
     ChatCompletions,
     Responses,
@@ -150,6 +151,31 @@ fn digest(parts: &[&[u8]]) -> String {
     format!("{:x}", digest.finalize())
 }
 
+pub(crate) struct RequestFingerprints {
+    pub endpoint_sha256: String,
+    pub credential_sha256: String,
+}
+
+pub(crate) fn request_fingerprints(request: &reqwest::Request) -> RequestFingerprints {
+    let headers = request.headers();
+    let authorization = headers
+        .get("authorization")
+        .map(|value| value.as_bytes())
+        .unwrap_or_default();
+    let api_key = headers
+        .get("x-api-key")
+        .map(|value| value.as_bytes())
+        .unwrap_or_default();
+    let account = headers
+        .get("chatgpt-account-id")
+        .map(|value| value.as_bytes())
+        .unwrap_or_default();
+    RequestFingerprints {
+        endpoint_sha256: digest(&[b"provider-endpoint-v1", request.url().as_str().as_bytes()]),
+        credential_sha256: digest(&[b"provider-credential-v1", authorization, api_key, account]),
+    }
+}
+
 pub(crate) async fn before_send(
     request: &reqwest::RequestBuilder,
     provider_id: &str,
@@ -188,25 +214,13 @@ pub(crate) async fn before_send(
         maximum_output_tokens <= policy.max_output_tokens,
         "provider output exceeds reviewed limit"
     );
-    let headers = built.headers();
-    let authorization = headers
-        .get("authorization")
-        .map(|value| value.as_bytes())
-        .unwrap_or_default();
-    let api_key = headers
-        .get("x-api-key")
-        .map(|value| value.as_bytes())
-        .unwrap_or_default();
-    let account = headers
-        .get("chatgpt-account-id")
-        .map(|value| value.as_bytes())
-        .unwrap_or_default();
+    let fingerprints = request_fingerprints(&built);
     let attempt = ProviderAttempt {
         provider_id: provider_id.into(),
         model_id: model_id.into(),
         protocol,
-        endpoint_sha256: digest(&[b"provider-endpoint-v1", built.url().as_str().as_bytes()]),
-        credential_sha256: digest(&[b"provider-credential-v1", authorization, api_key, account]),
+        endpoint_sha256: fingerprints.endpoint_sha256,
+        credential_sha256: fingerprints.credential_sha256,
         payload_sha256: digest(&[b"provider-payload-v1", bytes]),
         request_bytes: bytes.len(),
         maximum_output_tokens,

--- a/crates/tandem-providers/src/lib.rs
+++ b/crates/tandem-providers/src/lib.rs
@@ -16,3 +16,8 @@ pub use attempt_accounting::{
     ConfirmedProviderUsage, ProviderAttempt, ProviderAttemptOutcome, ProviderAttemptPolicy,
     ProviderAttemptReceipt, ProviderProtocol,
 };
+
+mod runtime_binding;
+pub use runtime_binding::{
+    ProviderCredentialSource, ProviderRuntimeBinding, ProviderTransportBinding,
+};

--- a/crates/tandem-providers/src/lib_parts/part01.rs
+++ b/crates/tandem-providers/src/lib_parts/part01.rs
@@ -841,6 +841,14 @@ pub trait Provider: Send + Sync {
     /// Only adapters with admission on every actual send may run in a budget scope.
     fn supports_attempt_accounting(&self) -> bool { false }
 
+    fn runtime_transport_binding(
+        &self,
+        _auth: &ProviderAuthOverride,
+    ) -> anyhow::Result<ProviderTransportBinding> {
+        anyhow::bail!("provider does not describe a current runtime binding")
+    }
+
+
     /// Unknown adapters remain usable by legacy callers, but cannot be
     /// approved for solution installation until they describe their route.
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
@@ -1090,17 +1098,26 @@ impl ProviderRegistry {
     }
 
     async fn auth_override_for_provider(&self, provider_id: &str) -> ProviderAuthOverride {
+        let tenant_context = PROVIDER_TENANT_CONTEXT.try_with(Clone::clone).ok();
+        self.auth_override_for_tenant(provider_id, tenant_context.as_ref()).await
+    }
+
+    async fn auth_override_for_tenant(
+        &self,
+        provider_id: &str,
+        tenant_context: Option<&TenantContext>,
+    ) -> ProviderAuthOverride {
         if !provider_id.eq_ignore_ascii_case("openai-codex") {
             return ProviderAuthOverride::Inherit;
         }
-        let Some(tenant_context) = PROVIDER_TENANT_CONTEXT.try_with(Clone::clone).ok() else {
+        let Some(tenant_context) = tenant_context else {
             return ProviderAuthOverride::Inherit;
         };
         if let Some(token) = self
             .tenant_bearer_tokens
             .read()
             .await
-            .get(&tenant_provider_auth_key(&tenant_context, provider_id))
+            .get(&tenant_provider_auth_key(tenant_context, provider_id))
             .cloned()
         {
             ProviderAuthOverride::Bearer(token)

--- a/crates/tandem-providers/src/lib_parts/part02.rs
+++ b/crates/tandem-providers/src/lib_parts/part02.rs
@@ -1,5 +1,9 @@
 #[async_trait]
 impl Provider for OpenAICompatibleProvider {
+    fn runtime_transport_binding(&self, auth: &ProviderAuthOverride) -> anyhow::Result<ProviderTransportBinding> {
+        anyhow::ensure!(matches!(auth, ProviderAuthOverride::Inherit), "provider does not support tenant-scoped authentication");
+        runtime_binding::transport(&format!("{}/chat/completions", self.base_url), ProviderProtocol::ChatCompletions, self.api_key.as_deref(), None, runtime_binding::inherited_source(self.api_key.as_deref()))
+    }
     fn supports_attempt_accounting(&self) -> bool { true }
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
         Some(ProviderInstallationMetadata::network(&self.id, &self.base_url))
@@ -496,6 +500,14 @@ fn codex_supported_models(context_window: usize) -> Vec<ModelInfo> {
 
 #[async_trait]
 impl Provider for OpenAIResponsesProvider {
+    fn runtime_transport_binding(&self, auth: &ProviderAuthOverride) -> anyhow::Result<ProviderTransportBinding> {
+        let (key, source) = match auth {
+            ProviderAuthOverride::Inherit => (self.api_key.as_deref(), runtime_binding::inherited_source(self.api_key.as_deref())),
+            ProviderAuthOverride::Bearer(token) => (Some(token.as_str()), ProviderCredentialSource::TenantBearer),
+            ProviderAuthOverride::Suppress => anyhow::bail!("tenant provider credential missing"),
+        };
+        runtime_binding::transport(&format!("{}/responses", self.base_url), ProviderProtocol::Responses, key, None, source)
+    }
     fn supports_attempt_accounting(&self) -> bool { true }
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
         Some(ProviderInstallationMetadata::network(&self.id, &self.base_url))
@@ -1386,6 +1398,10 @@ struct CohereProvider {
 
 #[async_trait]
 impl Provider for AnthropicProvider {
+    fn runtime_transport_binding(&self, auth: &ProviderAuthOverride) -> anyhow::Result<ProviderTransportBinding> {
+        anyhow::ensure!(matches!(auth, ProviderAuthOverride::Inherit), "provider does not support tenant-scoped authentication");
+        runtime_binding::transport("https://api.anthropic.com/v1/messages", ProviderProtocol::Anthropic, None, self.api_key.as_deref(), runtime_binding::inherited_source(self.api_key.as_deref()))
+    }
     fn supports_attempt_accounting(&self) -> bool { true }
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
         Some(ProviderInstallationMetadata::network("anthropic", "https://api.anthropic.com/v1/messages"))
@@ -1542,6 +1558,10 @@ impl Provider for AnthropicProvider {
 
 #[async_trait]
 impl Provider for CohereProvider {
+    fn runtime_transport_binding(&self, auth: &ProviderAuthOverride) -> anyhow::Result<ProviderTransportBinding> {
+        anyhow::ensure!(matches!(auth, ProviderAuthOverride::Inherit), "provider does not support tenant-scoped authentication");
+        runtime_binding::transport(&format!("{}/chat", self.base_url), ProviderProtocol::Cohere, self.api_key.as_deref(), None, runtime_binding::inherited_source(self.api_key.as_deref()))
+    }
     fn supports_attempt_accounting(&self) -> bool { true }
     fn installation_metadata(&self) -> Option<ProviderInstallationMetadata> {
         Some(ProviderInstallationMetadata::network("cohere", &self.base_url))

--- a/crates/tandem-providers/src/lib_parts/part04.rs
+++ b/crates/tandem-providers/src/lib_parts/part04.rs
@@ -4,6 +4,7 @@ mod tests {
     include!("../hosted_policy_tests.rs");
     include!("../provider_attempt_tests.rs");
     include!("../attempt_accounting_tests.rs");
+    include!("../runtime_binding_tests.rs");
     use futures::StreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;

--- a/crates/tandem-providers/src/runtime_binding.rs
+++ b/crates/tandem-providers/src/runtime_binding.rs
@@ -1,0 +1,152 @@
+//! Current concrete transport facts for trusted model policy. These are a
+//! read-only snapshot, not an authorization or a durable account generation.
+
+use anyhow::{ensure, Context};
+use serde::Serialize;
+use tandem_types::TenantContext;
+
+use crate::{ProviderAttempt, ProviderAuthOverride, ProviderProtocol, ProviderRegistry};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderCredentialSource {
+    HostService,
+    TenantBearer,
+    Unauthenticated,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ProviderRuntimeBinding {
+    pub tenant_context: TenantContext,
+    pub provider_id: String,
+    pub model_id: String,
+    pub protocol: ProviderProtocol,
+    pub endpoint_sha256: String,
+    pub credential_sha256: String,
+    pub credential_source: ProviderCredentialSource,
+}
+
+impl ProviderRuntimeBinding {
+    pub fn matches_attempt(&self, attempt: &ProviderAttempt) -> bool {
+        self.provider_id == attempt.provider_id
+            && self.model_id == attempt.model_id
+            && self.protocol == attempt.protocol
+            && self.endpoint_sha256 == attempt.endpoint_sha256
+            && self.credential_sha256 == attempt.credential_sha256
+    }
+}
+
+/// Adapter-owned request description. It never contains raw keys or endpoints.
+/// Unknown custom adapters cannot construct this through browser configuration.
+#[derive(Clone)]
+pub struct ProviderTransportBinding {
+    pub(crate) protocol: ProviderProtocol,
+    pub(crate) endpoint_sha256: String,
+    pub(crate) credential_sha256: String,
+    pub(crate) credential_source: ProviderCredentialSource,
+}
+
+pub(crate) fn transport(
+    endpoint: &str,
+    protocol: ProviderProtocol,
+    bearer: Option<&str>,
+    api_key: Option<&str>,
+    source: ProviderCredentialSource,
+) -> anyhow::Result<ProviderTransportBinding> {
+    let mut request = reqwest::Request::new(reqwest::Method::POST, reqwest::Url::parse(endpoint)?);
+    ensure!(
+        matches!(request.url().scheme(), "http" | "https")
+            && request.url().host_str().is_some()
+            && request.url().username().is_empty()
+            && request.url().password().is_none(),
+        "invalid provider transport endpoint"
+    );
+    if let Some(token) = bearer {
+        ensure!(!token.trim().is_empty(), "empty provider credential");
+        request.headers_mut().insert(
+            reqwest::header::AUTHORIZATION,
+            reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))?,
+        );
+    }
+    if let Some(token) = api_key {
+        ensure!(!token.trim().is_empty(), "empty provider credential");
+        request
+            .headers_mut()
+            .insert("x-api-key", reqwest::header::HeaderValue::from_str(token)?);
+    }
+    let fingerprints = crate::attempt_accounting::request_fingerprints(&request);
+    Ok(ProviderTransportBinding {
+        protocol,
+        endpoint_sha256: fingerprints.endpoint_sha256,
+        credential_sha256: fingerprints.credential_sha256,
+        credential_source: source,
+    })
+}
+
+pub(crate) fn inherited_source(key: Option<&str>) -> ProviderCredentialSource {
+    if key.is_some() {
+        ProviderCredentialSource::HostService
+    } else {
+        ProviderCredentialSource::Unauthenticated
+    }
+}
+
+impl ProviderRegistry {
+    /// Resolve an explicit model from the actual configured adapter and current
+    /// tenant authentication. No network, credential load/refresh or mutation.
+    /// Callers must independently authorize the tenant and approve the account,
+    /// model capabilities, prices, data classes and durable lifecycle revision.
+    pub async fn runtime_binding_for_tenant(
+        &self,
+        tenant: &TenantContext,
+        provider_id: &str,
+        model_id: &str,
+    ) -> anyhow::Result<ProviderRuntimeBinding> {
+        ensure!(
+            !provider_id.is_empty()
+                && !model_id.is_empty()
+                && provider_id == provider_id.trim()
+                && model_id == model_id.trim(),
+            "explicit provider and model IDs required"
+        );
+        // Keep the adapter read lock while inspecting tenant auth. A reload
+        // cannot splice a new adapter into this snapshot. No mutation holds the
+        // token lock while acquiring the adapter lock.
+        let providers = self.providers.read().await;
+        let mut matching = providers
+            .iter()
+            .filter(|provider| provider.info().id == provider_id);
+        let provider = matching.next().context("runtime provider unavailable")?;
+        ensure!(matching.next().is_none(), "ambiguous runtime provider ID");
+        ensure!(
+            provider.supports_attempt_accounting(),
+            "provider lacks bounded attempt support"
+        );
+        let info = provider.info();
+        ensure!(
+            info.models
+                .iter()
+                .filter(|model| model.id == model_id && model.provider_id == provider_id)
+                .count()
+                == 1,
+            "runtime model unavailable or ambiguous"
+        );
+        let auth = self
+            .auth_override_for_tenant(provider_id, Some(tenant))
+            .await;
+        ensure!(
+            !matches!(auth, ProviderAuthOverride::Suppress),
+            "tenant provider credential missing"
+        );
+        let binding = provider.runtime_transport_binding(&auth)?;
+        Ok(ProviderRuntimeBinding {
+            tenant_context: tenant.clone(),
+            provider_id: provider_id.into(),
+            model_id: model_id.into(),
+            protocol: binding.protocol,
+            endpoint_sha256: binding.endpoint_sha256,
+            credential_sha256: binding.credential_sha256,
+            credential_source: binding.credential_source,
+        })
+    }
+}

--- a/crates/tandem-providers/src/runtime_binding_tests.rs
+++ b/crates/tandem-providers/src/runtime_binding_tests.rs
@@ -1,0 +1,319 @@
+#[cfg(test)]
+mod runtime_binding_tests {
+    use super::provider_attempt_tests::{compatible, responses};
+    use super::*;
+
+    fn tenant(name: &str) -> TenantContext {
+        TenantContext::explicit(name, "workspace", Some("deployment".into()))
+    }
+
+    fn configured(url: &str, key: Option<&str>) -> AppConfig {
+        AppConfig {
+            providers: [(
+                "ollama".into(),
+                ProviderConfig {
+                    url: Some(url.into()),
+                    api_key: key.map(str::to_string),
+                    default_model: Some("synthetic-model".into()),
+                },
+            )]
+            .into(),
+            default_provider: Some("ollama".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn runtime_binding_reads_current_route_credentials_and_model_without_network() {
+        let registry = ProviderRegistry::new(configured(
+            "https://one.invalid/v1",
+            Some("synthetic-host-secret"),
+        ));
+        let scope = tenant("org-a");
+        let first = registry
+            .runtime_binding_for_tenant(&scope, "ollama", "synthetic-model")
+            .await
+            .unwrap();
+        assert_eq!(
+            first.credential_source,
+            ProviderCredentialSource::HostService
+        );
+        let encoded = serde_json::to_string(&first).unwrap();
+        assert!(!encoded.contains("synthetic-host-secret"));
+        assert!(!encoded.contains("one.invalid"));
+        registry
+            .reload(configured(
+                "https://two.invalid/v1",
+                Some("synthetic-host-secret"),
+            ))
+            .await;
+        let route = registry
+            .runtime_binding_for_tenant(&scope, "ollama", "synthetic-model")
+            .await
+            .unwrap();
+        assert_ne!(first.endpoint_sha256, route.endpoint_sha256);
+        assert_eq!(first.credential_sha256, route.credential_sha256);
+        registry
+            .reload(configured(
+                "https://two.invalid/v1",
+                Some("synthetic-replacement"),
+            ))
+            .await;
+        let key = registry
+            .runtime_binding_for_tenant(&scope, "ollama", "synthetic-model")
+            .await
+            .unwrap();
+        assert_ne!(route.credential_sha256, key.credential_sha256);
+        registry
+            .reload(configured("https://two.invalid/v1", None))
+            .await;
+        let no_key = registry
+            .runtime_binding_for_tenant(&scope, "ollama", "synthetic-model")
+            .await
+            .unwrap();
+        assert_eq!(
+            no_key.credential_source,
+            ProviderCredentialSource::Unauthenticated
+        );
+        assert!(registry
+            .runtime_binding_for_tenant(&scope, "ollama", "missing-model")
+            .await
+            .is_err());
+        assert!(registry
+            .runtime_binding_for_tenant(&scope, "", "synthetic-model")
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn runtime_binding_scopes_codex_credentials_and_never_inherits_for_missing_tenant() {
+        let registry = ProviderRegistry::new(AppConfig::default());
+        let mut provider = responses("https://synthetic.invalid".into());
+        provider.api_key = Some("synthetic-global-token".into());
+        provider.models = vec![ModelInfo {
+            id: "synthetic-model".into(),
+            provider_id: "openai-codex".into(),
+            display_name: "Synthetic".into(),
+            context_window: 100,
+        }];
+        registry
+            .replace_for_test(vec![Arc::new(provider)], Some("openai-codex".into()))
+            .await;
+        let a = tenant("org-a");
+        let b = tenant("org-b");
+        assert!(registry
+            .runtime_binding_for_tenant(&a, "openai-codex", "synthetic-model")
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("credential missing"));
+        registry
+            .set_tenant_provider_bearer_token(&a, "openai-codex", "synthetic-a".into())
+            .await;
+        registry
+            .set_tenant_provider_bearer_token(&b, "openai-codex", "synthetic-b".into())
+            .await;
+        let (a_binding, b_binding) = tokio::join!(
+            registry.runtime_binding_for_tenant(&a, "openai-codex", "synthetic-model"),
+            registry.runtime_binding_for_tenant(&b, "openai-codex", "synthetic-model")
+        );
+        let a_binding = a_binding.unwrap();
+        let b_binding = b_binding.unwrap();
+        assert_eq!(
+            a_binding.credential_source,
+            ProviderCredentialSource::TenantBearer
+        );
+        assert_ne!(a_binding.credential_sha256, b_binding.credential_sha256);
+        assert_eq!(a_binding.endpoint_sha256, b_binding.endpoint_sha256);
+        registry
+            .clear_tenant_provider_bearer_token(&a, "openai-codex")
+            .await;
+        assert!(registry
+            .runtime_binding_for_tenant(&a, "openai-codex", "synthetic-model")
+            .await
+            .is_err());
+        assert_eq!(
+            b_binding,
+            registry
+                .runtime_binding_for_tenant(&b, "openai-codex", "synthetic-model")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_binding_rejects_unknown_and_ambiguous_adapters() {
+        let registry = ProviderRegistry::new(AppConfig::default());
+        assert!(registry
+            .runtime_binding_for_tenant(&tenant("a"), "local", "synthetic-model")
+            .await
+            .is_err());
+        registry
+            .replace_for_test(
+                vec![
+                    Arc::new(compatible("http://127.0.0.1:1".into())),
+                    Arc::new(compatible("http://127.0.0.1:2".into())),
+                ],
+                None,
+            )
+            .await;
+        assert!(registry
+            .runtime_binding_for_tenant(&tenant("a"), "ollama", "synthetic-model")
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("ambiguous"));
+    }
+
+    #[tokio::test]
+    async fn runtime_binding_matches_three_actual_adapters_before_network() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let mut compatible = compatible(endpoint.clone());
+        compatible.api_key = Some("synthetic-host-key".into());
+        let mut responses = responses(endpoint.clone());
+        responses.models = vec![ModelInfo {
+            id: "synthetic-model".into(),
+            provider_id: "openai-codex".into(),
+            display_name: "Synthetic".into(),
+            context_window: 100,
+        }];
+        let providers: Vec<Arc<dyn Provider>> = vec![
+            Arc::new(compatible),
+            Arc::new(responses),
+            Arc::new(AnthropicProvider {
+                api_key: Some("synthetic-anthropic".into()),
+                default_model: "synthetic-model".into(),
+                client: Client::builder()
+                    .proxy(reqwest::Proxy::all(&endpoint).unwrap())
+                    .redirect(reqwest::redirect::Policy::none())
+                    .timeout(Duration::from_secs(3))
+                    .build()
+                    .unwrap(),
+            }),
+            Arc::new(CohereProvider {
+                api_key: Some("synthetic-cohere".into()),
+                base_url: "https://cohere.invalid/v2".into(),
+                default_model: "synthetic-model".into(),
+            }),
+        ];
+        let registry = ProviderRegistry::new(AppConfig::default());
+        registry.replace_for_test(providers, None).await;
+        let scope = tenant("org-a");
+        registry
+            .set_tenant_provider_bearer_token(&scope, "openai-codex", "synthetic-tenant-key".into())
+            .await;
+        let cohere = registry
+            .runtime_binding_for_tenant(&scope, "cohere", "synthetic-model")
+            .await
+            .unwrap();
+        assert_eq!(cohere.protocol, ProviderProtocol::Cohere);
+        assert_eq!(
+            cohere.credential_source,
+            ProviderCredentialSource::HostService
+        );
+        for id in ["ollama", "openai-codex", "anthropic"] {
+            for streaming in [false, true] {
+                let binding = registry
+                    .runtime_binding_for_tenant(&scope, id, "synthetic-model")
+                    .await
+                    .unwrap();
+                let count = Arc::new(AtomicUsize::new(0));
+                let observed = count.clone();
+                let policy = ProviderAttemptPolicy::new(10, 4096, move |attempt| {
+                    assert!(
+                        binding.matches_attempt(&attempt),
+                        "snapshot must describe final request bytes"
+                    );
+                    observed.fetch_add(1, Ordering::SeqCst);
+                    async { anyhow::bail!("verified snapshot; stopped before transport") }
+                })
+                .unwrap();
+                let result = registry
+                    .scope_tenant_provider_auth_with_recovery(
+                        scope.clone(),
+                        ProviderAuthRecovery::new(|_| async { Ok(false) }),
+                        true,
+                        policy.scope(async {
+                            if streaming {
+                                registry
+                                    .stream_for_provider(
+                                        Some(id),
+                                        Some("synthetic-model"),
+                                        vec![ChatMessage {
+                                            role: "user".into(),
+                                            content: "synthetic".into(),
+                                            attachments: Vec::new(),
+                                        }],
+                                        ToolMode::None,
+                                        None,
+                                        SamplingParams::default(),
+                                        CancellationToken::new(),
+                                    )
+                                    .await
+                                    .map(|_| ())
+                            } else {
+                                registry
+                                    .complete_for_provider(
+                                        Some(id),
+                                        "synthetic",
+                                        Some("synthetic-model"),
+                                    )
+                                    .await
+                                    .map(|_| ())
+                            }
+                        }),
+                    )
+                    .await;
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("verified snapshot"));
+                assert_eq!(count.load(Ordering::SeqCst), 1);
+            }
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+    #[tokio::test]
+    async fn runtime_binding_uses_concrete_codex_route_instead_of_ignored_url_override() {
+        let config = |url: &str| AppConfig {
+            providers: [(
+                "openai-codex".into(),
+                ProviderConfig {
+                    url: Some(url.into()),
+                    api_key: None,
+                    default_model: None,
+                },
+            )]
+            .into(),
+            default_provider: Some("openai-codex".into()),
+        };
+        let registry = ProviderRegistry::new(config("https://ignored-one.invalid"));
+        let scope = tenant("org-a");
+        registry
+            .set_tenant_provider_bearer_token(&scope, "openai-codex", "synthetic-tenant".into())
+            .await;
+        let model = registry
+            .list()
+            .await
+            .into_iter()
+            .find(|provider| provider.id == "openai-codex")
+            .unwrap()
+            .models[0]
+            .id
+            .clone();
+        let before = registry
+            .runtime_binding_for_tenant(&scope, "openai-codex", &model)
+            .await
+            .unwrap();
+        registry.reload(config("https://ignored-two.invalid")).await;
+        let after = registry
+            .runtime_binding_for_tenant(&scope, "openai-codex", &model)
+            .await
+            .unwrap();
+        assert_eq!(before, after);
+    }
+}

--- a/crates/tandem-providers/src/runtime_binding_tests.rs
+++ b/crates/tandem-providers/src/runtime_binding_tests.rs
@@ -10,7 +10,7 @@ mod runtime_binding_tests {
     fn configured(url: &str, key: Option<&str>) -> AppConfig {
         AppConfig {
             providers: [(
-                "ollama".into(),
+                "llama_cpp".into(),
                 ProviderConfig {
                     url: Some(url.into()),
                     api_key: key.map(str::to_string),
@@ -18,7 +18,7 @@ mod runtime_binding_tests {
                 },
             )]
             .into(),
-            default_provider: Some("ollama".into()),
+            default_provider: Some("llama_cpp".into()),
         }
     }
 
@@ -30,7 +30,7 @@ mod runtime_binding_tests {
         ));
         let scope = tenant("org-a");
         let first = registry
-            .runtime_binding_for_tenant(&scope, "ollama", "synthetic-model")
+            .runtime_binding_for_tenant(&scope, "llama_cpp", "synthetic-model")
             .await
             .unwrap();
         assert_eq!(
@@ -47,7 +47,7 @@ mod runtime_binding_tests {
             ))
             .await;
         let route = registry
-            .runtime_binding_for_tenant(&scope, "ollama", "synthetic-model")
+            .runtime_binding_for_tenant(&scope, "llama_cpp", "synthetic-model")
             .await
             .unwrap();
         assert_ne!(first.endpoint_sha256, route.endpoint_sha256);
@@ -59,7 +59,7 @@ mod runtime_binding_tests {
             ))
             .await;
         let key = registry
-            .runtime_binding_for_tenant(&scope, "ollama", "synthetic-model")
+            .runtime_binding_for_tenant(&scope, "llama_cpp", "synthetic-model")
             .await
             .unwrap();
         assert_ne!(route.credential_sha256, key.credential_sha256);
@@ -67,7 +67,7 @@ mod runtime_binding_tests {
             .reload(configured("https://two.invalid/v1", None))
             .await;
         let no_key = registry
-            .runtime_binding_for_tenant(&scope, "ollama", "synthetic-model")
+            .runtime_binding_for_tenant(&scope, "llama_cpp", "synthetic-model")
             .await
             .unwrap();
         assert_eq!(
@@ -75,7 +75,7 @@ mod runtime_binding_tests {
             ProviderCredentialSource::Unauthenticated
         );
         assert!(registry
-            .runtime_binding_for_tenant(&scope, "ollama", "missing-model")
+            .runtime_binding_for_tenant(&scope, "llama_cpp", "missing-model")
             .await
             .is_err());
         assert!(registry

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
@@ -1,8 +1,6 @@
 use super::*;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use tandem_providers::{
-    AppConfig, ProviderAttempt, ProviderAuthRecovery, ProviderConfig, ProviderRegistry,
-};
+use tandem_providers::{AppConfig, ProviderAuthRecovery, ProviderConfig, ProviderRegistry};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 fn network_fixture(store: &OrchestrationStateStore, name: &str) -> BudgetFixture {
@@ -42,19 +40,23 @@ fn runtime() -> tokio::runtime::Runtime {
         .unwrap()
 }
 
-fn registry(address: std::net::SocketAddr) -> ProviderRegistry {
-    ProviderRegistry::new(AppConfig {
+fn configuration(address: std::net::SocketAddr, key: Option<&str>) -> AppConfig {
+    AppConfig {
         providers: [(
             "ollama".into(),
             ProviderConfig {
                 url: Some(format!("http://{address}/v1")),
-                api_key: None,
+                api_key: key.map(str::to_string),
                 default_model: Some("synthetic-model".into()),
             },
         )]
         .into(),
         default_provider: Some("ollama".into()),
-    })
+    }
+}
+
+fn registry(address: std::net::SocketAddr) -> ProviderRegistry {
+    ProviderRegistry::new(configuration(address, None))
 }
 
 fn approval(
@@ -101,30 +103,41 @@ fn approval(
     }
 }
 
-fn current(
+async fn current(
     approved: &ApprovedSolutionProviderCharge,
-    attempt: ProviderAttempt,
-) -> ApprovedSolutionProviderCharge {
+    registry: &ProviderRegistry,
+) -> anyhow::Result<ApprovedSolutionProviderCharge> {
     let mut result = approved.clone();
-    // Synthetic trusted binding callback. Real activation must obtain these
-    // facts from its current host/account registry, not echo browser input.
-    result.endpoint_sha256 = attempt.endpoint_sha256;
-    result.credential_sha256 = attempt.credential_sha256;
-    result
+    // Model/root authorization remains a synthetic fixture; transport/account
+    // facts now come independently from the actual configured registry.
+    let binding = registry
+        .runtime_binding_for_tenant(
+            &approved.verified.tenant_context,
+            &approved.provider_id,
+            &approved.model_id,
+        )
+        .await?;
+    anyhow::ensure!(binding.protocol == result.protocol, "protocol changed");
+    result.endpoint_sha256 = binding.endpoint_sha256;
+    result.credential_sha256 = binding.credential_sha256;
+    Ok(result)
 }
 
 fn policy(
     store: &OrchestrationStateStore,
+    registry: &ProviderRegistry,
     approved: ApprovedSolutionProviderCharge,
     clock: Arc<AtomicU64>,
 ) -> tandem_providers::ProviderAttemptPolicy {
+    let registry = registry.clone();
     store
         .solution_provider_attempt_policy(
             10,
             4096,
-            move |attempt| {
-                let approved = current(&approved, attempt);
-                async move { Ok(approved) }
+            move |_attempt| {
+                let approved = approved.clone();
+                let registry = registry.clone();
+                async move { current(&approved, &registry).await }
             },
             move || clock.load(Ordering::SeqCst),
         )
@@ -250,7 +263,7 @@ fn solution_budget_provider_actual_sends_share_the_durable_ceiling() {
                 reply(&mut socket, true).await;
             });
             let clock = Arc::new(AtomicU64::new(1500));
-            let policy = policy(store, approved, clock);
+            let policy = policy(store, &registry, approved, clock);
             let first = complete(&registry, policy.clone());
             tokio::pin!(first);
             tokio::select! {
@@ -289,7 +302,7 @@ fn solution_budget_provider_missing_usage_survives_reopen_and_blocks_overspend()
                     reply(&mut socket, false).await;
                     listener
                 });
-                let policy = policy(store, approved, Arc::new(AtomicU64::new(1500)));
+                let policy = policy(store, &registry, approved, Arc::new(AtomicU64::new(1500)));
                 assert_eq!(complete(&registry, policy.clone()).await.unwrap(), "ok");
                 let reopened = store.clone();
                 crate::encrypted_file_store::spawn_protected_blocking(move || {
@@ -339,7 +352,7 @@ fn solution_budget_provider_confirmed_receipt_settles_after_user_assertion_expir
                     reply(&mut socket, true).await;
                     listener
                 });
-                let policy = policy(store, approved, clock);
+                let policy = policy(store, &registry, approved, clock);
                 assert_eq!(complete(&registry, policy.clone()).await.unwrap(), "ok");
                 assert!(
                     complete(&registry, policy).await.is_err(),
@@ -375,19 +388,30 @@ fn solution_budget_provider_rechecks_binding_after_reservation_without_sending()
             let approved = approval(&fixture, store);
             runtime().block_on(async {
                 let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-                let registry = registry(listener.local_addr().unwrap());
+                let address = listener.local_addr().unwrap();
+                let registry = registry(address);
                 let checks = Arc::new(AtomicUsize::new(0));
                 let count = checks.clone();
+                let runtime_registry = registry.clone();
                 let policy = store
                     .solution_provider_attempt_policy(
                         10,
                         4096,
-                        move |attempt| {
-                            let mut approved = current(&approved, attempt);
-                            if count.fetch_add(1, Ordering::SeqCst) > 0 {
-                                approved.route_revision = sha256(b"changed-account-generation");
+                        move |_attempt| {
+                            let approved = approved.clone();
+                            let registry = runtime_registry.clone();
+                            let changed = count.fetch_add(1, Ordering::SeqCst) > 0;
+                            async move {
+                                if changed {
+                                    registry
+                                        .reload(configuration(
+                                            address,
+                                            Some("synthetic-rebound-account"),
+                                        ))
+                                        .await;
+                                }
+                                current(&approved, &registry).await
                             }
-                            async move { Ok(approved) }
                         },
                         || 1500,
                     )
@@ -432,7 +456,7 @@ fn solution_budget_provider_rejects_stale_model_and_unknown_price_before_network
                         2 => invalid.price = None,
                         _ => invalid.price.as_mut().unwrap().valid_until_ms = 1499,
                     }
-                    let policy = policy(store, invalid, Arc::new(AtomicU64::new(1500)));
+                    let policy = policy(store, &registry, invalid, Arc::new(AtomicU64::new(1500)));
                     assert!(complete(&registry, policy).await.is_err());
                 }
                 assert!(tokio::time::timeout(

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
@@ -10,14 +10,14 @@ fn network_fixture(store: &OrchestrationStateStore, name: &str) -> BudgetFixture
         &mut installation.customer.blueprint.constraints,
         &mut installation.customer.config.constraints,
     ] {
-        policy.allowed_providers = ["ollama".into()].into();
+        policy.allowed_providers = ["llama_cpp".into()].into();
         policy.allow_network_egress = true;
         policy.max_daily_cost_microusd = 50;
         policy.max_tokens_per_run = 100;
         policy.max_concurrent_runs = 4;
     }
     let model = installation.models.get_mut("local.fixture").unwrap();
-    model.provider = "ollama".into();
+    model.provider = "llama_cpp".into();
     model.uses_network = true;
     let (config, digest) = installation.seed(store);
     store
@@ -43,7 +43,7 @@ fn runtime() -> tokio::runtime::Runtime {
 fn configuration(address: std::net::SocketAddr, key: Option<&str>) -> AppConfig {
     AppConfig {
         providers: [(
-            "ollama".into(),
+            "llama_cpp".into(),
             ProviderConfig {
                 url: Some(format!("http://{address}/v1")),
                 api_key: key.map(str::to_string),
@@ -51,7 +51,7 @@ fn configuration(address: std::net::SocketAddr, key: Option<&str>) -> AppConfig 
             },
         )]
         .into(),
-        default_provider: Some("ollama".into()),
+        default_provider: Some("llama_cpp".into()),
     }
 }
 
@@ -82,7 +82,7 @@ fn approval(
         root_run_id: "actual-root".into(),
         kind: SolutionChargeKind::Model,
         route_revision: sha256(b"synthetic-approved-account-model-price"),
-        provider_id: "ollama".into(),
+        provider_id: "llama_cpp".into(),
         model_id: "synthetic-model".into(),
         protocol: tandem_providers::ProviderProtocol::ChatCompletions,
         endpoint_sha256: String::new(),
@@ -157,7 +157,11 @@ async fn complete(
             ),
             ProviderAuthRecovery::new(|_| async { Ok(false) }),
             true,
-            policy.scope(registry.complete_for_provider(Some("ollama"), "synthetic request", None)),
+            policy.scope(registry.complete_for_provider(
+                Some("llama_cpp"),
+                "synthetic request",
+                None,
+            )),
         )
         .await
 }

--- a/docs/RUNTIME_MODEL_BINDING.md
+++ b/docs/RUNTIME_MODEL_BINDING.md
@@ -1,0 +1,58 @@
+# Current runtime model bindings
+
+`ProviderRegistry::runtime_binding_for_tenant` reads the actual configured adapter
+and current authentication selection for an explicit tenant/provider/model. It
+performs no network request, credential refresh or mutation. The adapter lock
+remains held while tenant authentication is inspected, preventing a reload from
+mixing two adapter snapshots.
+
+The result identifies the model, protocol, tenant and credential source:
+`host_service`, `tenant_bearer` or `unauthenticated`. Endpoint and final credential
+headers use the same fingerprints as physical-attempt accounting. Raw keys and
+endpoint URLs are absent. This describes concrete transport state; neither a
+customer credential-reference string nor a caller-provided hash supplies it.
+
+Codex keeps the existing tenant override rules. An explicit tenant with no loaded
+bearer token cannot inherit a global credential. Other adapters report their
+configured host service credential or unauthenticated state; that classification
+does not approve sharing a service account. Unknown adapters, ambiguous provider
+IDs and unavailable/ambiguous models fail the lookup. Legacy dispatch remains
+available outside the solution policy path.
+
+The lookup deliberately does not use configured URL overrides to infer Codex's
+endpoint: its concrete adapter owns the route. It also does not equate advertised
+context windows with verified input, output, tool, modality or billing limits.
+
+## Verification
+
+Provider tests inspect model availability, endpoint/key replacement, absent
+credentials, concurrent tenant token isolation and clearing one tenant without
+affecting another. Synthetic `.invalid` endpoints establish that snapshot lookup
+does not resolve or contact a provider. Compatible, Responses and Anthropic tests
+compare snapshots with actual complete/stream request descriptors and stop at
+admission before networking; Anthropic additionally uses a local proxy. Cohere
+has read-only binding coverage; its hardened transport does not permit the local
+HTTP fixture, so it is not claimed as an executed Cohere integration.
+
+The existing SQLite/PostgreSQL provider-ledger tests now obtain transport hashes
+independently from this registry API. Their higher-level model/root approval
+remains synthetic. Replacing the actual registry credential after reservation
+changes the second authorization result, prevents the HTTP send and reconciles
+the proven non-dispatch at zero.
+
+## Remaining authority and lifecycle work
+
+A snapshot is not a verified user identity, account authorization or durable
+account generation. Replacing a key and later restoring the same bytes can
+restore its fingerprint. Durable account lifecycle metadata belongs in the
+existing credential subsystem; OAuth token refresh must remain distinct from
+authorized account replacement. Registry reload and persisted credential
+changes also require current reconciliation at runtime.
+
+The production solution factory must independently authorize current users,
+account ownership/service sharing, model capabilities and data-class destination
+policy, approved prices/input ceilings and actual root lineage. It must compare
+the final attempt to current facts again after reservation, while preserving
+hosted-policy and exact-payload egress checks. Activation and user source/private
+memory authorization remain separate from the installer's admin preview. This
+slice does not complete TAN-831 or full Company Brain acceptance.


### PR DESCRIPTION
Budget admission needs independent current transport facts. Add a read-only ProviderRegistry lookup for an explicit tenant/provider/model using the actual configured adapter and existing tenant authentication selection. It returns the concrete protocol, endpoint/credential fingerprints and host-service/tenant-bearer/unauthenticated classification, without raw keys or URLs. Physical-attempt admission and snapshots share one fingerprint implementation.

Explicit Codex tenants with no loaded credential cannot inherit global authentication. Unknown adapters, duplicate provider IDs and unavailable/ambiguous models fail the lookup. The existing dispatch auth helper is reused; legacy unscoped dispatch behavior is preserved. Codex uses its concrete fixed route, not an ignored configuration URL override. Snapshot lookup makes no network request or credential mutation.

Five new provider tests cover route/key replacement, unavailable models, tenant isolation and clear, ambiguous adapters, concrete Codex routing, and actual complete/stream request descriptors for compatible/Responses/Anthropic. Anthropic uses a local proxy as an additional network barrier. Cohere has read-only snapshot coverage; no actual local Cohere HTTP integration is claimed. Existing real SQLite/PostgreSQL provider-budget tests now resolve hashes from the registry rather than echo request values. Replacing the actual registry credential after reservation must prevent the send and reconcile proven non-dispatch at zero.

Validation: current signed head a4a68e4c49f8bd392868811e39fbf97775c301e7 passed Solution34017834416 planning101444749616 and storage101444749524, including all13 real SQLite/PostgreSQL budget cases, actual credential replacement before send, encrypted transfer, native/service/HTTP tests and PostgreSQL/SQLite clippy. Hosted34017834403/job101444713247 passed all77 provider tests and the remaining workflow. All six workflows now pass at this exact head: Engine34017834392/workspace101445594967 completed 5221 tests passed, 7 skipped; Security34017834419 completed release, container and aggregate assurance. ACME34017834417 and Email34017834398 also pass. Marked ready for review after exact-head verification; not merged. The initial fixture assumed Ollama uses API keys; tests now use existing llama_cpp, which supports keys and local HTTP. Production behavior was unchanged. Local Rustfmt/diff checks passed; Cargo is unavailable locally. Stacked on #1947 at 6360e10df3fe366250e6b164f7cde34b491879ce; DCO sign-off verified before publishing. No remote PR merge.

This snapshot is not account authorization or a durable account generation. Token refresh differs from account replacement; A→B→A lifecycle metadata remains in scope for the existing credential subsystem. Production activation/current user permissions/account-sharing approval/model capability/data-class/pricing/root-lineage factory and full privacy/recovery/clean-host acceptance remain open. Do not mark TAN-831 Done or merge automatically. See docs/RUNTIME_MODEL_BINDING.md.