### PR TITLE
TAN-831: bind runtime model routes to persisted account revisions

### DIFF
--- a/crates/tandem-providers/src/lib.rs
+++ b/crates/tandem-providers/src/lib.rs
@@ -21,3 +21,7 @@ mod runtime_binding;
 pub use runtime_binding::{
     ProviderCredentialSource, ProviderRuntimeBinding, ProviderTransportBinding,
 };
+mod versioned_binding;
+pub use versioned_binding::{ProviderCredentialLocation, VersionedProviderRuntimeBinding};
+#[cfg(test)]
+mod versioned_binding_tests;

--- a/crates/tandem-providers/src/provider_auth_store.rs
+++ b/crates/tandem-providers/src/provider_auth_store.rs
@@ -10,6 +10,7 @@ use serde_json::{json, Value};
 use tandem_types::TenantContext;
 
 mod credential_lifecycle;
+pub(crate) use credential_lifecycle::match_runtime_credential_revision;
 use credential_lifecycle::Mutation;
 pub use credential_lifecycle::{
     provider_credential_revision, provider_credential_revision_for_tenant,

--- a/crates/tandem-providers/src/provider_auth_store/credential_lifecycle.rs
+++ b/crates/tandem-providers/src/provider_auth_store/credential_lifecycle.rs
@@ -319,12 +319,12 @@ fn same_oauth_account(left: Option<&Value>, right: Option<&Value>) -> bool {
     }
 }
 
-fn active_revision(
+fn active_material(
     dir: &Path,
     kind: ProviderCredentialKind,
     id: &str,
     consult_keychain: bool,
-) -> anyhow::Result<ProviderCredentialRevision> {
+) -> anyhow::Result<(ProviderCredentialRevision, Value)> {
     let _guard = ProviderCredentialMutationFileLock::acquire_blocking(dir)?;
     let id = normalize_provider_id(id);
     let index = strict_json(&kind.index(dir))?;
@@ -355,7 +355,68 @@ fn active_revision(
         actual.is_some() && actual == record.material_sha256,
         "credential revision material mismatch"
     );
-    Ok(record.revision)
+    Ok((
+        record.revision,
+        current.expect("active material was checked"),
+    ))
+}
+
+fn active_revision(
+    dir: &Path,
+    kind: ProviderCredentialKind,
+    id: &str,
+    consult_keychain: bool,
+) -> anyhow::Result<ProviderCredentialRevision> {
+    active_material(dir, kind, id, consult_keychain).map(|(revision, _)| revision)
+}
+
+pub(crate) fn match_runtime_credential_revision(
+    dir: &Path,
+    runtime: &crate::ProviderRuntimeBinding,
+    kind: ProviderCredentialKind,
+    location: crate::ProviderCredentialLocation,
+) -> anyhow::Result<ProviderCredentialRevision> {
+    let (id, consult_keychain) = match location {
+        crate::ProviderCredentialLocation::HostService => (runtime.provider_id.clone(), true),
+        crate::ProviderCredentialLocation::TenantService => (
+            tenant_scoped_provider_id(&runtime.tenant_context, &runtime.provider_id),
+            kind == ProviderCredentialKind::Credential,
+        ),
+    };
+    let (revision, material) = active_material(dir, kind, &id, consult_keychain)?;
+    let token = match kind {
+        ProviderCredentialKind::ApiKey => material
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("invalid API-key material"))?
+            .to_string(),
+        ProviderCredentialKind::Credential => {
+            let credential: ProviderCredential = serde_json::from_value(material)
+                .map_err(|_| anyhow::anyhow!("invalid typed credential material"))?;
+            credential
+                .runtime_bearer_token()
+                .ok_or_else(|| anyhow::anyhow!("credential has no runtime token"))?
+                .to_string()
+        }
+    };
+    // Reuse the real request-header fingerprint implementation. The dummy URL
+    // is only used to construct a Request; there is no client, DNS or network.
+    let (bearer, api_key) = if runtime.protocol == crate::ProviderProtocol::Anthropic {
+        (None, Some(token.as_str()))
+    } else {
+        (Some(token.as_str()), None)
+    };
+    let stored = crate::runtime_binding::transport(
+        "https://credential-binding.invalid/",
+        runtime.protocol,
+        bearer,
+        api_key,
+        runtime.credential_source,
+    )?;
+    anyhow::ensure!(
+        stored.credential_sha256 == runtime.credential_sha256,
+        "loaded runtime credential differs from selected persisted revision"
+    );
+    Ok(revision)
 }
 
 pub fn provider_credential_revision(

--- a/crates/tandem-providers/src/versioned_binding.rs
+++ b/crates/tandem-providers/src/versioned_binding.rs
@@ -1,0 +1,89 @@
+//! Join current registry transport facts to the selected persisted credential.
+//! A matching revision is necessary for model approval, never sufficient authority.
+use std::path::Path;
+
+use anyhow::{ensure, Context};
+use serde::Serialize;
+use tandem_types::TenantContext;
+
+use crate::{
+    ProviderCredentialKind, ProviderCredentialRevision, ProviderCredentialSource, ProviderRegistry,
+    ProviderRuntimeBinding,
+};
+
+/// Explicit storage scope. Tenant service credentials are scoped to the existing
+/// organization/workspace/deployment key, not to an individual human actor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderCredentialLocation {
+    HostService,
+    TenantService,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct VersionedProviderRuntimeBinding {
+    pub runtime: ProviderRuntimeBinding,
+    pub credential_kind: ProviderCredentialKind,
+    pub credential_location: ProviderCredentialLocation,
+    pub revision: ProviderCredentialRevision,
+}
+
+impl ProviderRegistry {
+    /// Resolve a model, verify that its loaded credential is the selected stored
+    /// material at the recorded revision, then recheck registry facts. An unrelated
+    /// record with a fresh revision cannot approve a stale loaded bearer token.
+    ///
+    /// This is an optimistic snapshot: callers must separately authorize account
+    /// sharing/current user/data policy and revalidate at every physical attempt.
+    /// No secret, endpoint, account identifier or credential refresh is returned.
+    pub async fn versioned_runtime_binding_for_tenant_in_dir(
+        &self,
+        security_dir: &Path,
+        tenant: &TenantContext,
+        provider_id: &str,
+        model_id: &str,
+        credential_kind: ProviderCredentialKind,
+        credential_location: ProviderCredentialLocation,
+    ) -> anyhow::Result<VersionedProviderRuntimeBinding> {
+        let runtime = self
+            .runtime_binding_for_tenant(tenant, provider_id, model_id)
+            .await?;
+        let expected_source = match credential_location {
+            ProviderCredentialLocation::HostService => ProviderCredentialSource::HostService,
+            ProviderCredentialLocation::TenantService if tenant.is_local_implicit() => {
+                anyhow::bail!("explicit tenant required for tenant service credential")
+            }
+            ProviderCredentialLocation::TenantService => ProviderCredentialSource::TenantBearer,
+        };
+        ensure!(
+            runtime.credential_source == expected_source,
+            "runtime credential source differs from selected account scope"
+        );
+        let directory = security_dir.to_path_buf();
+        let observed = runtime.clone();
+        // Filesystem/keychain locking must not block the asynchronous worker.
+        let revision = tokio::task::spawn_blocking(move || {
+            crate::provider_auth_store::match_runtime_credential_revision(
+                &directory,
+                &observed,
+                credential_kind,
+                credential_location,
+            )
+        })
+        .await
+        .context("join credential binding lookup")??;
+        let current = self
+            .runtime_binding_for_tenant(tenant, provider_id, model_id)
+            .await?;
+        ensure!(
+            current == runtime,
+            "runtime binding changed while reading credential revision"
+        );
+        Ok(VersionedProviderRuntimeBinding {
+            runtime,
+            credential_kind,
+            credential_location,
+            revision,
+        })
+    }
+}

--- a/crates/tandem-providers/src/versioned_binding_tests.rs
+++ b/crates/tandem-providers/src/versioned_binding_tests.rs
@@ -1,0 +1,305 @@
+use crate::*;
+use tempfile::tempdir;
+
+fn tenant() -> TenantContext {
+    TenantContext::explicit(
+        uuid::Uuid::new_v4().to_string(),
+        "workspace",
+        Some("actor".into()),
+    )
+}
+
+fn configured(provider: &str, key: Option<&str>, model: &str) -> AppConfig {
+    AppConfig {
+        providers: [(
+            provider.into(),
+            ProviderConfig {
+                url: Some("https://synthetic.invalid/v1".into()),
+                api_key: key.map(str::to_string),
+                default_model: Some(model.into()),
+            },
+        )]
+        .into(),
+        default_provider: Some(provider.into()),
+    }
+}
+
+fn save_host(dir: &std::path::Path, provider: &str, key: &str) {
+    set_provider_auth_for_tenant_in_dir(dir, &TenantContext::local_implicit(), provider, key)
+        .unwrap();
+}
+
+async fn binding(
+    registry: &ProviderRegistry,
+    dir: &std::path::Path,
+    tenant: &TenantContext,
+) -> anyhow::Result<VersionedProviderRuntimeBinding> {
+    registry
+        .versioned_runtime_binding_for_tenant_in_dir(
+            dir,
+            tenant,
+            "llama_cpp",
+            "synthetic-model",
+            ProviderCredentialKind::ApiKey,
+            ProviderCredentialLocation::HostService,
+        )
+        .await
+}
+
+#[tokio::test]
+async fn current_revision_cannot_approve_stale_loaded_material_or_restore_an_old_approval() {
+    let dir = tempdir().unwrap();
+    let tenant = tenant();
+    let registry = ProviderRegistry::new(configured(
+        "llama_cpp",
+        Some("synthetic-a"),
+        "synthetic-model",
+    ));
+    assert!(
+        binding(&registry, dir.path(), &tenant).await.is_err(),
+        "untracked config key"
+    );
+    save_host(dir.path(), "llama_cpp", "synthetic-a");
+    let first = binding(&registry, dir.path(), &tenant).await.unwrap();
+    save_host(dir.path(), "llama_cpp", "synthetic-b");
+    assert!(
+        binding(&registry, dir.path(), &tenant).await.is_err(),
+        "new revision cannot approve old runtime key"
+    );
+    registry
+        .reload(configured(
+            "llama_cpp",
+            Some("synthetic-b"),
+            "synthetic-model",
+        ))
+        .await;
+    let second = binding(&registry, dir.path(), &tenant).await.unwrap();
+    assert_ne!(
+        first.revision.authorization_revision,
+        second.revision.authorization_revision
+    );
+    save_host(dir.path(), "llama_cpp", "synthetic-a");
+    registry
+        .reload(configured(
+            "llama_cpp",
+            Some("synthetic-a"),
+            "synthetic-model",
+        ))
+        .await;
+    let restored = binding(&registry, dir.path(), &tenant).await.unwrap();
+    assert_eq!(
+        restored.runtime.credential_sha256,
+        first.runtime.credential_sha256
+    );
+    assert_ne!(
+        restored.revision.authorization_revision,
+        first.revision.authorization_revision
+    );
+    let public = format!("{restored:?} {}", serde_json::to_string(&restored).unwrap());
+    assert!(!public.contains("synthetic-a"));
+    assert!(!public.contains("synthetic.invalid"));
+    delete_provider_auth_for_tenant_in_dir(
+        dir.path(),
+        &TenantContext::local_implicit(),
+        "llama_cpp",
+    )
+    .unwrap();
+    assert!(
+        binding(&registry, dir.path(), &tenant).await.is_err(),
+        "disconnect cannot reuse still-loaded bearer"
+    );
+}
+
+#[tokio::test]
+async fn tenant_account_lookup_requires_both_selected_scope_and_its_own_persisted_material() {
+    let dir = tempdir().unwrap();
+    let alpha = tenant();
+    let beta = tenant();
+    let registry = ProviderRegistry::new(configured(
+        "openai-codex",
+        Some("synthetic-shared"),
+        "gpt-5.6-sol",
+    ));
+    save_host(dir.path(), "openai-codex", "synthetic-shared");
+    set_provider_auth_for_tenant_in_dir(dir.path(), &alpha, "openai-codex", "synthetic-shared")
+        .unwrap();
+    let lookup = |scope: TenantContext| {
+        let registry = registry.clone();
+        let path = dir.path().to_path_buf();
+        async move {
+            registry
+                .versioned_runtime_binding_for_tenant_in_dir(
+                    &path,
+                    &scope,
+                    "openai-codex",
+                    "gpt-5.6-sol",
+                    ProviderCredentialKind::ApiKey,
+                    ProviderCredentialLocation::TenantService,
+                )
+                .await
+        }
+    };
+    assert!(
+        lookup(alpha.clone()).await.is_err(),
+        "global credentials do not authorize an unloaded tenant account"
+    );
+    registry
+        .set_tenant_provider_bearer_token(&alpha, "openai-codex", "synthetic-shared".into())
+        .await;
+    lookup(alpha.clone()).await.unwrap();
+    assert!(
+        registry
+            .versioned_runtime_binding_for_tenant_in_dir(
+                dir.path(),
+                &alpha,
+                "openai-codex",
+                "gpt-5.6-sol",
+                ProviderCredentialKind::ApiKey,
+                ProviderCredentialLocation::HostService,
+            )
+            .await
+            .is_err(),
+        "tenant bearer cannot be relabeled host service"
+    );
+    registry
+        .set_tenant_provider_bearer_token(&beta, "openai-codex", "synthetic-shared".into())
+        .await;
+    assert!(
+        lookup(beta.clone()).await.is_err(),
+        "other tenant's index is not proof"
+    );
+    set_provider_auth_for_tenant_in_dir(dir.path(), &beta, "openai-codex", "synthetic-beta")
+        .unwrap();
+    assert!(
+        lookup(beta.clone()).await.is_err(),
+        "other tenant's matching loaded key does not match selected persisted material"
+    );
+    registry
+        .set_tenant_provider_bearer_token(&beta, "openai-codex", "synthetic-beta".into())
+        .await;
+    lookup(beta).await.unwrap();
+    assert!(lookup(TenantContext::local_implicit()).await.is_err());
+}
+
+fn oauth(label: &str) -> OAuthProviderCredential {
+    OAuthProviderCredential {
+        provider_id: "openai-codex".into(),
+        access_token: format!("access-{label}"),
+        refresh_token: format!("refresh-{label}"),
+        expires_at_ms: 2_000_000_000_000,
+        account_id: Some("synthetic-account".into()),
+        email: None,
+        display_name: None,
+        managed_by: "tandem".into(),
+        api_key: Some(format!("runtime-{label}")),
+    }
+}
+
+#[tokio::test]
+async fn oauth_binding_uses_runtime_api_key_and_preserves_only_same_account_refresh_authorization()
+{
+    let dir = tempdir().unwrap();
+    let tenant = tenant();
+    let registry = ProviderRegistry::new(configured("openai-codex", None, "gpt-5.6-sol"));
+    let old = oauth("old");
+    set_provider_oauth_credential_for_tenant_in_dir(
+        dir.path(),
+        &tenant,
+        "openai-codex",
+        old.clone(),
+    )
+    .unwrap();
+    let lookup = || {
+        registry.versioned_runtime_binding_for_tenant_in_dir(
+            dir.path(),
+            &tenant,
+            "openai-codex",
+            "gpt-5.6-sol",
+            ProviderCredentialKind::Credential,
+            ProviderCredentialLocation::TenantService,
+        )
+    };
+    registry
+        .set_tenant_provider_bearer_token(&tenant, "openai-codex", old.access_token.clone())
+        .await;
+    assert!(
+        lookup().await.is_err(),
+        "access token cannot substitute for selected runtime API key"
+    );
+    registry
+        .set_tenant_provider_bearer_token(&tenant, "openai-codex", old.api_key.clone().unwrap())
+        .await;
+    let before = lookup().await.unwrap();
+    let refreshed = oauth("refreshed");
+    assert!(
+        refresh_provider_oauth_credential_for_tenant_in_dir_serialized(
+            dir.path(),
+            &tenant,
+            "openai-codex",
+            &old,
+            refreshed.clone(),
+        )
+        .await
+        .unwrap()
+    );
+    assert!(
+        lookup().await.is_err(),
+        "persisted refresh must not approve old loaded token"
+    );
+    registry
+        .set_tenant_provider_bearer_token(
+            &tenant,
+            "openai-codex",
+            refreshed.api_key.clone().unwrap(),
+        )
+        .await;
+    let after = lookup().await.unwrap();
+    assert_eq!(
+        after.revision.authorization_revision,
+        before.revision.authorization_revision
+    );
+    assert_ne!(
+        after.revision.material_revision,
+        before.revision.material_revision
+    );
+    assert_ne!(
+        after.runtime.credential_sha256,
+        before.runtime.credential_sha256
+    );
+    set_provider_oauth_credential_for_tenant_in_dir(dir.path(), &tenant, "openai-codex", refreshed)
+        .unwrap();
+    assert_ne!(
+        lookup().await.unwrap().revision.authorization_revision,
+        before.revision.authorization_revision
+    );
+}
+
+#[tokio::test]
+async fn host_key_header_fingerprints_match_compatible_anthropic_and_cohere_adapters() {
+    let dir = tempdir().unwrap();
+    let tenant = tenant();
+    for (provider, protocol) in [
+        ("llama_cpp", ProviderProtocol::ChatCompletions),
+        ("anthropic", ProviderProtocol::Anthropic),
+        ("cohere", ProviderProtocol::Cohere),
+    ] {
+        let registry = ProviderRegistry::new(configured(
+            provider,
+            Some("synthetic-header-key"),
+            "synthetic-model",
+        ));
+        save_host(dir.path(), provider, "synthetic-header-key");
+        let binding = registry
+            .versioned_runtime_binding_for_tenant_in_dir(
+                dir.path(),
+                &tenant,
+                provider,
+                "synthetic-model",
+                ProviderCredentialKind::ApiKey,
+                ProviderCredentialLocation::HostService,
+            )
+            .await
+            .unwrap();
+        assert_eq!(binding.runtime.protocol, protocol);
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
@@ -495,3 +495,144 @@ fn solution_budget_provider_price_ceilings_round_up_and_reject_overflow() {
     price.request_microusd = u64::MAX;
     assert!(price.cost(0, 1).is_err());
 }
+
+#[test]
+#[serial]
+fn solution_budget_provider_binds_persisted_revision_to_loaded_material_after_reservation() {
+    use tandem_providers::{ProviderCredentialKind, ProviderCredentialLocation};
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            for variant in ["allowed", "stale-loaded", "reconnected"] {
+                let fixture = network_fixture(store, &format!("provider-version-{variant}"));
+                let approved = approval(&fixture, store);
+                let security = tempfile::tempdir().unwrap();
+                tandem_providers::set_provider_auth_for_tenant_in_dir(
+                    security.path(),
+                    &tandem_types::TenantContext::local_implicit(),
+                    "llama_cpp",
+                    "synthetic-a",
+                )
+                .unwrap();
+                runtime().block_on(async {
+                    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                    let registry = ProviderRegistry::new(configuration(
+                        listener.local_addr().unwrap(),
+                        Some("synthetic-a"),
+                    ));
+                    let reviewed = registry
+                        .versioned_runtime_binding_for_tenant_in_dir(
+                            security.path(),
+                            &approved.verified.tenant_context,
+                            "llama_cpp",
+                            "synthetic-model",
+                            ProviderCredentialKind::ApiKey,
+                            ProviderCredentialLocation::HostService,
+                        )
+                        .await
+                        .unwrap();
+                    let expected_revision = reviewed.revision.authorization_revision;
+                    let checks = Arc::new(AtomicUsize::new(0));
+                    let count = checks.clone();
+                    let path = security.path().to_path_buf();
+                    let providers = registry.clone();
+                    let policy = store
+                        .solution_provider_attempt_policy(
+                            10,
+                            4096,
+                            move |_attempt| {
+                                let mut approved = approved.clone();
+                                let expected_revision = expected_revision.clone();
+                                let path = path.clone();
+                                let providers = providers.clone();
+                                let recheck = count.fetch_add(1, Ordering::SeqCst) == 1;
+                                async move {
+                                    if recheck && variant != "allowed" {
+                                        let mut mutation =
+                                            tandem_providers::provider_auth_mutation_in_dir(&path)
+                                                .await?;
+                                        let local = tandem_types::TenantContext::local_implicit();
+                                        mutation.set_for_tenant(
+                                            &local,
+                                            "llama_cpp",
+                                            "synthetic-b",
+                                        )?;
+                                        if variant == "reconnected" {
+                                            mutation.set_for_tenant(
+                                                &local,
+                                                "llama_cpp",
+                                                "synthetic-a",
+                                            )?;
+                                        }
+                                    }
+                                    let current = providers
+                                        .versioned_runtime_binding_for_tenant_in_dir(
+                                            &path,
+                                            &approved.verified.tenant_context,
+                                            &approved.provider_id,
+                                            &approved.model_id,
+                                            ProviderCredentialKind::ApiKey,
+                                            ProviderCredentialLocation::HostService,
+                                        )
+                                        .await?;
+                                    anyhow::ensure!(
+                                        current.revision.authorization_revision
+                                            == expected_revision,
+                                        "credential authorization revision changed after review"
+                                    );
+                                    approved.route_revision =
+                                        sha256(&tandem_solutions::canonical_json(&(
+                                            &approved.route_revision,
+                                            &expected_revision,
+                                        ))?);
+                                    approved.endpoint_sha256 = current.runtime.endpoint_sha256;
+                                    approved.credential_sha256 = current.runtime.credential_sha256;
+                                    Ok(approved)
+                                }
+                            },
+                            || 1500,
+                        )
+                        .unwrap();
+                    let listener = if variant == "allowed" {
+                        let server = tokio::spawn(async move {
+                            let (mut socket, _) = listener.accept().await.unwrap();
+                            request(&mut socket).await;
+                            reply(&mut socket, true).await;
+                            listener
+                        });
+                        assert_eq!(complete(&registry, policy).await.unwrap(), "ok");
+                        tokio::time::timeout(std::time::Duration::from_secs(3), server)
+                            .await
+                            .unwrap()
+                            .unwrap()
+                    } else {
+                        let error = complete(&registry, policy).await.unwrap_err().to_string();
+                        assert!(
+                            error.contains(if variant == "reconnected" {
+                                "authorization revision changed"
+                            } else {
+                                "loaded runtime credential differs"
+                            }),
+                            "{error}"
+                        );
+                        listener
+                    };
+                    assert_eq!(checks.load(Ordering::SeqCst), 2);
+                    assert_eq!(account(store, &fixture, "global").await["outstanding"], 0);
+                    let root =
+                        account(store, &fixture, &format!("root:{}", sha256(b"actual-root"))).await;
+                    assert_eq!(root["requests"], 1);
+                    assert_eq!(
+                        root["committed_cost"],
+                        if variant == "allowed" { 5 } else { 0 }
+                    );
+                    assert!(tokio::time::timeout(
+                        std::time::Duration::from_millis(50),
+                        listener.accept()
+                    )
+                    .await
+                    .is_err());
+                });
+            }
+        });
+    });
+}

--- a/docs/VERSIONED_MODEL_ACCOUNT_BINDING.md
+++ b/docs/VERSIONED_MODEL_ACCOUNT_BINDING.md
@@ -1,0 +1,44 @@
+# Versioned model account binding
+
+A registry transport snapshot and a credential revision read independently can
+refer to different token material. For example, a refresh may already be stored
+while the provider still has the previous bearer loaded. The new
+`versioned_runtime_binding_for_tenant_in_dir` lookup joins the existing registry
+snapshot and credential lifecycle reader rather than treating any active revision
+as approval for the loaded token.
+
+The caller explicitly selects the existing credential kind and host-service or
+tenant-service location. The lookup checks the actual adapter's authentication
+source, reads active material and its revision under the credential file lock,
+and compares the selected stored token against the actual request-header
+fingerprint. Typed OAuth uses `runtime_bearer_token`, including the existing
+API-key preference. Anthropic's API-key header and the other adapters' bearer
+headers use the shared transport fingerprint implementation. It then checks the
+registry snapshot again to detect a route/model/loaded-key change during the
+filesystem lookup. Lock acquisition runs on a blocking worker, not an async
+runtime worker. No network request, secret loading into the registry, or refresh
+occurs.
+
+The result contains transport fingerprints, selected credential kind/location,
+and authorization/material revisions. It contains no raw token, URL, or OAuth
+account details. An untracked config/environment key, stale loaded key, pending
+record, disconnected account, wrong tenant store, or source mismatch cannot
+produce a result. Same-account refresh changes the material revision and token
+fingerprint while retaining the authorization revision. Explicit A→B→A reconnect
+can restore the original fingerprint but always has a new authorization revision.
+
+Tests cover those transitions and all four built-in header/protocol forms.
+The real SQLite/PostgreSQL provider-budget test additionally changes persisted
+material or reconnects the account after reservation and before dispatch. It
+checks that denial makes no HTTP request and reconciles proven non-dispatch at
+zero, while the permitted case sends once and settles its observed usage.
+
+This is an optimistic current-state snapshot, not a grant. Callers must authorize
+the current actor's access to the account, approved sharing, source/data-class
+policy, model capabilities, prices, configuration, activation and real root/child
+lineage, and repeat validation at each physical attempt. Tenant credentials remain
+scoped to organization/workspace/deployment rather than individual actor. The
+budget test's model/root authorization is still a synthetic fixture; it does not
+claim the full production approval or activation factory exists. Logical profile
+policy, fallback/escalation and production integration remain required. External
+rollback anchors and clean-host recovery acceptance also remain open.


### PR DESCRIPTION
A stored credential can change before the provider registry reloads it. Reading a current registry snapshot and an unrelated active credential revision independently could approve stale loaded token material. Join the existing snapshot and lifecycle reader: select the credential kind and host/tenant service location, verify the actual loaded authentication source and request-header fingerprint against the selected persisted material/revision, then recheck the registry snapshot.

The lookup performs filesystem/keychain locking on a blocking worker and never makes a network request, loads credentials into the registry or refreshes an account. It returns only transport fingerprints and revision metadata. Typed OAuth uses the existing runtime API-key preference. Host/tenant scope mismatch, untracked configuration credentials, stale material and disconnects are rejected. Same-account refresh retains authorization but changes material; explicit reconnect cannot revive an earlier authorization revision.

Four new provider tests cover persisted-versus-loaded mismatch, A→B→A, disconnect, current Codex tenant scope, OAuth refresh/API-key preference, and all four adapter header/protocol forms. A new real SQLite/PostgreSQL provider-budget case exercises allowed dispatch/usage settlement and changes persisted material or reconnects after reservation: denial must send no HTTP request and reconcile proven non-dispatch at zero. Existing root/model authorization in that test remains synthetic.

Validation: Current head `621153a610422a81e3750110a588f715e31f2a98` passes all six workflows. [Hosted](https://github.com/frumu-ai/tandem/actions/runs/34021743703/job/101455473184) confirms 90 provider tests plus server refresh/audit regressions. [Solution Contract](https://github.com/frumu-ai/tandem/actions/runs/34021743726/job/101455473425) passes actual SQLite/PostgreSQL integration, including 14 budget cases and the after-reservation loaded-versus-persisted material/reconnect regression. Engine34021743725, Security34021743727, ACME34021743769 and Email34021743723 pass. Exact-head readiness checked; ready for review, unmerged. Production model/current-actor authority remains open.

This is an optimistic current-state snapshot, not account-sharing authority or the full production model factory. Logical class profiles, data-class/capability/price policy, current actor approval, activation and actual root/child propagation remain open. Tenant credential scope is organization/workspace/deployment, not personal identity. No live provider, billing or clean-host recovery acceptance is claimed. Keep TAN-831 and full-system issues open; do not merge automatically. See docs/VERSIONED_MODEL_ACCOUNT_BINDING.md.
