### PR TITLE
TAN-831: bind native goals to protected installation authority

### DIFF
--- a/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store.rs
@@ -26,6 +26,7 @@ mod runtime_records;
 pub(crate) mod solution_budget_records;
 mod solution_budgets;
 mod solution_execution;
+mod solution_goals;
 pub(crate) mod solution_installations;
 mod transfer;
 mod transition;
@@ -45,6 +46,7 @@ pub use solution_budgets::{
     SolutionRunBudget,
 };
 pub use solution_execution::SolutionRunExecution;
+pub use solution_goals::SolutionGoalStart;
 pub use solution_installations::{
     SolutionComponentProgress, SolutionInstallation, SolutionInstallationInput,
     SolutionInstallationTransition, SOLUTION_INSTALLATION_CONFLICT,
@@ -760,7 +762,13 @@ impl OrchestrationStateStore {
     }
 
     pub fn put_goal(&self, goal: &LongRunningGoal) -> anyhow::Result<()> {
-        self.with_connection(|connection| upsert_goal(connection, goal))
+        self.with_connection(|connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            upsert_goal(&transaction, goal)?;
+            transaction.commit()?;
+            Ok(())
+        })
     }
 
     pub fn get_goal(&self, goal_id: &str) -> anyhow::Result<Option<LongRunningGoal>> {
@@ -1429,7 +1437,19 @@ fn table_has_column(
     Ok(false)
 }
 
-fn upsert_goal(connection: &impl Executor, goal: &LongRunningGoal) -> anyhow::Result<()> {
+fn upsert_goal(
+    connection: &backend::Transaction<'_>,
+    goal: &LongRunningGoal,
+) -> anyhow::Result<()> {
+    upsert_goal_record(connection, goal, false)
+}
+
+fn upsert_goal_record(
+    connection: &backend::Transaction<'_>,
+    goal: &LongRunningGoal,
+    allow_initial_solution: bool,
+) -> anyhow::Result<()> {
+    solution_goals::preserve(connection, goal, allow_initial_solution)?;
     let status = serde_json::to_value(&goal.status)?;
     connection.execute(
         "INSERT INTO long_running_goals

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_lifecycle.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_lifecycle.rs
@@ -67,6 +67,31 @@ impl OrchestrationStateStore {
         link: &GoalRunLink,
         actor: &PrincipalRef,
     ) -> anyhow::Result<StartGoalOutcome> {
+        self.start_goal_inner(goal, root_run, link, actor, None)
+    }
+
+    /// Associate current installation facts in the same transaction as native
+    /// goal/root/link creation. Host-only; callers still authorize activation.
+    pub fn start_solution_goal(
+        &self,
+        goal: &LongRunningGoal,
+        root_run: &AutomationV2RunRecord,
+        link: &GoalRunLink,
+        actor: &PrincipalRef,
+        solution: super::SolutionGoalStart<'_>,
+    ) -> anyhow::Result<StartGoalOutcome> {
+        self.start_goal_inner(goal, root_run, link, actor, Some(solution))
+    }
+
+    fn start_goal_inner(
+        &self,
+        goal: &LongRunningGoal,
+        root_run: &AutomationV2RunRecord,
+        link: &GoalRunLink,
+        actor: &PrincipalRef,
+        solution: Option<super::SolutionGoalStart<'_>>,
+    ) -> anyhow::Result<StartGoalOutcome> {
+        super::solution_goals::reject_caller_binding(goal)?;
         if link.goal_id != goal.goal_id || link.run_id != root_run.run_id {
             bail!("goal start lineage must bind the goal to its root run");
         }
@@ -76,9 +101,24 @@ impl OrchestrationStateStore {
         if root_run.tenant_context != goal.tenant_context {
             bail!("root run must remain in the goal tenant scope");
         }
+        if solution.is_some()
+            && (goal.active_run_id.as_deref() != Some(root_run.run_id.as_str())
+                || goal.current_node_id.as_deref() != Some(link.orchestration_node_id.as_str())
+                || goal.orchestration_version != link.orchestration_version
+                || goal.hop_count != 0)
+        {
+            bail!("solution goal must start at its current orchestration root");
+        }
         self.with_connection(|connection| {
             let transaction =
                 connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let bound;
+            let goal = if let Some(solution) = &solution {
+                bound = super::solution_goals::bind(&transaction, goal, solution, &root_run.run_id, actor)?;
+                &bound
+            } else {
+                goal
+            };
             let existing = transaction
                 .query_row(
                     "SELECT goal_json FROM long_running_goals WHERE goal_id = ?1",
@@ -108,6 +148,9 @@ impl OrchestrationStateStore {
                         stored.orchestration_version
                     );
                 }
+                if !super::solution_goals::same(&stored, goal)? {
+                    bail!("goal start idempotency key is already bound to another solution authority");
+                }
                 let root_payload = transaction
                     .query_row(
                         "SELECT run_json FROM automation_runs WHERE run_id = ?1",
@@ -128,7 +171,16 @@ impl OrchestrationStateStore {
                 });
             }
 
-            upsert_goal(&transaction, goal)?;
+            if solution.is_some() {
+                let root_exists: bool = transaction.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM automation_runs WHERE run_id=?1)",
+                    [&root_run.run_id], |row| row.get(0),
+                )?;
+                if root_exists {
+                    bail!("solution goal root already belongs to an existing run");
+                }
+            }
+            super::upsert_goal_record(&transaction, goal, solution.is_some())?;
             upsert_automation_run(&transaction, root_run)?;
             transaction.execute(
                 "INSERT INTO goal_run_links

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_lifecycle.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/goal_lifecycle.rs
@@ -67,7 +67,7 @@ impl OrchestrationStateStore {
         link: &GoalRunLink,
         actor: &PrincipalRef,
     ) -> anyhow::Result<StartGoalOutcome> {
-        self.start_goal_inner(goal, root_run, link, actor, None)
+        self.start_goal_inner(goal, root_run, link, actor, None, &|| 0)
     }
 
     /// Associate current installation facts in the same transaction as native
@@ -79,8 +79,9 @@ impl OrchestrationStateStore {
         link: &GoalRunLink,
         actor: &PrincipalRef,
         solution: super::SolutionGoalStart<'_>,
+        clock: impl Fn() -> u64,
     ) -> anyhow::Result<StartGoalOutcome> {
-        self.start_goal_inner(goal, root_run, link, actor, Some(solution))
+        self.start_goal_inner(goal, root_run, link, actor, Some(solution), &clock)
     }
 
     fn start_goal_inner(
@@ -90,6 +91,7 @@ impl OrchestrationStateStore {
         link: &GoalRunLink,
         actor: &PrincipalRef,
         solution: Option<super::SolutionGoalStart<'_>>,
+        clock: &dyn Fn() -> u64,
     ) -> anyhow::Result<StartGoalOutcome> {
         super::solution_goals::reject_caller_binding(goal)?;
         if link.goal_id != goal.goal_id || link.run_id != root_run.run_id {
@@ -112,6 +114,12 @@ impl OrchestrationStateStore {
         self.with_connection(|connection| {
             let transaction =
                 connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            // Waiting for the writer must not preserve an expired initiating
+            // timestamp. Ordinary goal creation does not use this clock.
+            let solution = solution.map(|input| super::SolutionGoalStart {
+                now_ms: clock(),
+                ..input
+            });
             let bound;
             let goal = if let Some(solution) = &solution {
                 bound = super::solution_goals::bind(&transaction, goal, solution, &root_run.run_id, actor)?;

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/provider_attempt_budget.rs
@@ -167,16 +167,11 @@ impl OrchestrationStateStore {
                         );
                         let execution_store = store.clone();
                         let execution_clock = clock.clone();
-                        let tenant = current.verified.tenant_context.clone();
-                        let execution = current.execution.clone();
-                        let root = current.root_run_id.clone();
+                        let execution_approval = current.clone();
                         crate::encrypted_file_store::spawn_protected_blocking(move || {
-                            execution_store.validate_solution_execution(
-                                &tenant,
-                                &execution,
-                                &root,
-                                || execution_clock(),
-                            )
+                            execution_store.validate_solution_execution(&execution_approval, || {
+                                execution_clock()
+                            })
                         })
                         .await??;
                         // The final writer transaction can itself wait. Do not

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_budgets.rs
@@ -223,12 +223,25 @@ impl OrchestrationStateStore {
                 solution_installations::load(&transaction, input.verified, input.scope)?
                     .context("solution installation missing")?;
             if let Some(model) = model {
-                super::solution_execution::validate(
+                let goal = super::solution_execution::validate(
                     &transaction,
                     tenant,
                     &model.execution,
                     &intent.root_run_id,
                     input.now_ms,
+                )?;
+                super::solution_goals::validate(
+                    &transaction,
+                    &goal,
+                    &super::SolutionGoalStart {
+                        verified: input.verified,
+                        scope: input.scope,
+                        configuration: &model.configuration,
+                        installation_generation: model.installation_generation,
+                        composition_sha256: input.composition_sha256,
+                        now_ms: input.now_ms,
+                    },
+                    &intent.root_run_id,
                 )?;
                 ensure!(
                     installation.generation == model.installation_generation

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution.rs
@@ -80,7 +80,7 @@ pub(super) fn validate(
     execution: &SolutionRunExecution,
     expected_root: &str,
     now_ms: u64,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<LongRunningGoal> {
     ensure!(
         !tenant.is_local_implicit(),
         "solution execution requires explicit tenant scope"
@@ -165,7 +165,7 @@ pub(super) fn validate(
         );
         current = parent;
     }
-    Ok(())
+    Ok(goal)
 }
 
 impl OrchestrationStateStore {
@@ -173,15 +173,33 @@ impl OrchestrationStateStore {
     /// dispatch. A later settlement remains permitted after a goal stops.
     pub(super) fn validate_solution_execution(
         &self,
-        tenant: &TenantContext,
-        execution: &SolutionRunExecution,
-        expected_root: &str,
+        approval: &super::ApprovedSolutionProviderCharge,
         clock: impl Fn() -> u64,
     ) -> anyhow::Result<()> {
         self.with_connection(|connection| {
             let transaction =
                 connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-            validate(&transaction, tenant, execution, expected_root, clock())?;
+            let now_ms = clock();
+            let goal = validate(
+                &transaction,
+                &approval.verified.tenant_context,
+                &approval.execution,
+                &approval.root_run_id,
+                now_ms,
+            )?;
+            super::solution_goals::validate(
+                &transaction,
+                &goal,
+                &super::SolutionGoalStart {
+                    verified: &approval.verified,
+                    scope: &approval.scope,
+                    configuration: &approval.configuration,
+                    installation_generation: approval.installation_generation,
+                    composition_sha256: &approval.composition_sha256,
+                    now_ms,
+                },
+                &approval.root_run_id,
+            )?;
             transaction.commit()?;
             Ok(())
         })

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution_tests.rs
@@ -387,12 +387,7 @@ fn solution_budget_provider_parent_chain_rejects_missing_cyclic_and_foreign_root
                 let mut approved = approval(&fixture, store);
                 approved.execution.run_id = seed_child(store, &fixture);
                 store
-                    .validate_solution_execution(
-                        &approved.verified.tenant_context,
-                        &approved.execution,
-                        &approved.root_run_id,
-                        || 1500,
-                    )
+                    .validate_solution_execution(&approved, || 1500)
                     .unwrap();
                 store.with_connection(|connection| {
                 let raw: String = connection.query_row(
@@ -413,12 +408,7 @@ fn solution_budget_provider_parent_chain_rejects_missing_cyclic_and_foreign_root
             }).unwrap();
                 assert!(
                     store
-                        .validate_solution_execution(
-                            &approved.verified.tenant_context,
-                            &approved.execution,
-                            &approved.root_run_id,
-                            || 1500
-                        )
+                        .validate_solution_execution(&approved, || 1500)
                         .is_err(),
                     "{fault}"
                 );

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution_tests.rs
@@ -42,6 +42,7 @@ pub(super) fn seed_execution(store: &OrchestrationStateStore, fixture: &BudgetFi
                 &fixture.installation.customer.context.human_actor.actor_id,
             ),
             goal_start(fixture, &installed),
+            || 1500,
         )
         .unwrap();
 }

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_execution_tests.rs
@@ -31,6 +31,86 @@ fn execution_run(fixture: &BudgetFixture, id: &str) -> AutomationV2RunRecord {
 }
 
 pub(super) fn seed_execution(store: &OrchestrationStateStore, fixture: &BudgetFixture) {
+    let installed = staged_installation(store, fixture);
+    let (goal, root, link) = execution_records(fixture);
+    store
+        .start_solution_goal(
+            &goal,
+            &root,
+            &link,
+            &tandem_types::PrincipalRef::human_user(
+                &fixture.installation.customer.context.human_actor.actor_id,
+            ),
+            goal_start(fixture, &installed),
+        )
+        .unwrap();
+}
+
+fn goal_start<'a>(
+    fixture: &'a BudgetFixture,
+    installed: &'a SolutionInstallation,
+) -> SolutionGoalStart<'a> {
+    SolutionGoalStart {
+        verified: &fixture.installation.customer.context,
+        scope: &fixture.installation.customer.config.scope,
+        configuration: &installed.config_version,
+        installation_generation: installed.generation,
+        composition_sha256: &fixture.digest,
+        now_ms: 1500,
+    }
+}
+
+fn staged_installation(
+    store: &OrchestrationStateStore,
+    fixture: &BudgetFixture,
+) -> SolutionInstallation {
+    let config = store
+        .customer_configuration(
+            &fixture.installation.customer.context,
+            &fixture.installation.customer.config.scope,
+            1500,
+        )
+        .unwrap()
+        .unwrap();
+    let mut installed = fixture.installation.read(store);
+    // Storage fixtures exercise the real journal transition protocol with
+    // synthetic receipts. They do not establish native activation readiness.
+    for component in installed.plan.install_order.clone() {
+        if matches!(
+            installed.components[&component],
+            SolutionComponentProgress::Staged { .. }
+        ) {
+            continue;
+        }
+        let attempt = format!("synthetic-stage-{component}");
+        installed = store
+            .transition_solution_installation(
+                fixture.installation.input(&config, &fixture.digest),
+                Some(installed.generation),
+                SolutionInstallationTransition::Claim {
+                    component_id: &component,
+                    attempt_id: &attempt,
+                },
+            )
+            .unwrap();
+        installed = store
+            .transition_solution_installation(
+                fixture.installation.input(&config, &fixture.digest),
+                Some(installed.generation),
+                SolutionInstallationTransition::RecordStaged {
+                    component_id: &component,
+                    attempt_id: &attempt,
+                    resource_sha256: &sha256(component.as_bytes()),
+                },
+            )
+            .unwrap();
+    }
+    installed
+}
+
+fn execution_records(
+    fixture: &BudgetFixture,
+) -> (LongRunningGoal, AutomationV2RunRecord, GoalRunLink) {
     let root = execution_run(fixture, &root_id(fixture));
     let goal: LongRunningGoal = serde_json::from_value(serde_json::json!({
         "schema_version": 1, "goal_id": goal_id(fixture), "orchestration_id": "synthetic-orchestration",
@@ -50,18 +130,11 @@ pub(super) fn seed_execution(store: &OrchestrationStateStore, fixture: &BudgetFi
         triggering_handoff_id: None,
         created_at_ms: 1000,
     };
-    store
-        .start_goal(
-            &goal,
-            &root,
-            &link,
-            &tandem_types::PrincipalRef::new(
-                tandem_types::PrincipalKind::HumanUser,
-                &fixture.installation.customer.context.human_actor.actor_id,
-            ),
-        )
-        .unwrap();
+    (goal, root, link)
 }
+
+#[path = "solution_goal_binding_tests.rs"]
+mod binding_tests;
 
 fn seed_child(store: &OrchestrationStateStore, fixture: &BudgetFixture) -> String {
     let child_id = format!("child-{}", root_id(fixture));

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_goal_binding_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_goal_binding_tests.rs
@@ -1,0 +1,205 @@
+use super::*;
+
+#[test]
+#[serial]
+fn solution_budget_provider_historical_metadata_cannot_forge_goal_binding() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            for fault in ["plaintext", "copied-envelope"] {
+                let a = network_fixture(store, &format!("historical-{fault}"));
+                let b = network_fixture(store, &format!("other-{fault}"));
+                let approved = approval(&a, store);
+                let mut goal = store.get_goal(&goal_id(&a)).unwrap().unwrap();
+                let forged = if fault == "plaintext" {
+                    serde_json::Value::String(
+                        serde_json::json!({
+                            "schema_version": 1, "scope": approved.scope,
+                            "configuration": approved.configuration,
+                            "installation_generation": approved.installation_generation,
+                            "composition_sha256": approved.composition_sha256,
+                            "actor_id": approved.verified.human_actor.actor_id,
+                            "root_run_id": approved.root_run_id,
+                        })
+                        .to_string(),
+                    )
+                } else {
+                    store
+                        .get_goal(&goal_id(&b))
+                        .unwrap()
+                        .unwrap()
+                        .metadata
+                        .unwrap()["tandem_solution_binding"]
+                        .clone()
+                };
+                goal.metadata.as_mut().unwrap()["tandem_solution_binding"] = forged;
+                // Simulate metadata persisted by an old server. Its outer record
+                // is genuinely protected; only the host-issued inner proof is absent
+                // or belongs to a different goal.
+                store
+                    .with_connection(|connection| {
+                        connection.execute(
+                            "UPDATE long_running_goals SET goal_json=?1 WHERE goal_id=?2",
+                            params![
+                                protected_records::encode(
+                                    &goal.tenant_context,
+                                    "goal",
+                                    &goal.goal_id,
+                                    &goal
+                                )?,
+                                goal.goal_id
+                            ],
+                        )?;
+                        Ok(())
+                    })
+                    .unwrap();
+                runtime().block_on(async {
+                    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                    let registry = registry(listener.local_addr().unwrap());
+                    let policy = policy(store, &registry, approved, Arc::new(AtomicU64::new(1500)));
+                    assert!(complete(&registry, policy).await.is_err(), "{fault}");
+                    assert!(account_row(store, &a, "global").await.is_none());
+                    assert!(tokio::time::timeout(
+                        std::time::Duration::from_millis(30),
+                        listener.accept()
+                    )
+                    .await
+                    .is_err());
+                });
+            }
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_goal_binding_requires_staging_and_is_immutable() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let fixture = BudgetFixture::new(store, "a", "goal-binding", 4);
+            let (goal, root, link) = execution_records(&fixture);
+            let actor = tandem_types::PrincipalRef::human_user(
+                &fixture.installation.customer.context.human_actor.actor_id,
+            );
+            let pending = fixture.installation.read(store);
+            assert!(store
+                .start_solution_goal(&goal, &root, &link, &actor, goal_start(&fixture, &pending))
+                .is_err());
+            assert!(store.get_goal(&goal.goal_id).unwrap().is_none());
+            assert!(store.get_automation_run(&root.run_id).unwrap().is_none());
+            let installed = staged_installation(store, &fixture);
+            assert!(matches!(
+                store
+                    .start_solution_goal(
+                        &goal,
+                        &root,
+                        &link,
+                        &actor,
+                        goal_start(&fixture, &installed)
+                    )
+                    .unwrap(),
+                StartGoalOutcome::Created { .. }
+            ));
+            store.initialize().unwrap();
+            assert!(matches!(
+                store
+                    .start_solution_goal(
+                        &goal,
+                        &root,
+                        &link,
+                        &actor,
+                        goal_start(&fixture, &installed)
+                    )
+                    .unwrap(),
+                StartGoalOutcome::AlreadyStarted { .. }
+            ));
+            let bound = store.get_goal(&goal.goal_id).unwrap().unwrap();
+            assert!(store.start_goal(&bound, &root, &link, &actor).is_err());
+            assert!(store.start_goal(&goal, &root, &link, &actor).is_err());
+            let mut changed = bound.clone();
+            changed.metadata = None;
+            assert!(store.put_goal(&changed).is_err());
+            changed = bound.clone();
+            changed.goal_id = "forged-copy".into();
+            assert!(store.put_goal(&changed).is_err());
+            assert!(store.get_goal("forged-copy").unwrap().is_none());
+            assert_eq!(store.get_goal(&goal.goal_id).unwrap().unwrap(), bound);
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_goal_cannot_charge_another_installation() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let a = network_fixture(store, "goal-owner-a");
+            let b = network_fixture(store, "goal-owner-b");
+            let original = approval(&a, store);
+            let mut other = approval(&b, store);
+            other.execution = original.execution;
+            other.root_run_id = original.root_run_id;
+            runtime().block_on(async {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let registry = registry(listener.local_addr().unwrap());
+                let policy = policy(store, &registry, other, Arc::new(AtomicU64::new(1500)));
+                let denied = complete(&registry, policy).await.unwrap_err();
+                assert!(format!("{denied:#}").contains("another solution"));
+                assert!(account_row(store, &b, "global").await.is_none());
+                assert!(tokio::time::timeout(
+                    std::time::Duration::from_millis(30),
+                    listener.accept()
+                )
+                .await
+                .is_err());
+            });
+        })
+    });
+}
+
+#[test]
+#[serial]
+fn solution_budget_provider_concurrent_goal_start_cannot_rebind_installation() {
+    encrypted(|| {
+        for_each_backend(|_, store| {
+            let a = BudgetFixture::new(store, "a", "start-race-a", 4);
+            let b = BudgetFixture::new(store, "a", "start-race-b", 4);
+            let ia = staged_installation(store, &a);
+            let ib = staged_installation(store, &b);
+            let (goal, root, link) = execution_records(&a);
+            let actor = tandem_types::PrincipalRef::human_user(
+                &a.installation.customer.context.human_actor.actor_id,
+            );
+            let barrier = std::sync::Barrier::new(2);
+            let results = std::thread::scope(|scope| {
+                let handles: Vec<_> = [(&a, &ia), (&b, &ib)]
+                    .into_iter()
+                    .map(|(fixture, installed)| {
+                        let (goal, root, link, actor, barrier) =
+                            (&goal, &root, &link, &actor, &barrier);
+                        scope.spawn(move || {
+                            encrypted(|| {
+                                barrier.wait();
+                                store.start_solution_goal(
+                                    goal,
+                                    root,
+                                    link,
+                                    actor,
+                                    goal_start(fixture, installed),
+                                )
+                            })
+                        })
+                    })
+                    .collect();
+                handles
+                    .into_iter()
+                    .map(|handle| handle.join().unwrap())
+                    .collect::<Vec<_>>()
+            });
+            assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+            assert_eq!(results.iter().filter(|result| result.is_err()).count(), 1);
+            let winner = store.get_goal(&goal.goal_id).unwrap().unwrap();
+            store.initialize().unwrap();
+            assert_eq!(store.get_goal(&goal.goal_id).unwrap().unwrap(), winner);
+        })
+    });
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_goal_binding_tests.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_goal_binding_tests.rs
@@ -82,11 +82,33 @@ fn solution_budget_provider_goal_binding_requires_staging_and_is_immutable() {
             );
             let pending = fixture.installation.read(store);
             assert!(store
-                .start_solution_goal(&goal, &root, &link, &actor, goal_start(&fixture, &pending))
+                .start_solution_goal(
+                    &goal,
+                    &root,
+                    &link,
+                    &actor,
+                    goal_start(&fixture, &pending),
+                    || 1500
+                )
                 .is_err());
             assert!(store.get_goal(&goal.goal_id).unwrap().is_none());
             assert!(store.get_automation_run(&root.run_id).unwrap().is_none());
             let installed = staged_installation(store, &fixture);
+            // The initiating input still says 1500. Admission must instead use
+            // the trusted clock sampled inside its writer transaction.
+            let expired = fixture.installation.customer.context.expires_at_ms + 1;
+            assert!(store
+                .start_solution_goal(
+                    &goal,
+                    &root,
+                    &link,
+                    &actor,
+                    goal_start(&fixture, &installed),
+                    || expired,
+                )
+                .is_err());
+            assert!(store.get_goal(&goal.goal_id).unwrap().is_none());
+            assert!(store.get_automation_run(&root.run_id).unwrap().is_none());
             assert!(matches!(
                 store
                     .start_solution_goal(
@@ -94,7 +116,8 @@ fn solution_budget_provider_goal_binding_requires_staging_and_is_immutable() {
                         &root,
                         &link,
                         &actor,
-                        goal_start(&fixture, &installed)
+                        goal_start(&fixture, &installed),
+                        || 1500,
                     )
                     .unwrap(),
                 StartGoalOutcome::Created { .. }
@@ -107,7 +130,8 @@ fn solution_budget_provider_goal_binding_requires_staging_and_is_immutable() {
                         &root,
                         &link,
                         &actor,
-                        goal_start(&fixture, &installed)
+                        goal_start(&fixture, &installed),
+                        || 1500,
                     )
                     .unwrap(),
                 StartGoalOutcome::AlreadyStarted { .. }
@@ -185,6 +209,7 @@ fn solution_budget_provider_concurrent_goal_start_cannot_rebind_installation() {
                                     link,
                                     actor,
                                     goal_start(fixture, installed),
+                                    || 1500,
                                 )
                             })
                         })

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_goals.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_goals.rs
@@ -1,0 +1,187 @@
+//! Immutable installation association in the existing protected goal record.
+//! This does not grant activation or replace current per-attempt user policy.
+
+use anyhow::{ensure, Context};
+use serde::{Deserialize, Serialize};
+use tandem_automation::LongRunningGoal;
+use tandem_solutions::{validate_customer_config_scope, CustomerScope};
+use tandem_types::{PrincipalRef, VerifiedTenantContext};
+
+use super::{customer_configs, protected_records, solution_installations, CustomerConfigVersion};
+use crate::stateful_runtime::backend::{Executor, OptionalExtension};
+
+const KEY: &str = "tandem_solution_binding";
+const RECORD_KIND: &str = "solution-goal-binding";
+
+/// Trusted host inputs, never an HTTP-deserializable start permission. The
+/// calling service must authorize activation and the current execution actor.
+pub struct SolutionGoalStart<'a> {
+    pub verified: &'a VerifiedTenantContext,
+    pub scope: &'a CustomerScope,
+    pub configuration: &'a CustomerConfigVersion,
+    pub installation_generation: u64,
+    pub composition_sha256: &'a str,
+    pub now_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Binding {
+    schema_version: u32,
+    scope: CustomerScope,
+    configuration: CustomerConfigVersion,
+    installation_generation: u64,
+    composition_sha256: String,
+    actor_id: String,
+    root_run_id: String,
+}
+
+pub(super) fn value(goal: &LongRunningGoal) -> Option<&serde_json::Value> {
+    goal.metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get(KEY))
+}
+
+pub(super) fn reject_caller_binding(goal: &LongRunningGoal) -> anyhow::Result<()> {
+    ensure!(
+        value(goal).is_none(),
+        "solution goal binding is reserved host authority"
+    );
+    Ok(())
+}
+
+fn current_binding(
+    executor: &impl Executor,
+    input: &SolutionGoalStart<'_>,
+    root: &str,
+) -> anyhow::Result<Binding> {
+    validate_customer_config_scope(input.verified, input.scope, input.now_ms)?;
+    ensure!(!root.is_empty(), "solution root run is required");
+    let installation = solution_installations::load(executor, input.verified, input.scope)?
+        .context("solution installation missing")?;
+    ensure!(
+        installation.all_components_staged()
+            && installation.generation == input.installation_generation
+            && &installation.config_version == input.configuration
+            && installation.composition_sha256 == input.composition_sha256,
+        "solution goal requires the current fully staged installation"
+    );
+    let configuration =
+        customer_configs::load(executor, &input.verified.tenant_context, input.scope)?
+            .context("solution customer configuration missing")?;
+    ensure!(
+        configuration.version == installation.config_version
+            && configuration.blueprint_sha256 == installation.plan.blueprint_sha256,
+        "solution goal configuration changed"
+    );
+    Ok(Binding {
+        schema_version: 1,
+        scope: input.scope.clone(),
+        configuration: input.configuration.clone(),
+        installation_generation: input.installation_generation,
+        composition_sha256: input.composition_sha256.into(),
+        actor_id: input.verified.human_actor.actor_id.clone(),
+        root_run_id: root.into(),
+    })
+}
+
+pub(super) fn bind(
+    executor: &impl Executor,
+    goal: &LongRunningGoal,
+    input: &SolutionGoalStart<'_>,
+    root: &str,
+    actor: &PrincipalRef,
+) -> anyhow::Result<LongRunningGoal> {
+    reject_caller_binding(goal)?;
+    let tenant = &input.verified.tenant_context;
+    ensure!(
+        goal.tenant_context.org_id == tenant.org_id
+            && goal.tenant_context.workspace_id == tenant.workspace_id
+            && goal.tenant_context.deployment_id == tenant.deployment_id
+            && actor == &PrincipalRef::human_user(&input.verified.human_actor.actor_id),
+        "solution goal actor or tenant differs from current authorization"
+    );
+    let binding = current_binding(executor, input, root)?;
+    let mut bound = goal.clone();
+    let mut metadata = match bound.metadata.take() {
+        Some(serde_json::Value::Object(metadata)) => metadata,
+        Some(other) => serde_json::Map::from_iter([("value".into(), other)]),
+        None => serde_json::Map::new(),
+    };
+    // A separately authenticated record kind distinguishes host issuance from
+    // arbitrary metadata persisted by older servers before this key was reserved.
+    metadata.insert(
+        KEY.into(),
+        serde_json::Value::String(protected_records::encode(
+            &goal.tenant_context,
+            RECORD_KIND,
+            &goal.goal_id,
+            &binding,
+        )?),
+    );
+    metadata.insert("started_by".into(), serde_json::to_value(actor)?);
+    bound.metadata = Some(serde_json::Value::Object(metadata));
+    read(&bound)?;
+    Ok(bound)
+}
+
+pub(super) fn validate(
+    executor: &impl Executor,
+    goal: &LongRunningGoal,
+    input: &SolutionGoalStart<'_>,
+    root: &str,
+) -> anyhow::Result<()> {
+    let binding = read(goal)?.context("native goal has no approved solution association")?;
+    ensure!(
+        binding == current_binding(executor, input, root)?,
+        "native goal belongs to another solution, configuration, actor or root"
+    );
+    Ok(())
+}
+
+fn read(goal: &LongRunningGoal) -> anyhow::Result<Option<Binding>> {
+    value(goal)
+        .map(|value| {
+            let raw = value
+                .as_str()
+                .context("solution goal association lacks host authentication")?;
+            ensure!(
+                crate::encrypted_file_store::is_encrypted_payload(raw),
+                "solution goal association requires an authenticated envelope"
+            );
+            protected_records::decode(&goal.tenant_context, RECORD_KIND, &goal.goal_id, raw)
+        })
+        .transpose()
+}
+
+pub(super) fn same(left: &LongRunningGoal, right: &LongRunningGoal) -> anyhow::Result<bool> {
+    Ok(read(left)? == read(right)?)
+}
+
+/// All generic goal writes preserve the association, including its absence.
+/// The writer transaction prevents a concurrent insert from turning an ordinary
+/// upsert into an overwrite of a newly bound solution goal.
+pub(super) fn preserve(
+    executor: &impl Executor,
+    goal: &LongRunningGoal,
+    allow_initial: bool,
+) -> anyhow::Result<()> {
+    let raw: Option<String> = executor
+        .query_row(
+            "SELECT goal_json FROM long_running_goals WHERE goal_id=?1",
+            [&goal.goal_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(raw) = raw {
+        let stored: LongRunningGoal =
+            protected_records::decode(&goal.tenant_context, "goal", &goal.goal_id, &raw)?;
+        ensure!(
+            value(&stored) == value(goal),
+            "solution goal association is immutable"
+        );
+    } else if !allow_initial {
+        reject_caller_binding(goal)?;
+    }
+    Ok(())
+}

--- a/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_goals.rs
+++ b/crates/tandem-server/src/stateful_runtime/orchestration_store/solution_goals.rs
@@ -15,6 +15,7 @@ const RECORD_KIND: &str = "solution-goal-binding";
 
 /// Trusted host inputs, never an HTTP-deserializable start permission. The
 /// calling service must authorize activation and the current execution actor.
+#[derive(Clone, Copy)]
 pub struct SolutionGoalStart<'a> {
     pub verified: &'a VerifiedTenantContext,
     pub scope: &'a CustomerScope,

--- a/docs/SOLUTION_GOAL_BINDING.md
+++ b/docs/SOLUTION_GOAL_BINDING.md
@@ -9,7 +9,9 @@ the same tenant with an otherwise valid model approval.
 customer configuration, fully staged installation, generation, composition and
 verified human. It commits the association with the existing native goal, root
 run, hop-zero link and start event in one writer transaction. A reused root run
-is rejected. Replaying the same start returns the existing records; replaying
+is rejected. Identity expiry uses the trusted clock sampled after acquiring the
+writer lock, rather than the initiating input's timestamp. Replaying the same
+start returns the existing records; replaying
 another installation or actor under that goal ID fails. No additional root
 registry, storage schema or secret store is introduced.
 

--- a/docs/SOLUTION_GOAL_BINDING.md
+++ b/docs/SOLUTION_GOAL_BINDING.md
@@ -1,0 +1,47 @@
+# Native goal installation binding
+
+The trusted solution provider budget path now requires both native execution
+lineage and an immutable association between that goal and its installation.
+An active goal for installation A cannot spend against installation B, even in
+the same tenant with an otherwise valid model approval.
+
+`OrchestrationStateStore::start_solution_goal` validates the current protected
+customer configuration, fully staged installation, generation, composition and
+verified human. It commits the association with the existing native goal, root
+run, hop-zero link and start event in one writer transaction. A reused root run
+is rejected. Replaying the same start returns the existing records; replaying
+another installation or actor under that goal ID fails. No additional root
+registry, storage schema or secret store is introduced.
+
+The association is an authenticated envelope inside the existing encrypted goal
+record. Its record kind and goal ID are authenticated through the existing
+protected-record subsystem. This additional provenance matters because older
+goal APIs accepted arbitrary metadata: plaintext metadata, even inside a valid
+encrypted outer goal, cannot assert host approval. Copying an envelope from a
+different goal also fails. Ordinary goal start rejects the reserved metadata
+key. Generic goal writes preserve the association, including its absence, under
+a writer transaction; they cannot attach, strip or replace it later.
+
+Every physical provider reservation checks the association against the current
+installation/configuration and actual root. The final check after reservation
+repeats those reads with time sampled after the writer lock. Existing child
+lineage shares the same association and budget; stopping execution still permits
+settlement of already admitted attempts. Existing ordinary goals remain usable
+outside solution dispatch but cannot acquire a solution budget through metadata.
+
+This storage entry point accepts trusted host inputs. It is not exposed as a new
+HTTP endpoint and does not authorize activation, establish current source/model
+permissions or verify a workflow belongs to an installed worker component. The
+production service still needs those checks, the current execution actor factory,
+durable profile history and propagation into workers/routines/sessions before
+Company Brain activation and end-to-end acceptance. No staged resource is enabled
+by this change. The existing installer identity must not become another runtime
+user's private-memory authority.
+
+Regression coverage uses actual SQLite/PostgreSQL state and existing physical
+provider attempts: rejected unstaged creation leaves no goal/root, restart and
+idempotent creation, immutable generic writes, concurrent competing installation
+starts, cross-installation spending with zero sends/reservations, and historical
+plaintext/copied-envelope forgery. Existing child/restart and shared-ceiling tests
+now start associated goals. Storage fixtures record synthetic staging receipts;
+these tests do not claim real activation or governed worker handoff acceptance.


### PR DESCRIPTION
An active native goal could previously be paired with another installation's otherwise valid budget approval. Bind a goal to the current protected configuration, fully staged installation generation/composition, human actor and actual root when creating its native goal/run/link/event records in one writer transaction. Reservation and the final pre-dispatch writer check require that association and current installation/configuration.

Reuse the existing encrypted goal record. The association has a distinct authenticated record kind and goal ID inside that record: older caller-supplied plaintext metadata and envelopes copied from other goals cannot claim host issuance. Ordinary goal start rejects the reserved field; generic goal writes preserve its value or absence under a writer transaction. Same-authority start replay remains idempotent, while competing installation starts cannot rebind it. No new root registry or database schema is introduced.

Four SQLite/PostgreSQL regressions cover rejected unstaged creation without partial goal/root records, restart/idempotency and generic-write immutability; historical plaintext/copied-envelope forgery; a live goal spending against another same-tenant installation with zero sends/reservations; and concurrent starts with different installation authority. Existing provider/child/shared-root tests now use associated native goals and the actual staging journal transitions with synthetic receipts.

Validation: current signed head 89c519532427a5895c0c3eee6360b92ed28aad9d, standalone rustfmt/diff checks pass. Initial CI exposed two existing lineage tests still calling the former final-validation signature; f019ca83 updates them to the full approval input. Current 89c51953 also samples the goal-start clock after acquiring the writer transaction and tests rejection of an expired identity despite a stale initiating timestamp. Current-head compilation and runtime tests require CI; keep draft pending current-head evidence. Stacked on #1953 at c0f7973eab28c2032bd2499686c0e7a400c394e2.

This trusted storage entry point is not a new HTTP endpoint or activation permission. Production current-user/source/model authority, workflow-to-installed-worker validation, durable profile history, activation/task propagation, routine/session adapters, non-model charges and full customer acceptance remain open. Synthetic staging receipts do not prove native activation or governed handoff. No resources are enabled, PRs merged or whole issues completed. See docs/SOLUTION_GOAL_BINDING.md.
