### PR TITLE
TAN-831: authorize model credentials with current native user grants

### DIFF
--- a/crates/tandem-providers/src/versioned_binding.rs
+++ b/crates/tandem-providers/src/versioned_binding.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use anyhow::{ensure, Context};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tandem_types::TenantContext;
 
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
 
 /// Explicit storage scope. Tenant service credentials are scoped to the existing
 /// organization/workspace/deployment key, not to an individual human actor.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderCredentialLocation {
     HostService,

--- a/crates/tandem-server/src/pack_manager_installation_tests.rs
+++ b/crates/tandem-server/src/pack_manager_installation_tests.rs
@@ -6,6 +6,8 @@ use crate::stateful_runtime::orchestration_store::{
     OrchestrationStateStore, SolutionComponentProgress,
 };
 use crate::AppState;
+#[path = "pack_manager_model_account_tests.rs"]
+mod model_account_tests;
 use tandem_enterprise_contract::{
     hosted_policy::hosted_unit_principal, AccessPermission, AuthorityChain, ConnectorInstance,
     DataClass, HumanActor, OrganizationUnitAccessGrant, PrincipalRef, RequestPrincipal,

--- a/crates/tandem-server/src/pack_manager_model_account_tests.rs
+++ b/crates/tandem-server/src/pack_manager_model_account_tests.rs
@@ -1,0 +1,229 @@
+use super::*;
+use tandem_providers::{ProviderCredentialKind, ProviderRegistry};
+
+const BINDING: &str = "local.fixture";
+const REFERENCE: &str = "secret-ref:model-service";
+const TOKEN: &str = "synthetic-model-account-fixture";
+
+async fn stored_key(fixture: &Fixture, token: &str) -> String {
+    let dir = crate::http::config_providers::provider_auth_security_dir_for_state(&fixture.state);
+    let token = token.to_string();
+    tokio::task::spawn_blocking(move || {
+        let tenant = TenantContext::local_implicit();
+        tandem_providers::set_provider_auth_for_tenant_in_dir(&dir, &tenant, "llama_cpp", &token)
+            .unwrap();
+        tandem_providers::provider_credential_revision_for_tenant_in_dir(
+            &dir,
+            &tenant,
+            ProviderCredentialKind::ApiKey,
+            "llama_cpp",
+        )
+        .unwrap()
+        .authorization_revision
+    })
+    .await
+    .unwrap()
+}
+
+async fn configure(fixture: &mut Fixture, revision: &str, token: &str) {
+    let mut runtime = fixture.state.runtime.wait().clone();
+    runtime.config = tandem_core::ConfigStore::new(fixture.root.path().join("model-config.json"),
+        Some(serde_json::json!({"solution_installation": {
+            "schema_version": 1, "policy": {"allowed_providers": ["llama_cpp"],
+                "allow_network_egress": true, "max_tokens_per_run": 1024,
+                "max_concurrent_runs": 1, "max_daily_cost_microusd": 100},
+            "models": {BINDING: {"provider_id": "llama_cpp", "model_id": "synthetic-model",
+                "credential_ref": REFERENCE, "account": {"credential_kind": "api_key",
+                    "credential_location": "host_service", "authorization_revision": revision,
+                    "resource": ResourceRef::new("org-a", "dep-a", ResourceKind::SecretProviderCredential, REFERENCE)}}}
+        }}))).await.unwrap();
+    runtime.providers = ProviderRegistry::new(serde_json::from_value(serde_json::json!({
+        "default_provider": "llama_cpp", "providers": {"llama_cpp": {
+            "url": "http://127.0.0.1:9/v1", "api_key": token, "default_model": "synthetic-model"}}
+    })).unwrap());
+    fixture.state.runtime = Arc::new(std::sync::OnceLock::from(runtime));
+}
+
+async fn grant(fixture: &Fixture, id: &str, unit: &str) {
+    fixture
+        .state
+        .enterprise
+        .org_unit_access_grants
+        .write()
+        .await
+        .insert(
+            id.into(),
+            OrganizationUnitAccessGrant::active(
+                id,
+                fixture.verified.tenant_context.clone(),
+                hosted_unit_principal(unit),
+                ResourceRef::new(
+                    "org-a",
+                    "dep-a",
+                    ResourceKind::SecretProviderCredential,
+                    REFERENCE,
+                ),
+                crate::now_ms(),
+            )
+            .with_permissions(vec![AccessPermission::Execute])
+            .with_data_classes(vec![DataClass::Credential]),
+        );
+}
+
+fn identity(actor: &str, version: u64) -> VerifiedTenantContext {
+    let now = crate::now_ms();
+    let mut claims = TenantContextAssertionClaims::new_v1(
+        "tandem-web",
+        "tandem-runtime",
+        now,
+        now + 300000,
+        format!("model-{actor}-{version}"),
+        TenantContext::explicit_user_workspace("org-a", "dep-a", Some("dep-a".into()), actor),
+        HumanActor::tandem_user(actor),
+        AuthorityChain::from_request(RequestPrincipal::authenticated_user(actor, "tandem-web")),
+        vec!["hosted:role:member".into()],
+    );
+    claims.policy_version = Some(version);
+    claims.capabilities = vec!["hosted.use".into()];
+    claims.org_units = vec![if actor == "alice" { "eng" } else { "ops" }.into()];
+    claims.into()
+}
+
+async fn two_user_policy(fixture: &Fixture, version: u64, bob_active: bool) {
+    let now = crate::now_ms();
+    let path = fixture.root.path().join("model-policy.json");
+    let raw = serde_json::to_vec(&serde_json::json!({
+        "schema_version": 1, "policy_version": version, "organization_id": "org-a", "deployment_id": "dep-a",
+        "generated_at": chrono::DateTime::from_timestamp_millis(now as i64).unwrap(),
+        "users": [{"id": "alice", "role": "member", "capabilities": ["hosted.use"], "is_active": true, "email_verified": true},
+            {"id": "bob", "role": "member", "capabilities": ["hosted.use"], "is_active": bob_active, "email_verified": true}],
+        "org_units": [{"id": "eng", "slug": "eng", "display_name": "Engineering", "kind": "department", "state": "active"},
+            {"id": "ops", "slug": "ops", "display_name": "Operations", "kind": "department", "state": "active"}],
+        "org_unit_memberships": [{"unit_id": "eng", "user_id": "alice"}, {"unit_id": "ops", "user_id": "bob"}],
+        "deployment_grants": []
+    })).unwrap();
+    std::fs::write(&path, raw).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+    fixture
+        .state
+        .enterprise
+        .hosted_policy
+        .configure_test_source("org-a", "dep-a", path);
+    fixture.state.reload_hosted_policy().await.unwrap();
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_service_model_account_checks_current_user_grants_and_revocation() {
+    let mut f = Fixture::new().await;
+    f.state.memory_db_path = f.root.path().join("memory.sqlite");
+    let revision = stored_key(&f, TOKEN).await;
+    configure(&mut f, &revision, TOKEN).await;
+    two_user_policy(&f, 2, true).await;
+    let alice = identity("alice", 2);
+    let bob = identity("bob", 2);
+    let scope = &f.configuration.configuration.scope;
+    // Hosted use alone, even an installer's earlier admin identity, is not a
+    // credential resource grant. Both actors start denied.
+    assert!(f
+        .state
+        .authorize_solution_model_account(&alice, scope, BINDING)
+        .await
+        .is_err());
+    grant(&f, "model-eng", "eng").await;
+    let first = f
+        .state
+        .authorize_solution_model_account(&alice, scope, BINDING)
+        .await
+        .unwrap();
+    assert_eq!(first.verified.human_actor.actor_id, "alice");
+    assert_eq!(first.binding.revision.authorization_revision, revision);
+    assert!(f
+        .state
+        .authorize_solution_model_account(&bob, scope, BINDING)
+        .await
+        .is_err());
+    grant(&f, "model-ops", "ops").await;
+    let shared = f
+        .state
+        .authorize_solution_model_account(&bob, scope, BINDING)
+        .await
+        .unwrap();
+    assert_eq!(shared.verified.human_actor.actor_id, "bob");
+    assert_ne!(shared.authority_sha256, first.authority_sha256);
+    f.state
+        .enterprise
+        .org_unit_access_grants
+        .write()
+        .await
+        .remove("model-ops");
+    assert!(f
+        .state
+        .authorize_solution_model_account(&bob, scope, BINDING)
+        .await
+        .is_err());
+    grant(&f, "model-ops", "ops").await;
+    two_user_policy(&f, 3, false).await;
+    assert!(f
+        .state
+        .authorize_solution_model_account(&identity("bob", 3), scope, BINDING)
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_service_model_account_reconnect_requires_a_new_operator_revision() {
+    let mut f = Fixture::new().await;
+    f.state.memory_db_path = f.root.path().join("memory.sqlite");
+    let original = stored_key(&f, TOKEN).await;
+    configure(&mut f, &original, TOKEN).await;
+    grant(&f, "model-eng", "eng").await;
+    assert!(f
+        .state
+        .authorize_solution_model_account(
+            &f.verified,
+            &f.configuration.configuration.scope,
+            BINDING
+        )
+        .await
+        .is_ok());
+    // Reconnecting the same material still creates a new authorization revision.
+    let reconnected = stored_key(&f, TOKEN).await;
+    assert_ne!(reconnected, original);
+    assert!(f
+        .state
+        .authorize_solution_model_account(
+            &f.verified,
+            &f.configuration.configuration.scope,
+            BINDING
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("reconnected"));
+    configure(&mut f, &reconnected, TOKEN).await;
+    assert!(f
+        .state
+        .authorize_solution_model_account(
+            &f.verified,
+            &f.configuration.configuration.scope,
+            BINDING
+        )
+        .await
+        .is_ok());
+    stored_key(&f, "different-synthetic-model-material").await;
+    assert!(f
+        .state
+        .authorize_solution_model_account(
+            &f.verified,
+            &f.configuration.configuration.scope,
+            BINDING
+        )
+        .await
+        .is_err());
+}

--- a/crates/tandem-server/src/pack_manager_model_account_tests.rs
+++ b/crates/tandem-server/src/pack_manager_model_account_tests.rs
@@ -269,3 +269,123 @@ async fn solution_service_model_account_revokes_while_credential_lookup_waits() 
         .unwrap();
     assert!(result.unwrap_err().to_string().contains("current user"));
 }
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_service_model_account_preview_and_stage_require_current_account() {
+    crate::encrypted_file_store::with_test_crypto_provider(
+        tandem_memory::MemoryCryptoProvider::local_key([0x39; 32]),
+        None,
+        async {
+            let mut f = Fixture::new().await;
+            f.state.memory_db_path = f.root.path().join("memory.sqlite");
+            let revision = stored_key(&f, TOKEN).await;
+            configure(&mut f, &revision, TOKEN).await;
+
+            // A separately signed synthetic pack explicitly permits this HTTP
+            // provider. The shipped local-only diagnostic fixture is unchanged.
+            let mut entries = fixture();
+            let (_, source) = entries
+                .iter_mut()
+                .find(|(path, _)| path == "solution.json")
+                .unwrap();
+            let mut blueprint: serde_json::Value = serde_json::from_str(source).unwrap();
+            blueprint["constraints"]["allowed_providers"] = serde_json::json!(["llama_cpp"]);
+            blueprint["constraints"]["allow_network_egress"] = true.into();
+            *source = serde_json::to_string(&blueprint).unwrap();
+            let archive = f.root.path().join("model-solution.zip");
+            let key = signed(&archive, &entries);
+            let _keys = EnvGuard::set("TANDEM_PACK_TRUSTED_PUBLIC_KEYS", &key);
+            f.state.pack_manager = Arc::new(PackManager::new(f.root.path().join("model-packs")));
+            f.state
+                .pack_manager
+                .install(request(&archive))
+                .await
+                .unwrap();
+            f.configuration.configuration.constraints.allowed_providers =
+                std::collections::BTreeSet::from(["llama_cpp".into()]);
+            f.configuration
+                .configuration
+                .constraints
+                .allow_network_egress = true;
+
+            let denied = f
+                .state
+                .preview_solution_configuration(&f.verified, &f.configuration)
+                .await
+                .err()
+                .expect("catalog membership must not approve the account");
+            assert!(denied.to_string().contains("model_binding_unapproved"));
+            grant(&f, "model-eng", "eng").await;
+
+            // An unrelated denied account must not block the selected allowed
+            // model. It is still omitted from the host's approved model facts.
+            let mut cli = f.state.config.get_layers_value().await["cli"].clone();
+            let mut unused = cli["solution_installation"]["models"][BINDING].clone();
+            unused["account"]["authorization_revision"] = "not-the-reviewed-revision".into();
+            cli["solution_installation"]["models"]["unused.denied"] = unused;
+            let mut runtime = f.state.runtime.wait().clone();
+            runtime.config = tandem_core::ConfigStore::new(
+                f.root.path().join("unrelated-model-config.json"),
+                Some(cli),
+            )
+            .await
+            .unwrap();
+            f.state.runtime = Arc::new(std::sync::OnceLock::from(runtime));
+            let mut reviewed = f.review_and_save().await;
+
+            f.state
+                .enterprise
+                .org_unit_access_grants
+                .write()
+                .await
+                .remove("model-eng");
+            let denied = f
+                .state
+                .stage_solution_installation(&f.verified, reviewed.clone())
+                .await
+                .unwrap_err();
+            assert!(denied.to_string().contains("model_binding_unapproved"));
+            assert!(!f.root.path().join(".tandem/agent-team/templates").exists());
+
+            grant(&f, "model-eng", "eng").await;
+            let reconnected = stored_key(&f, TOKEN).await;
+            assert_ne!(reconnected, revision);
+            assert!(f
+                .state
+                .preview_solution_configuration(&f.verified, &f.configuration)
+                .await
+                .is_err());
+            assert!(f
+                .state
+                .stage_solution_installation(&f.verified, reviewed.clone())
+                .await
+                .is_err());
+            configure(&mut f, &reconnected, TOKEN).await;
+            // The customer document is unchanged. Review the new host account
+            // facts against its existing protected configuration version.
+            reviewed.reviewed_composition = f
+                .state
+                .preview_solution_configuration(&f.verified, &f.configuration)
+                .await
+                .unwrap()
+                .composition_sha256;
+            let staged = f
+                .state
+                .stage_solution_installation(&f.verified, reviewed)
+                .await
+                .unwrap();
+            assert!(staged.all_components_staged());
+            let agent = &staged.plan.components["central-brain"].resource_id;
+            let template = f
+                .root
+                .path()
+                .join(".tandem/agent-team/templates")
+                .join(format!("{agent}.yaml"));
+            let observed: tandem_orchestrator::AgentTemplate =
+                serde_json::from_slice(&std::fs::read(template).unwrap()).unwrap();
+            assert!(!observed.enabled);
+        },
+    )
+    .await;
+}

--- a/crates/tandem-server/src/pack_manager_model_account_tests.rs
+++ b/crates/tandem-server/src/pack_manager_model_account_tests.rs
@@ -227,3 +227,45 @@ async fn solution_service_model_account_reconnect_requires_a_new_operator_revisi
         .await
         .is_err());
 }
+
+#[tokio::test]
+#[serial_test::serial(pack_signature_env)]
+async fn solution_service_model_account_revokes_while_credential_lookup_waits() {
+    let mut f = Fixture::new().await;
+    f.state.memory_db_path = f.root.path().join("memory.sqlite");
+    let revision = stored_key(&f, TOKEN).await;
+    configure(&mut f, &revision, TOKEN).await;
+    grant(&f, "model-eng", "eng").await;
+    let directory = crate::http::config_providers::provider_auth_security_dir_for_state(&f.state);
+    let guard = tandem_providers::provider_auth_mutation_in_dir(&directory)
+        .await
+        .unwrap();
+    let observed = Arc::new(tokio::sync::Notify::new());
+    let lookup = crate::solution_installation::scope_model_account_observation(
+        observed.clone(),
+        f.state.authorize_solution_model_account(
+            &f.verified,
+            &f.configuration.configuration.scope,
+            BINDING,
+        ),
+    );
+    tokio::pin!(lookup);
+    // A test-only notification proves that the initiating grant check allowed
+    // this operation. The actual credential file lock still prevents completion.
+    tokio::select! {
+        result = &mut lookup => panic!("lookup completed while mutation lock held: {result:?}"),
+        _ = observed.notified() => {},
+        _ = tokio::time::sleep(std::time::Duration::from_secs(3)) => panic!("initial account grant check was not reached"),
+    }
+    f.state
+        .enterprise
+        .org_unit_access_grants
+        .write()
+        .await
+        .remove("model-eng");
+    drop(guard);
+    let result = tokio::time::timeout(std::time::Duration::from_secs(3), lookup)
+        .await
+        .unwrap();
+    assert!(result.unwrap_err().to_string().contains("current user"));
+}

--- a/crates/tandem-server/src/solution_installation/host_facts.rs
+++ b/crates/tandem-server/src/solution_installation/host_facts.rs
@@ -30,6 +30,10 @@ pub(super) struct HostModel {
     /// Local echo is a diagnostic, never an implicit production fallback.
     #[serde(default)]
     pub allow_test_provider: bool,
+    /// Optional runtime account-use binding. Existing installation metadata
+    /// alone must never authorize access to a provider credential.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account: Option<super::model_accounts::HostAccountBinding>,
 }
 
 pub(super) struct HostFacts {

--- a/crates/tandem-server/src/solution_installation/host_facts.rs
+++ b/crates/tandem-server/src/solution_installation/host_facts.rs
@@ -134,6 +134,23 @@ impl AppState {
             }) {
                 continue;
             }
+            // A configured account must be usable by this current installer,
+            // including its reviewed revision and actual loaded credential.
+            // Unrelated denied bindings are omitted; the resolver will reject
+            // a selected binding that is absent. Metadata alone grants nothing.
+            if binding.account.is_some()
+                && self
+                    .authorize_solution_model_account_binding(
+                        verified,
+                        scope,
+                        binding_id,
+                        binding.clone(),
+                    )
+                    .await
+                    .is_err()
+            {
+                continue;
+            }
             models.insert(
                 binding_id.clone(),
                 ModelBinding {

--- a/crates/tandem-server/src/solution_installation/mod.rs
+++ b/crates/tandem-server/src/solution_installation/mod.rs
@@ -3,6 +3,8 @@
 //! pack, credential or memory registry is introduced here.
 
 mod host_facts;
+mod model_accounts;
+pub use model_accounts::SolutionModelAccount;
 mod staging;
 pub use staging::SolutionStagingRequest;
 

--- a/crates/tandem-server/src/solution_installation/mod.rs
+++ b/crates/tandem-server/src/solution_installation/mod.rs
@@ -4,6 +4,8 @@
 
 mod host_facts;
 mod model_accounts;
+#[cfg(test)]
+pub(crate) use model_accounts::scope_model_account_observation;
 pub use model_accounts::SolutionModelAccount;
 mod staging;
 pub use staging::SolutionStagingRequest;

--- a/crates/tandem-server/src/solution_installation/model_accounts.rs
+++ b/crates/tandem-server/src/solution_installation/model_accounts.rs
@@ -1,0 +1,180 @@
+//! Current account-use authorization over existing hosted/native grants and the
+//! existing provider credential store. This snapshot does not authorize a run.
+
+use anyhow::{ensure, Context};
+use serde::{Deserialize, Serialize};
+use tandem_enterprise_contract::{
+    AccessDecision, AccessPermission, DataClass, ResourceKind, ResourceRef, VerifiedTenantContext,
+};
+use tandem_providers::{
+    ProviderCredentialKind, ProviderCredentialLocation, VersionedProviderRuntimeBinding,
+};
+use tandem_solutions::{canonical_json, sha256, validate_customer_config_scope, CustomerScope};
+
+use super::host_facts::{HostModel, HostSettings};
+use crate::AppState;
+
+/// Operator-managed configuration, not an HTTP account grant or secret value.
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct HostAccountBinding {
+    pub credential_kind: ProviderCredentialKind,
+    pub credential_location: ProviderCredentialLocation,
+    /// Explicit reconnect requires operator review of a new account revision.
+    pub authorization_revision: String,
+    pub resource: ResourceRef,
+}
+
+/// Non-deserializable host snapshot. Model capability/data/price policy,
+/// installation activation and current run authority are separate prerequisites.
+#[derive(Debug)]
+pub struct SolutionModelAccount {
+    pub verified: VerifiedTenantContext,
+    pub binding_id: String,
+    pub binding: VersionedProviderRuntimeBinding,
+    pub authority_sha256: String,
+}
+
+impl AppState {
+    async fn operator_model_account(&self, binding_id: &str) -> anyhow::Result<HostModel> {
+        ensure!(
+            !binding_id.is_empty() && binding_id.len() <= 256,
+            "invalid model binding"
+        );
+        let layers = self.config.get_layers_value().await;
+        let settings: HostSettings = serde_json::from_value(
+            layers
+                .get("cli")
+                .and_then(|value| value.get("solution_installation"))
+                .or_else(|| {
+                    layers
+                        .get("managed")
+                        .and_then(|value| value.get("solution_installation"))
+                })
+                .cloned()
+                .context("operator solution installation policy required")?,
+        )?;
+        ensure!(
+            settings.schema_version == 1,
+            "unsupported host installation settings version"
+        );
+        settings
+            .models
+            .get(binding_id)
+            .cloned()
+            .context("operator model account binding unavailable")
+    }
+
+    async fn current_model_account_context(
+        &self,
+        verified: &VerifiedTenantContext,
+        scope: &CustomerScope,
+        model: &HostModel,
+    ) -> anyhow::Result<VerifiedTenantContext> {
+        let mut context = verified.clone();
+        let memberships = self
+            .enterprise
+            .hosted_policy
+            .project(&mut context)
+            .map_err(anyhow::Error::msg)?
+            .context("synchronized hosted identity required")?;
+        self.enterprise
+            .hosted_policy
+            .authorize_execution(Some(&context))
+            .map_err(anyhow::Error::msg)?;
+        crate::http::enrich_verified_context_with_org_unit_grants(
+            self,
+            &mut context,
+            Some(memberships),
+        )
+        .await;
+        validate_customer_config_scope(&context, scope, crate::now_ms())?;
+        let account = model
+            .account
+            .as_ref()
+            .context("explicit model account approval required")?;
+        ensure!(
+            account.resource.organization_id == scope.org_id
+                && account.resource.workspace_id == scope.workspace_id
+                && account.resource.resource_kind == ResourceKind::SecretProviderCredential
+                && account.resource.resource_id == model.credential_ref
+                && !account.authorization_revision.is_empty()
+                && account.authorization_revision.len() <= 256,
+            "model account resource or revision scope mismatch"
+        );
+        let strict = context
+            .strict_projection
+            .as_ref()
+            .context("strict model account context required")?;
+        ensure!(
+            strict
+                .evaluate_access(
+                    &account.resource,
+                    AccessPermission::Execute,
+                    DataClass::Credential,
+                    crate::now_ms()
+                )
+                .decision
+                == AccessDecision::Allow,
+            "current user is not permitted to use the model credential"
+        );
+        Ok(context)
+    }
+
+    /// Reuse current hosted identity, native credential resource grants and the
+    /// persisted-to-loaded credential matcher. No refresh, request or secret
+    /// value is returned, and tenant service scope never implies personal access.
+    pub async fn authorize_solution_model_account(
+        &self,
+        verified: &VerifiedTenantContext,
+        scope: &CustomerScope,
+        binding_id: &str,
+    ) -> anyhow::Result<SolutionModelAccount> {
+        let model = self.operator_model_account(binding_id).await?;
+        let context = self
+            .current_model_account_context(verified, scope, &model)
+            .await?;
+        let account = model
+            .account
+            .as_ref()
+            .context("explicit model account approval required")?;
+        let directory = crate::http::config_providers::provider_auth_security_dir_for_state(self);
+        let binding = self
+            .providers
+            .versioned_runtime_binding_for_tenant_in_dir(
+                &directory,
+                &context.tenant_context,
+                &model.provider_id,
+                &model.model_id,
+                account.credential_kind,
+                account.credential_location,
+            )
+            .await?;
+        ensure!(
+            binding.revision.authorization_revision == account.authorization_revision,
+            "model account was reconnected; review current authorization revision"
+        );
+        let current_model = self.operator_model_account(binding_id).await?;
+        ensure!(
+            canonical_json(&current_model)? == canonical_json(&model)?,
+            "operator model account binding changed during resolution"
+        );
+        // Filesystem/keychain reads can wait. Reproject current grants after
+        // that wait instead of reusing the initiating user's old projection.
+        let context = self
+            .current_model_account_context(verified, scope, &current_model)
+            .await?;
+        let authority_sha256 = sha256(&canonical_json(&serde_json::json!({
+            "schema_version": 1, "scope": scope, "binding_id": binding_id,
+            "model": current_model, "runtime": binding,
+            "verified": context,
+            "hosted_revision": self.enterprise.hosted_policy.revision().map_err(anyhow::Error::msg)?,
+        }))?);
+        Ok(SolutionModelAccount {
+            verified: context,
+            binding_id: binding_id.into(),
+            binding,
+            authority_sha256,
+        })
+    }
+}

--- a/crates/tandem-server/src/solution_installation/model_accounts.rs
+++ b/crates/tandem-server/src/solution_installation/model_accounts.rs
@@ -146,6 +146,19 @@ impl AppState {
         binding_id: &str,
     ) -> anyhow::Result<SolutionModelAccount> {
         let model = self.operator_model_account(binding_id).await?;
+        self.authorize_solution_model_account_binding(verified, scope, binding_id, model)
+            .await
+    }
+
+    /// Installation passes its exact operator snapshot so authorization cannot
+    /// silently approve a different model binding read after a configuration change.
+    pub(super) async fn authorize_solution_model_account_binding(
+        &self,
+        verified: &VerifiedTenantContext,
+        scope: &CustomerScope,
+        binding_id: &str,
+        model: HostModel,
+    ) -> anyhow::Result<SolutionModelAccount> {
         let context = self
             .current_model_account_context(verified, scope, &model)
             .await?;

--- a/crates/tandem-server/src/solution_installation/model_accounts.rs
+++ b/crates/tandem-server/src/solution_installation/model_accounts.rs
@@ -14,6 +14,19 @@ use tandem_solutions::{canonical_json, sha256, validate_customer_config_scope, C
 use super::host_facts::{HostModel, HostSettings};
 use crate::AppState;
 
+#[cfg(test)]
+tokio::task_local! {
+    static MODEL_ACCOUNT_CHECKED: std::sync::Arc<tokio::sync::Notify>;
+}
+
+#[cfg(test)]
+pub(crate) async fn scope_model_account_observation<F: std::future::Future>(
+    observed: std::sync::Arc<tokio::sync::Notify>,
+    future: F,
+) -> F::Output {
+    MODEL_ACCOUNT_CHECKED.scope(observed, future).await
+}
+
 /// Operator-managed configuration, not an HTTP account grant or secret value.
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -118,6 +131,8 @@ impl AppState {
                 == AccessDecision::Allow,
             "current user is not permitted to use the model credential"
         );
+        #[cfg(test)]
+        let _ = MODEL_ACCOUNT_CHECKED.try_with(|observed| observed.notify_one());
         Ok(context)
     }
 

--- a/docs/SOLUTION_MODEL_ACCOUNT_AUTHORITY.md
+++ b/docs/SOLUTION_MODEL_ACCOUNT_AUTHORITY.md
@@ -59,3 +59,8 @@ explicit sharing, native grant revocation and hosted-user removal. A second test
 checks reconnect with unchanged material, operator revision review and a mismatch
 between loaded and persisted material. The endpoint is never called; availability
 and provider billing are not claimed by these tests.
+
+A deterministic race test observes the initial successful grant check, holds the
+actual credential mutation lock, revokes the grant and releases the lock. The
+pending lookup must reject the user after its credential read completes. Its
+observation hook exists only in test builds and does not alter production checks.

--- a/docs/SOLUTION_MODEL_ACCOUNT_AUTHORITY.md
+++ b/docs/SOLUTION_MODEL_ACCOUNT_AUTHORITY.md
@@ -1,0 +1,61 @@
+# Current model account authority
+
+`AppState::authorize_solution_model_account` connects a model binding's existing
+stored credential revision to the current hosted user's native credential-use
+grant. Tenant credential scope alone does not grant account access.
+
+The existing operator `solution_installation.models` entry may now include an
+optional `account` object with `credential_kind` (`api_key` or `credential`),
+`credential_location` (`host_service` or `tenant_service`), the reviewed
+`authorization_revision`, and an existing credential `resource` reference. The
+resource must be `secret_provider_credential`, belong to the selected workspace
+and organization, and identify the model entry's existing `credential_ref`.
+Only managed/startup CLI policy supplies this binding; ordinary configuration
+overlays and customer documents do not approve it. An absent account object
+continues to support installation metadata but cannot authorize credential use.
+
+The service reprojects current hosted identity and memberships, requires
+`HostedUse`, and incorporates existing native organization-unit resource grants.
+The current human must have `Execute` on the exact credential resource for
+`Credential` data. An installer's old admin role and a peer's department grant
+are insufficient. This uses the existing resource-grant system; it does not add
+another provider-account store, user directory or permission registry.
+
+The existing provider matcher verifies that the actual loaded material matches
+the persisted credential and selected host/tenant location. The stored
+authorization revision must match operator approval. Same-account refresh may
+change material while retaining authorization; reconnect requires a new reviewed
+authorization revision even when its material is unchanged. Pending, disconnected,
+untracked and stale loaded credentials fail closed.
+
+After the credential read, the service rechecks operator configuration and
+reprojects current resource grants. The result includes the current verified
+identity, versioned runtime binding and a digest of the authority snapshot. It
+contains no credential values and performs no provider request or refresh.
+Callers must repeat authorization for every physical attempt and reject changes
+across reservation; the snapshot is not a durable dispatch capability.
+
+## Remaining integration
+
+The new service authorizes use of an existing service credential through current
+native grants. It does not implement personal provider-account storage or change
+which adapters support tenant bearer credentials. Only the existing Codex path
+currently supports that tenant authentication form. Unauthenticated local model
+routes continue to require their separate runtime/policy checks; they do not need
+fabricated credentials to fit this credential-use service.
+
+Current model availability, modality, tool support, data handling, price and
+customer constraints still belong to model-profile resolution and its trusted
+fact adapter. Installation-to-goal binding, durable profile history, activation,
+worker/routine/session integration and complete customer acceptance remain open.
+No runtime resources are activated by account authorization.
+
+## Tests
+
+`solution_service_model_account_` tests reuse the installed signed-pack service
+fixture and actual hosted-policy projection, native grants, credential store and
+provider registry. Two members in different departments demonstrate default deny,
+explicit sharing, native grant revocation and hosted-user removal. A second test
+checks reconnect with unchanged material, operator revision review and a mismatch
+between loaded and persisted material. The endpoint is never called; availability
+and provider billing are not claimed by these tests.

--- a/docs/SOLUTION_MODEL_ACCOUNT_AUTHORITY.md
+++ b/docs/SOLUTION_MODEL_ACCOUNT_AUTHORITY.md
@@ -35,6 +35,15 @@ contains no credential values and performs no provider request or refresh.
 Callers must repeat authorization for every physical attempt and reject changes
 across reservation; the snapshot is not a durable dispatch capability.
 
+Installation preview and every staging transition now apply the same current
+account checks to operator model entries with an account binding. A denied or
+stale account is omitted from approved models, so selecting it fails resolution.
+An unrelated denied model does not prevent review of an allowed selection.
+Authorization receives the exact operator model snapshot used for the plan and
+rejects a changed binding. Existing account-free diagnostic metadata retains its
+behavior. Saving customer intent remains separate from model readiness; it does
+not grant authority to stage or activate it.
+
 ## Remaining integration
 
 The new service authorizes use of an existing service credential through current
@@ -64,3 +73,9 @@ A deterministic race test observes the initial successful grant check, holds the
 actual credential mutation lock, revokes the grant and releases the lock. The
 pending lookup must reject the user after its credential read completes. Its
 observation hook exists only in test builds and does not alter production checks.
+
+The preview/staging integration test signs a separate synthetic HTTP-provider
+pack in a temporary directory. It checks default denial, an unrelated denied
+account, grant removal after review, reconnect invalidation and disabled staging
+after explicit revision review. It does not alter the shipped local-only pack,
+send a provider request or activate the staged agent.


### PR DESCRIPTION
A provider credential revision and model catalog entry did not establish that the current human may use that account. Connect the existing operator model binding to an explicit credential resource and reviewed authorization revision. Require current HostedUse plus native Execute/Credential permission, match persisted and loaded credentials, and reproject current memberships/grants after credential reads.

Installation preview and staging now apply these checks to configured account-backed models. A denied selected binding fails resolution, while unrelated denied bindings are omitted. The authorizer checks the exact operator model snapshot used by installation. Saved customer intent remains separate from readiness and grants no activation authority. Existing account-free diagnostic metadata remains compatible.

Managed/startup CLI model entries may include credential kind/location, reviewed authorization revision and an existing resource reference. Reconnecting unchanged material invalidates the old approval. No additional secret store, account directory or grant registry is introduced.

Four integration tests reuse actual hosted-policy projection, native organization-unit grants, credential files and provider registry. They cover two users in different departments, explicit sharing, revocation/removal, reconnect and stale loaded material; deterministic grant removal while the real credential mutation lock is held; and signed-pack preview/staging rejection after revocation or reconnect. The last test signs a separate synthetic network-provider pack and verifies the resulting agent stays disabled. The shipped local-only pack is unchanged. No provider endpoint is called, so these tests do not establish availability or billing.

Validation: current signed head c0f7973eab28c2032bd2499686c0e7a400c394e2 passes standalone rustfmt/diff checks; current-head Solution34028973739, Hosted34028973733, Engine34028973732, ACME34028973794 and Email34028973744 pass. Security34028973768 is still completing release/container checks; keep draft until it passes. Previous f018e55289ba6898b7290cfd3b8c561071d269fe passed [Solution Contract storage](https://github.com/frumu-ai/tandem/actions/runs/34028369346/job/101473305527), including the first three new account tests and SQLite/PostgreSQL suites. The fourth installation test and all three earlier account tests also pass on current head in [Solution storage](https://github.com/frumu-ai/tandem/actions/runs/34028973739/job/101474925837); seven solution service cases pass with actual SQLite/PostgreSQL suites. Stacked on #1952 at caee854cb183ba97cee2f1c47c908ab652b5b5fe. Keep draft until current-head checks pass.

This authorizes existing service credentials through current grants. Personal provider-account storage, per-physical-attempt production factory integration, current capability/availability/data/price facts, installation-to-goal binding, durable profile history, activation/task propagation, native routine/session adapters, non-model charges and full customer acceptance remain open. Unauthenticated local routes retain separate checks without fabricated credentials. Do not merge or mark whole issues Done. See docs/SOLUTION_MODEL_ACCOUNT_AUTHORITY.md.
