### PR TITLE
TAN-831: bind solution provider spending to native goal lineage

### DIFF
--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -25,6 +25,7 @@ mod provider_attempt_budget;
 mod runtime_records;
 pub(crate) mod solution_budget_records;
 mod solution_budgets;
+mod solution_execution;
 pub(crate) mod solution_installations;
 mod transfer;
 mod transition;
@@ -43,6 +44,7 @@ pub use solution_budgets::{
     SolutionChargeIntent, SolutionChargeKind, SolutionChargeReservation, SolutionChargeStatus,
     SolutionRunBudget,
 };
+pub use solution_execution::SolutionRunExecution;
 pub use solution_installations::{
     SolutionComponentProgress, SolutionInstallation, SolutionInstallationInput,
     SolutionInstallationTransition, SOLUTION_INSTALLATION_CONFLICT,

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/protected_records.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/protected_records.rs
@@ -35,7 +35,12 @@ pub(crate) fn tenant_from_scope(
     if org_id == "local" && workspace_id == "local" && deployment_id.is_none() {
         TenantContext::local_implicit()
     } else {
-        TenantContext::explicit(org_id, workspace_id, deployment_id)
+        // `explicit` takes an actor as its third argument, not a deployment.
+        // SQL scope columns cannot establish personal identity; preserve only
+        // their actual tenant/deployment partition for envelope verification.
+        let mut tenant = TenantContext::explicit(org_id, workspace_id, None);
+        tenant.deployment_id = deployment_id;
+        tenant
     }
 }
 
@@ -155,4 +160,58 @@ pub(crate) fn digest<T: Serialize>(
         value,
     ))?;
     Ok(format!("sha256:{:x}", Sha256::digest(canonical)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn protected_runtime_record_columns_preserve_deployment_without_inventing_actor() {
+        crate::encrypted_file_store::with_test_crypto_provider(
+            tandem_memory::MemoryCryptoProvider::local_key([0x47; 32]),
+            None,
+            async {
+                let tenant = TenantContext::explicit_user_workspace(
+                    "org-a",
+                    "workspace-a",
+                    Some("deployment-a".into()),
+                    "alice",
+                );
+                let reconstructed = tenant_from_scope("org-a", "workspace-a", Some("deployment-a"));
+                assert_eq!(reconstructed.deployment_id.as_deref(), Some("deployment-a"));
+                assert!(reconstructed.actor_id.is_none());
+                let value = serde_json::json!({"goal_id": "scoped-goal"});
+                let stored = encode(&tenant, "goal", "scoped-goal", &value).unwrap();
+                assert!(crate::encrypted_file_store::is_encrypted_payload(&stored));
+                let decoded: serde_json::Value = decode_scoped(
+                    "org-a",
+                    "workspace-a",
+                    Some("deployment-a"),
+                    "goal",
+                    "scoped-goal",
+                    &stored,
+                )
+                .unwrap();
+                assert_eq!(decoded, value);
+                for (workspace, deployment) in [
+                    ("workspace-a", Some("deployment-b")),
+                    ("workspace-b", Some("deployment-a")),
+                    ("workspace-a", None),
+                ] {
+                    assert!(decode_scoped::<serde_json::Value>(
+                        "org-a",
+                        workspace,
+                        deployment,
+                        "goal",
+                        "scoped-goal",
+                        &stored
+                    )
+                    .is_err());
+                }
+                assert!(tenant_from_scope("local", "local", None).is_local_implicit());
+            },
+        )
+        .await;
+    }
 }

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget.rs
@@ -32,6 +32,7 @@ pub struct ApprovedSolutionProviderCharge {
     pub model_class: String,
     pub binding: tandem_solutions::LockedModelBinding,
     pub root_run_id: String,
+    pub execution: super::SolutionRunExecution,
     pub kind: SolutionChargeKind,
     /// Reviewed model/account/price revision, not an arbitrary request ID.
     pub route_revision: String,
@@ -135,6 +136,7 @@ impl OrchestrationStateStore {
                                 installation_generation: approval.installation_generation,
                                 model_class: approval.model_class,
                                 binding: approval.binding,
+                                execution: approval.execution,
                             },
                         )?;
                         ensure!(
@@ -162,6 +164,31 @@ impl OrchestrationStateStore {
                         ensure!(
                             clock() <= price.valid_until_ms,
                             "model price expired during budget admission"
+                        );
+                        let execution_store = store.clone();
+                        let execution_clock = clock.clone();
+                        let tenant = current.verified.tenant_context.clone();
+                        let execution = current.execution.clone();
+                        let root = current.root_run_id.clone();
+                        crate::encrypted_file_store::spawn_protected_blocking(move || {
+                            execution_store.validate_solution_execution(
+                                &tenant,
+                                &execution,
+                                &root,
+                                || execution_clock(),
+                            )
+                        })
+                        .await??;
+                        // The final writer transaction can itself wait. Do not
+                        // return a permit using the pre-wait identity/price time.
+                        tandem_solutions::validate_customer_config_scope(
+                            &current.verified,
+                            &current.scope,
+                            clock(),
+                        )?;
+                        ensure!(
+                            clock() <= price.valid_until_ms,
+                            "model price expired during execution validation"
                         );
                         Ok::<_, anyhow::Error>(())
                     }

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
@@ -27,11 +27,17 @@ fn network_fixture(store: &OrchestrationStateStore, name: &str) -> BudgetFixture
             SolutionInstallationTransition::Begin,
         )
         .unwrap();
-    BudgetFixture {
+    let fixture = BudgetFixture {
         installation,
         digest,
-    }
+    };
+    seed_execution(store, &fixture);
+    fixture
 }
+
+#[path = "solution_execution_tests.rs"]
+mod execution_tests;
+use execution_tests::{root_id, seed_execution};
 
 fn runtime() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_current_thread()
@@ -79,7 +85,13 @@ fn approval(
         installation_generation: installed.generation,
         model_class: "economy".into(),
         binding: installed.plan.models["economy"].clone(),
-        root_run_id: "actual-root".into(),
+        root_run_id: root_id(fixture),
+        execution: crate::stateful_runtime::orchestration_store::SolutionRunExecution {
+            run_id: root_id(fixture),
+            claim_id: "claim-1".into(),
+            claimant_id: "executor-1".into(),
+            lease_epoch: 1,
+        },
         kind: SolutionChargeKind::Model,
         route_revision: sha256(b"synthetic-approved-account-model-price"),
         provider_id: "llama_cpp".into(),
@@ -108,8 +120,8 @@ async fn current(
     registry: &ProviderRegistry,
 ) -> anyhow::Result<ApprovedSolutionProviderCharge> {
     let mut result = approved.clone();
-    // Model/root authorization remains a synthetic fixture; transport/account
-    // facts now come independently from the actual configured registry.
+    // Model/user authorization remains synthetic. Transport/account facts come
+    // from the registry; run/claim/root facts are checked in protected storage.
     let binding = registry
         .runtime_binding_for_tenant(
             &approved.verified.tenant_context,
@@ -282,7 +294,7 @@ fn solution_budget_provider_actual_sends_share_the_durable_ceiling() {
             assert_eq!(complete(&registry, policy).await.unwrap(), "ok");
             tokio::time::timeout(std::time::Duration::from_secs(3), server).await.unwrap().unwrap();
             assert_eq!(account(store, &fixture, "global").await["outstanding"], 0);
-            let root = account(store, &fixture, &format!("root:{}", sha256(b"actual-root"))).await;
+            let root = account(store, &fixture, &format!("root:{}", sha256(root_id(&fixture).as_bytes()))).await;
             assert_eq!(root["requests"], 2, "repeated policy checks must not double-charge");
             assert_eq!(root["committed_cost"], 10);
         });
@@ -364,8 +376,12 @@ fn solution_budget_provider_confirmed_receipt_settles_after_user_assertion_expir
                 );
                 assert_eq!(account(store, &fixture, "global").await["outstanding"], 0);
                 assert_eq!(
-                    account(store, &fixture, &format!("root:{}", sha256(b"actual-root"))).await
-                        ["committed_cost"],
+                    account(
+                        store,
+                        &fixture,
+                        &format!("root:{}", sha256(root_id(&fixture).as_bytes()))
+                    )
+                    .await["committed_cost"],
                     5
                 );
                 let listener = tokio::time::timeout(std::time::Duration::from_secs(3), server)
@@ -427,8 +443,12 @@ fn solution_budget_provider_rechecks_binding_after_reservation_without_sending()
                     .contains("changed during"));
                 assert_eq!(checks.load(Ordering::SeqCst), 2);
                 assert_eq!(account(store, &fixture, "global").await["outstanding"], 0);
-                let root =
-                    account(store, &fixture, &format!("root:{}", sha256(b"actual-root"))).await;
+                let root = account(
+                    store,
+                    &fixture,
+                    &format!("root:{}", sha256(root_id(&fixture).as_bytes())),
+                )
+                .await;
                 assert_eq!(root["committed_cost"], 0);
                 assert_eq!(root["requests"], 1);
                 assert!(tokio::time::timeout(
@@ -618,8 +638,12 @@ fn solution_budget_provider_binds_persisted_revision_to_loaded_material_after_re
                     };
                     assert_eq!(checks.load(Ordering::SeqCst), 2);
                     assert_eq!(account(store, &fixture, "global").await["outstanding"], 0);
-                    let root =
-                        account(store, &fixture, &format!("root:{}", sha256(b"actual-root"))).await;
+                    let root = account(
+                        store,
+                        &fixture,
+                        &format!("root:{}", sha256(root_id(&fixture).as_bytes())),
+                    )
+                    .await;
                     assert_eq!(root["requests"], 1);
                     assert_eq!(
                         root["committed_cost"],

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget_tests.rs
@@ -162,10 +162,11 @@ async fn complete(
 ) -> anyhow::Result<String> {
     registry
         .scope_tenant_provider_auth_with_recovery(
-            tandem_types::TenantContext::explicit(
+            tandem_types::TenantContext::explicit_user_workspace(
                 "org-a",
                 "workspace-a",
                 Some("deployment-a".into()),
+                "owner-a",
             ),
             ProviderAuthRecovery::new(|_| async { Ok(false) }),
             true,

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
@@ -104,6 +104,7 @@ pub(crate) struct RuntimeSolutionCharge {
 }
 
 pub(crate) struct RuntimeSolutionModel {
+    pub execution: super::SolutionRunExecution,
     pub configuration: super::CustomerConfigVersion,
     pub installation_generation: u64,
     pub model_class: String,
@@ -222,6 +223,13 @@ impl OrchestrationStateStore {
                 solution_installations::load(&transaction, input.verified, input.scope)?
                     .context("solution installation missing")?;
             if let Some(model) = model {
+                super::solution_execution::validate(
+                    &transaction,
+                    tenant,
+                    &model.execution,
+                    &intent.root_run_id,
+                    input.now_ms,
+                )?;
                 ensure!(
                     installation.generation == model.installation_generation
                         && installation.config_version == model.configuration

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution.rs
@@ -1,0 +1,189 @@
+//! Resolve provider accounting roots from the existing protected goal/run
+//! records. This validates execution lineage, not installation or user grants.
+
+use anyhow::{ensure, Context};
+use tandem_automation::{
+    AutomationRunStatus, AutomationV2RunRecord, GoalRunLink, LongRunningGoal, LongRunningGoalStatus,
+};
+use tandem_types::TenantContext;
+
+use super::{protected_records, OrchestrationStateStore};
+use crate::stateful_runtime::backend::{params, Executor, TransactionBehavior};
+
+/// Current executor identity supplied by the trusted runtime. This is not an
+/// HTTP-deserializable permission or a caller-selected accounting root.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SolutionRunExecution {
+    pub run_id: String,
+    pub claim_id: String,
+    pub claimant_id: String,
+    pub lease_epoch: u64,
+}
+
+fn same_tenant(left: &TenantContext, right: &TenantContext) -> bool {
+    left.org_id == right.org_id
+        && left.workspace_id == right.workspace_id
+        && left.deployment_id == right.deployment_id
+}
+
+fn run(
+    executor: &impl Executor,
+    tenant: &TenantContext,
+    run_id: &str,
+) -> anyhow::Result<AutomationV2RunRecord> {
+    let raw: String = executor.query_row(
+        "SELECT run_json FROM automation_runs WHERE run_id=?1",
+        [run_id],
+        |row| row.get(0),
+    )?;
+    let value: AutomationV2RunRecord = protected_records::decode(tenant, "run", run_id, &raw)?;
+    ensure!(
+        value.run_id == run_id && same_tenant(&value.tenant_context, tenant),
+        "solution execution run scope mismatch"
+    );
+    Ok(value)
+}
+
+fn link(
+    executor: &impl Executor,
+    tenant: &TenantContext,
+    run_id: &str,
+) -> anyhow::Result<GoalRunLink> {
+    let count: u64 = executor.query_row(
+        "SELECT COUNT(*) FROM goal_run_links WHERE run_id=?1",
+        [run_id],
+        |row| row.get(0),
+    )?;
+    ensure!(
+        count == 1,
+        "solution execution requires one durable goal lineage"
+    );
+    let (goal_id, hop, parent, raw): (String, u32, Option<String>, String) = executor.query_row(
+        "SELECT goal_id,hop_index,parent_run_id,link_json FROM goal_run_links WHERE run_id=?1",
+        [run_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )?;
+    let value: GoalRunLink = protected_records::decode(tenant, "link", run_id, &raw)?;
+    ensure!(
+        value.run_id == run_id
+            && value.goal_id == goal_id
+            && value.hop_index == hop
+            && value.parent_run_id == parent,
+        "solution execution lineage binding mismatch"
+    );
+    Ok(value)
+}
+
+pub(super) fn validate(
+    executor: &impl Executor,
+    tenant: &TenantContext,
+    execution: &SolutionRunExecution,
+    expected_root: &str,
+    now_ms: u64,
+) -> anyhow::Result<()> {
+    ensure!(
+        !tenant.is_local_implicit(),
+        "solution execution requires explicit tenant scope"
+    );
+    let active = run(executor, tenant, &execution.run_id)?;
+    ensure!(
+        active.status == AutomationRunStatus::Running && active.finished_at_ms.is_none(),
+        "solution execution run is not running"
+    );
+    let claim = active
+        .execution_claim
+        .as_ref()
+        .context("solution execution claim missing")?;
+    ensure!(
+        !execution.claim_id.is_empty()
+            && !execution.claimant_id.is_empty()
+            && execution.lease_epoch > 0
+            && claim.claim_id == execution.claim_id
+            && claim.claimant_id == execution.claimant_id
+            && claim.lease_epoch == execution.lease_epoch
+            && active.execution_claim_epoch == execution.lease_epoch
+            && claim.claimed_at_ms <= now_ms
+            && !claim.is_expired(now_ms),
+        "solution execution claim expired or changed"
+    );
+    let mut current = link(executor, tenant, &execution.run_id)?;
+    let raw: String = executor.query_row(
+        "SELECT goal_json FROM long_running_goals WHERE goal_id=?1",
+        [&current.goal_id],
+        |row| row.get(0),
+    )?;
+    let goal: LongRunningGoal = protected_records::decode(tenant, "goal", &current.goal_id, &raw)?;
+    ensure!(
+        goal.goal_id == current.goal_id
+            && same_tenant(&goal.tenant_context, tenant)
+            && goal.status == LongRunningGoalStatus::Active
+            && goal.finished_at_ms.is_none()
+            && goal.active_run_id.as_deref() == Some(execution.run_id.as_str())
+            && goal.current_node_id.as_deref() == Some(current.orchestration_node_id.as_str())
+            && goal.hop_count == current.hop_index
+            && goal.hop_count <= goal.policy.max_hops
+            && goal.created_at_ms <= now_ms
+            && goal
+                .policy
+                .deadline_at_ms
+                .is_none_or(|deadline| now_ms < deadline),
+        "solution execution goal is not current and active"
+    );
+    // Bound traversal even when an operator configured an unreasonable hop cap.
+    ensure!(
+        current.hop_index <= 4096,
+        "solution execution lineage exceeds traversal limit"
+    );
+    loop {
+        ensure!(
+            current.goal_id == goal.goal_id
+                && current.orchestration_version == goal.orchestration_version,
+            "solution execution crosses goal lineage"
+        );
+        run(executor, tenant, &current.run_id)?;
+        if current.hop_index == 0 {
+            ensure!(
+                current.parent_run_id.is_none() && current.run_id == expected_root,
+                "solution accounting root differs from durable lineage"
+            );
+            let roots: u64 = executor.query_row(
+                "SELECT COUNT(*) FROM goal_run_links WHERE goal_id=?1 AND hop_index=0",
+                params![goal.goal_id],
+                |row| row.get(0),
+            )?;
+            ensure!(roots == 1, "solution goal root is ambiguous");
+            break;
+        }
+        let parent_id = current
+            .parent_run_id
+            .as_deref()
+            .context("solution execution parent missing")?;
+        let parent = link(executor, tenant, parent_id)?;
+        ensure!(
+            parent.hop_index.checked_add(1) == Some(current.hop_index),
+            "solution execution parent hop mismatch"
+        );
+        current = parent;
+    }
+    Ok(())
+}
+
+impl OrchestrationStateStore {
+    /// Recheck the same persisted run/claim/root after reservation and before
+    /// dispatch. A later settlement remains permitted after a goal stops.
+    pub(super) fn validate_solution_execution(
+        &self,
+        tenant: &TenantContext,
+        execution: &SolutionRunExecution,
+        expected_root: &str,
+        clock: impl Fn() -> u64,
+    ) -> anyhow::Result<()> {
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            validate(&transaction, tenant, execution, expected_root, clock())?;
+            transaction.commit()?;
+            Ok(())
+        })
+    }
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution_tests.rs
@@ -1,0 +1,355 @@
+use super::*;
+use crate::stateful_runtime::backend::{params, Executor, TransactionBehavior};
+use crate::stateful_runtime::orchestration_store::protected_records;
+use tandem_automation::{AutomationV2RunRecord, GoalRunLink, LongRunningGoal};
+
+pub(super) fn root_id(fixture: &BudgetFixture) -> String {
+    format!(
+        "root-{}",
+        fixture.installation.customer.config.scope.instance_id
+    )
+}
+
+fn goal_id(fixture: &BudgetFixture) -> String {
+    format!(
+        "goal-{}",
+        fixture.installation.customer.config.scope.instance_id
+    )
+}
+
+fn execution_run(fixture: &BudgetFixture, id: &str) -> AutomationV2RunRecord {
+    serde_json::from_value(serde_json::json!({
+        "run_id": id, "automation_id": "synthetic-worker",
+        "tenant_context": fixture.installation.customer.context.tenant_context,
+        "trigger_type": "goal_start", "status": "running", "created_at_ms": 1000,
+        "updated_at_ms": 1000, "started_at_ms": 1000, "checkpoint": {},
+        "execution_claim_epoch": 1,
+        "execution_claim": {"claim_id": "claim-1", "claimant_id": "executor-1",
+            "claimed_at_ms": 1000, "lease_expires_at_ms": 10000, "lease_epoch": 1}
+    }))
+    .unwrap()
+}
+
+pub(super) fn seed_execution(store: &OrchestrationStateStore, fixture: &BudgetFixture) {
+    let root = execution_run(fixture, &root_id(fixture));
+    let goal: LongRunningGoal = serde_json::from_value(serde_json::json!({
+        "schema_version": 1, "goal_id": goal_id(fixture), "orchestration_id": "synthetic-orchestration",
+        "orchestration_version": 1, "objective": "Exercise current runtime lineage",
+        "status": "active", "tenant_context": root.tenant_context,
+        "policy": {"max_hops": 4, "deadline_at_ms": 10000}, "active_run_id": root.run_id,
+        "current_node_id": "work", "hop_count": 0, "total_tokens": 0,
+        "total_cost_usd": 0.0, "created_at_ms": 1000, "updated_at_ms": 1000
+    })).unwrap();
+    let link = GoalRunLink {
+        goal_id: goal.goal_id.clone(),
+        run_id: root.run_id.clone(),
+        orchestration_node_id: "work".into(),
+        orchestration_version: 1,
+        hop_index: 0,
+        parent_run_id: None,
+        triggering_handoff_id: None,
+        created_at_ms: 1000,
+    };
+    store
+        .start_goal(
+            &goal,
+            &root,
+            &link,
+            &tandem_types::PrincipalRef::new(
+                tandem_types::PrincipalKind::HumanUser,
+                &fixture.installation.customer.context.human_actor.actor_id,
+            ),
+        )
+        .unwrap();
+}
+
+fn seed_child(store: &OrchestrationStateStore, fixture: &BudgetFixture) -> String {
+    let child_id = format!("child-{}", root_id(fixture));
+    let child = execution_run(fixture, &child_id);
+    let mut goal = store.get_goal(&goal_id(fixture)).unwrap().unwrap();
+    goal.active_run_id = Some(child_id.clone());
+    goal.hop_count = 1;
+    let link = GoalRunLink {
+        goal_id: goal.goal_id.clone(),
+        run_id: child_id.clone(),
+        orchestration_node_id: "work".into(),
+        orchestration_version: 1,
+        hop_index: 1,
+        parent_run_id: Some(root_id(fixture)),
+        triggering_handoff_id: None,
+        created_at_ms: 1000,
+    };
+    store.with_connection(|connection| {
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        crate::stateful_runtime::orchestration_store::upsert_automation_run(&transaction, &child)?;
+        crate::stateful_runtime::orchestration_store::upsert_goal(&transaction, &goal)?;
+        transaction.execute("INSERT INTO goal_run_links
+            (goal_id,run_id,orchestration_node_id,orchestration_version,hop_index,parent_run_id,
+             triggering_handoff_id,link_json,created_at_ms) VALUES (?1,?2,'work',1,1,?3,NULL,?4,1000)",
+            params![goal.goal_id,child_id,root_id(fixture),
+                protected_records::encode(&child.tenant_context,"link",&child_id,&link)?])?;
+        transaction.commit()?;
+        Ok(())
+    }).unwrap();
+    child_id
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_current_goal_and_claim_are_required_before_any_send() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            for fault in [
+                "missing-run",
+                "root",
+                "claim",
+                "claimant",
+                "epoch",
+                "expired",
+                "paused",
+                "cancelled",
+                "goal-deadline",
+                "goal-active-run",
+                "run-paused",
+                "tenant",
+            ] {
+                let fixture = network_fixture(store, &format!("lineage-{fault}"));
+                let mut approved = approval(&fixture, store);
+                let mut goal = store.get_goal(&goal_id(&fixture)).unwrap().unwrap();
+                let mut run = store
+                    .get_automation_run(&root_id(&fixture))
+                    .unwrap()
+                    .unwrap();
+                match fault {
+                    "missing-run" => approved.execution.run_id = "nonexistent".into(),
+                    "root" => approved.root_run_id = "invented-budget".into(),
+                    "claim" => approved.execution.claim_id = "stale-claim".into(),
+                    "claimant" => approved.execution.claimant_id = "other-executor".into(),
+                    "epoch" => approved.execution.lease_epoch = 2,
+                    "expired" => run.execution_claim.as_mut().unwrap().lease_expires_at_ms = 1500,
+                    "paused" => goal.status = tandem_automation::LongRunningGoalStatus::Paused,
+                    "cancelled" => {
+                        goal.status = tandem_automation::LongRunningGoalStatus::Cancelled
+                    }
+                    "goal-deadline" => goal.policy.deadline_at_ms = Some(1500),
+                    "goal-active-run" => goal.active_run_id = Some("other-run".into()),
+                    "run-paused" => run.status = tandem_automation::AutomationRunStatus::Paused,
+                    "tenant" => run.tenant_context.workspace_id = "other-workspace".into(),
+                    _ => unreachable!(),
+                }
+                store.put_goal(&goal).unwrap();
+                store.upsert_automation_runs([&run]).unwrap();
+                runtime().block_on(async {
+                    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                    let registry = registry(listener.local_addr().unwrap());
+                    let policy = policy(store, &registry, approved, Arc::new(AtomicU64::new(1500)));
+                    assert!(complete(&registry, policy).await.is_err(), "{fault}");
+                    assert!(
+                        account_row(store, &fixture, "global").await.is_none(),
+                        "{fault}"
+                    );
+                    assert!(tokio::time::timeout(
+                        std::time::Duration::from_millis(30),
+                        listener.accept()
+                    )
+                    .await
+                    .is_err());
+                });
+            }
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_goal_pause_after_reservation_refunds_proven_non_dispatch() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = network_fixture(store, "lineage-pause-after-reserve");
+            let approved = approval(&fixture, store);
+            let mut paused = store.get_goal(&goal_id(&fixture)).unwrap().unwrap();
+            paused.status = tandem_automation::LongRunningGoalStatus::Paused;
+            runtime().block_on(async {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let registry = registry(listener.local_addr().unwrap());
+                let registry_for_auth = registry.clone();
+                let mutator = store.clone();
+                let calls = Arc::new(AtomicUsize::new(0));
+                let policy = store
+                    .solution_provider_attempt_policy(
+                        10,
+                        4096,
+                        move |_| {
+                            let current_registry = registry_for_auth.clone();
+                            let approved = approved.clone();
+                            let paused = paused.clone();
+                            let mutator = mutator.clone();
+                            let second = calls.fetch_add(1, Ordering::SeqCst) == 1;
+                            async move {
+                                if second {
+                                    crate::encrypted_file_store::spawn_protected_blocking(
+                                        move || mutator.put_goal(&paused),
+                                    )
+                                    .await??;
+                                }
+                                current(&approved, &current_registry).await
+                            }
+                        },
+                        || 1500,
+                    )
+                    .unwrap();
+                assert!(complete(&registry, policy).await.is_err());
+                let root = account(
+                    store,
+                    &fixture,
+                    &format!("root:{}", sha256(root_id(&fixture).as_bytes())),
+                )
+                .await;
+                assert_eq!(root["requests"], 1);
+                assert_eq!(root["committed_cost"], 0);
+                assert_eq!(root["reserved_cost"], 0);
+                assert_eq!(account(store, &fixture, "global").await["outstanding"], 0);
+                assert!(tokio::time::timeout(
+                    std::time::Duration::from_millis(30),
+                    listener.accept()
+                )
+                .await
+                .is_err());
+            });
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_child_inherits_persisted_root_after_restart() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = network_fixture(store, "lineage-child");
+            let mut approved = approval(&fixture, store);
+            approved.run_budget.max_requests = 2;
+            let rt = runtime();
+            let (listener, registry, first) = rt.block_on(async {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let registry = registry(listener.local_addr().unwrap());
+                let server = tokio::spawn(async move {
+                    let (mut socket, _) = listener.accept().await.unwrap();
+                    request(&mut socket).await;
+                    reply(&mut socket, true).await;
+                    listener
+                });
+                let first = policy(
+                    store,
+                    &registry,
+                    approved.clone(),
+                    Arc::new(AtomicU64::new(1500)),
+                );
+                assert_eq!(complete(&registry, first.clone()).await.unwrap(), "ok");
+                (server.await.unwrap(), registry, first)
+            });
+            // The native lifecycle writes these same protected goal/run/link rows.
+            // This fixture isolates accounting lineage from handoff policy.
+            approved.execution.run_id = seed_child(store, &fixture);
+            store.initialize().unwrap();
+            rt.block_on(async {
+                assert!(
+                    complete(&registry, first).await.is_err(),
+                    "old active run must stop"
+                );
+                let server = tokio::spawn(async move {
+                    let (mut socket, _) = listener.accept().await.unwrap();
+                    request(&mut socket).await;
+                    reply(&mut socket, true).await;
+                    listener
+                });
+                let child_policy =
+                    policy(store, &registry, approved, Arc::new(AtomicU64::new(1500)));
+                assert_eq!(
+                    complete(&registry, child_policy.clone()).await.unwrap(),
+                    "ok"
+                );
+                assert!(complete(&registry, child_policy)
+                    .await
+                    .unwrap_err()
+                    .to_string()
+                    .contains("budget"));
+                let listener = server.await.unwrap();
+                let root = account(
+                    store,
+                    &fixture,
+                    &format!("root:{}", sha256(root_id(&fixture).as_bytes())),
+                )
+                .await;
+                assert_eq!(root["requests"], 2);
+                assert_eq!(root["committed_cost"], 10);
+                assert!(account_row(
+                    store,
+                    &fixture,
+                    &format!(
+                        "root:{}",
+                        sha256(format!("child-{}", root_id(&fixture)).as_bytes())
+                    )
+                )
+                .await
+                .is_none());
+                assert!(tokio::time::timeout(
+                    std::time::Duration::from_millis(30),
+                    listener.accept()
+                )
+                .await
+                .is_err());
+            });
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_parent_chain_rejects_missing_cyclic_and_foreign_roots() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            for fault in ["missing", "cycle", "foreign"] {
+                let fixture = network_fixture(store, &format!("parent-{fault}"));
+                let foreign = network_fixture(store, &format!("other-parent-{fault}"));
+                let mut approved = approval(&fixture, store);
+                approved.execution.run_id = seed_child(store, &fixture);
+                store
+                    .validate_solution_execution(
+                        &approved.verified.tenant_context,
+                        &approved.execution,
+                        &approved.root_run_id,
+                        || 1500,
+                    )
+                    .unwrap();
+                store.with_connection(|connection| {
+                let raw: String = connection.query_row(
+                    "SELECT link_json FROM goal_run_links WHERE run_id=?1",
+                    [&approved.execution.run_id], |row| row.get(0))?;
+                let mut link: GoalRunLink = protected_records::decode(
+                    &approved.verified.tenant_context, "link", &approved.execution.run_id, &raw)?;
+                link.parent_run_id = Some(match fault {
+                    "missing" => "missing-parent".into(),
+                    "cycle" => approved.execution.run_id.clone(),
+                    "foreign" => root_id(&foreign),
+                    _ => unreachable!(),
+                });
+                connection.execute("UPDATE goal_run_links SET parent_run_id=?2,link_json=?3 WHERE run_id=?1",
+                    params![approved.execution.run_id,link.parent_run_id,
+                        protected_records::encode(&approved.verified.tenant_context,"link",&approved.execution.run_id,&link)?])?;
+                Ok(())
+            }).unwrap();
+                assert!(
+                    store
+                        .validate_solution_execution(
+                            &approved.verified.tenant_context,
+                            &approved.execution,
+                            &approved.root_run_id,
+                            || 1500
+                        )
+                        .is_err(),
+                    "{fault}"
+                );
+            }
+        })
+    });
+}

--- a/docs/SOLUTION_EXECUTION_LINEAGE.md
+++ b/docs/SOLUTION_EXECUTION_LINEAGE.md
@@ -1,0 +1,57 @@
+# Solution provider execution lineage
+
+The solution provider-attempt budget adapter now requires the current native
+Automation V2 run and execution claim. An arbitrary `root_run_id` in a trusted
+callback is no longer sufficient for runtime admission.
+
+Inside the budget writer transaction, the adapter reads the existing protected
+run, goal and goal-run links. It requires a running run with an unexpired claim
+matching the executor, claim ID and lease epoch; an active goal naming this run
+and orchestration node; a current deadline; and a complete parent chain to the
+claimed hop-zero root in the same tenant and goal version. Missing, cyclic,
+cross-goal or mismatched lineage blocks admission. Native goal links remain the
+source of lineage; no new run store, goal service or schema is introduced.
+
+After reservation, it repeats the current callback and persisted execution
+check. The final check samples time after acquiring its writer transaction, then
+checks identity and price freshness again after the wait. A proven denial before
+dispatch settles the reservation at zero. Settlement for an already dispatched
+request remains possible after its goal pauses or identity expires; unknown
+usage remains reserved under the existing ledger rules.
+
+All goal children use the same protected hop-zero accounting root. Claim renewal
+with the same claim ID and epoch remains valid; takeover, claim expiration,
+paused/cancelled/finished goals and old active runs cannot continue spending.
+The existing solution ledger enforces its root, daily and concurrent request
+ceilings. Existing goal policy still controls orchestration transitions.
+
+## Scope and remaining integration
+
+This adapter currently supports native Automation V2 goal lineage. Standalone
+sessions, AgentTemplate workers and classic routines still need their native
+execution adapters; they must not fabricate a goal link to bypass those checks.
+The generic accounting store remains a trusted ledger primitive, not a dispatch
+API. This change does not activate installed resources or attach the optional
+provider policy automatically to every worker task.
+
+The trusted production factory must still establish current user and account
+sharing authority, bind a goal to its approved installation, resolve current
+model/data/price policy and supply narrowed budgets. Durable profile history,
+explicit activation, source-backed text execution, non-model charges and full
+customer acceptance remain open. A lineage check does not replace those grants.
+Cancellation stops later admission; it cannot retract a request already sent.
+
+## Regression evidence
+
+The provider budget fixture now creates actual protected native goals, runs and
+execution claims through the existing store. New SQLite/PostgreSQL cases cover
+missing or wrong run/root/claim/executor/epoch/tenant, claim expiration, paused
+or cancelled goals, stale active runs and deadlines before any HTTP send; pause
+after reservation with a zero-cost refund; a child using the parent's request
+ceiling after reopening storage; and missing, cyclic or foreign parent links.
+
+The child test writes the native protected transition records directly to
+isolate accounting lineage; it does not claim to validate the entire governed
+handoff lifecycle or real user authorization. Existing provider wire, retry,
+account revision and unknown-usage tests also exercise the required execution
+check. Runtime test results must be read from the current-head CI jobs.

--- a/docs/SOLUTION_EXECUTION_LINEAGE.md
+++ b/docs/SOLUTION_EXECUTION_LINEAGE.md
@@ -12,6 +12,12 @@ claimed hop-zero root in the same tenant and goal version. Missing, cyclic,
 cross-goal or mismatched lineage blocks admission. Native goal links remain the
 source of lineage; no new run store, goal service or schema is introduced.
 
+Encrypted native goal startup exposed a scope reconstruction defect: the
+existing column reader passed deployment IDs into `TenantContext::explicit`'s
+actor argument. It now preserves the deployment partition explicitly and leaves
+actor identity unset. Trusted scope columns do not identify a user. The direct
+encrypted round-trip regression also rejects another or missing deployment.
+
 After reservation, it repeats the current callback and persisted execution
 check. The final check samples time after acquiring its writer transaction, then
 checks identity and price freshness again after the wait. A proven denial before


### PR DESCRIPTION
A caller-supplied root ID was previously accepted by the trusted solution provider budget callback without checking native execution state. Require a current Automation V2 run and execution claim, then verify its protected goal/run/parent links inside the reservation transaction. Paused/cancelled goals, old active runs, expired or replaced claims and roots that differ from the actual hop-zero lineage cannot admit a request.

Recheck persisted execution after reservation and the existing current-authorization callback. Sample time after acquiring the final writer transaction, then recheck identity/price freshness after that wait. A denial before dispatch settles at zero; completed/unknown requests retain the existing accounting behavior. Child runs share their actual protected parent root and cannot reset the request ceiling by supplying a new root ID.

The existing provider fixture now seeds protected native goal/run/claim records. Four new SQLite/PostgreSQL cases exercise twelve invalid execution states before any HTTP send; a goal pause after reservation with zero-cost refund; root-to-child continuation after storage reopen with one shared request ceiling; and missing/cyclic/foreign parent links. Child transition records are written directly by the storage fixture; governed handoff and user authority are not claimed as end-to-end evidence.

Validation: initial head38ddd19b compiled but the real storage suite exposed an existing deployment reconstruction defect during encrypted native goal startup. `protected_records::tenant_from_scope` passed the deployment ID as `TenantContext::explicit`'s actor argument, losing the deployment partition. Current head `caee854cb183ba97cee2f1c47c908ab652b5b5fe` preserves the deployment explicitly and leaves personal identity unset. A direct encrypted record round-trip regression rejects foreign/missing deployment and foreign workspace; the provider fixture now also uses the correct explicit-user constructor. Decryption checks remain intact. Standalone rustfmt/diff and DCO pass; current-head [Solution Contract](https://github.com/frumu-ai/tandem/actions/runs/34026912044/job/101469400489) passes actual SQLite/PostgreSQL integration (26 installation / 18 budget cases including all four new execution tests). [Workspace](https://github.com/frumu-ai/tandem/actions/runs/34026912039/job/101470255969) passes 5251 tests with 7 skipped, including the direct encrypted deployment-scope regression. Hosted34026912125, ACME34026912132 and Email34026912087 pass. Security34026912050 also passed, including release composition, engine container and aggregate assurance. All six current-head workflows passed; ready for review, unmerged. Stacked on #1951 at c763ce86f6ff888f71e2f0eaafa870934d7e2ddc. Current-head evidence reviewed.

This supports native Automation V2 goal lineage, without a new root store or schema. Classic routines, standalone sessions and AgentTemplate workers still need their native execution adapters. Current-user/account-sharing authority, approved installation-to-goal binding, durable profile history, activation, task propagation, non-model charges and full customer acceptance remain open. No merge or whole-issue completion. See docs/SOLUTION_EXECUTION_LINEAGE.md.
